### PR TITLE
Remove geslacht from required fields.

### DIFF
--- a/app/components/leidinggevendenbeheer/create-persoon.js
+++ b/app/components/leidinggevendenbeheer/create-persoon.js
@@ -87,7 +87,6 @@ const CreatePersoon = Component.extend({
         gebruikteVoornaam: this.voornaam,
         achternaam: this.familienaam,
         alternatieveNaam: this.roepnaam,
-        geslacht: yield store.findRecord('geslacht-code', this.geslacht),
         identificator: yield this.loadOrCreateRijksregister.perform(),
         geboorte: yield this.loadOrCreateGeboorte.perform()
       });
@@ -108,7 +107,7 @@ const CreatePersoon = Component.extend({
 
 CreatePersoon.reopen({
   // eslint-disable-next-line ember/avoid-leaking-state-in-ember-objects
-  requiredFields: [ 'geslacht', 'voornaam', 'familienaam', "rijksregisternummer" ],
+  requiredFields: [ 'voornaam', 'familienaam', "rijksregisternummer" ],
   male: maleId,
   female: femaleId
 });


### PR DESCRIPTION
_geslacht_ was not a field in the UI but it was registered as a _required field_, hence the person creation process failed. This PR seeks to resolve this issue by tweaking the form validation logic.