### PR TITLE
Feature/toezicht url validation

### DIFF
--- a/app/components/toezicht/inzending-edit.js
+++ b/app/components/toezicht/inzending-edit.js
@@ -34,6 +34,16 @@ export default Component.extend({
     return !this.isSent || this.get('fileAddresses.length') > 0;
   }),
 
+  invalidFileAddresses: computed('fileAddresses.@each.address', function() {
+    return this.fileAddresses.filter(fileAddress => {
+      try {
+        new URL(fileAddress.address);
+        return false;
+      }
+      catch(err) { return true }
+    })
+  }),
+  
   flushErrors() {
     this.set('errorMsg', '');
   },
@@ -71,16 +81,6 @@ export default Component.extend({
     const lastModifier = yield this.currentSession.get('user');
     inzending.set('lastModifier', lastModifier);
     return inzending.save();
-  }),
-
-  invalidFileAddresses: computed('fileAddresses.@each.address', function() {
-    return this.fileAddresses.filter(fileAddress => {
-      try {
-        new URL(fileAddress.address);
-        return false;
-      }
-      catch(err) { return true }
-    })
   }),
 
   validate: task(function*() {

--- a/app/components/toezicht/inzending-edit.js
+++ b/app/components/toezicht/inzending-edit.js
@@ -34,11 +34,17 @@ export default Component.extend({
     return !this.isSent || this.get('fileAddresses.length') > 0;
   }),
 
+  /**
+   * An invalid FileAddress is one which has an invalid address.
+   * An invalid address is either a malformed url or a url with an
+   * unsupported protocol.
+   */
   invalidFileAddresses: computed('fileAddresses.@each.address', function() {
     return this.fileAddresses.filter(fileAddress => {
       try {
-        new URL(fileAddress.address);
-        return false;
+        const url = new URL(fileAddress.address);
+        const supportedProtocols = ['http:', 'https:', 'ftp:', 'sftp:'];
+        return ! supportedProtocols.includes(url.protocol);
       }
       catch(err) { return true }
     })

--- a/app/components/toezicht/inzending-edit.js
+++ b/app/components/toezicht/inzending-edit.js
@@ -74,7 +74,7 @@ export default Component.extend({
     (yield inzending.get('files')).setObjects(this.files);
 
     // TODO add stricter validation on URLs
-    this.fileAddresses.forEach(a => a.set('address', a.address && a.address.trim()));
+    this.fileAddresses.forEach(a => a.set('address', a.address));
     yield Promise.all(this.fileAddresses.map(a => a.save()));
     (yield inzending.get('fileAddresses')).setObjects(this.fileAddresses);
 

--- a/app/components/toezicht/inzending-edit.js
+++ b/app/components/toezicht/inzending-edit.js
@@ -77,7 +77,7 @@ export default Component.extend({
     this.flushErrors();
     const errors = [];
     const states = yield this.get('dynamicForm.formNode.unionStates');
-    if (states.filter((s) => s == 'noSend').length)
+    if (states.some(s => s == 'noSend'))
       errors.push('Gelieve alle verplichte velden in te vullen.');
 
     if ((yield this.files).length == 0 && this.allEmptyFileAddresses)

--- a/app/components/toezicht/inzending-edit.js
+++ b/app/components/toezicht/inzending-edit.js
@@ -73,6 +73,16 @@ export default Component.extend({
     return inzending.save();
   }),
 
+  invalidFileAddresses: computed('fileAddresses.@each.address', function() {
+    return this.fileAddresses.filter(fileAddress => {
+      try {
+        new URL(fileAddress.address);
+        return false;
+      }
+      catch(err) { return true }
+    })
+  }),
+
   validate: task(function*() {
     this.flushErrors();
     const errors = [];
@@ -82,6 +92,10 @@ export default Component.extend({
 
     if ((yield this.files).length == 0 && this.allEmptyFileAddresses)
       errors.push('Gelieve minstens één bestand of link naar document op te laden.');
+
+    this.invalidFileAddresses.forEach(fileAddress => {
+        errors.push(`[Ongelgide link: ${fileAddress.address}.]`);
+    });
 
     this.set('errorMsg', errors.join(' '));
   }),

--- a/app/components/toezicht/inzending-edit.js
+++ b/app/components/toezicht/inzending-edit.js
@@ -97,7 +97,7 @@ export default Component.extend({
         errors.push(`Ongeldige link: ${fileAddress.address}.`);
     });
 
-    this.set('errorMsg', errors.join(' '));
+    this.set('errorMsg', errors);
   }),
 
   save: task(function*() {

--- a/app/components/toezicht/inzending-edit.js
+++ b/app/components/toezicht/inzending-edit.js
@@ -43,7 +43,7 @@ export default Component.extend({
       catch(err) { return true }
     })
   }),
-  
+
   flushErrors() {
     this.set('errorMsg', '');
   },
@@ -94,7 +94,7 @@ export default Component.extend({
       errors.push('Gelieve minstens één bestand of link naar document op te laden.');
 
     this.invalidFileAddresses.forEach(fileAddress => {
-        errors.push(`[Ongelgide link: ${fileAddress.address}.]`);
+        errors.push(`Ongeldige link: ${fileAddress.address}.`);
     });
 
     this.set('errorMsg', errors.join(' '));

--- a/app/templates/components/toezicht/inzending-edit.hbs
+++ b/app/templates/components/toezicht/inzending-edit.hbs
@@ -2,7 +2,13 @@
 
 {{#if deleteModal}}{{toezicht/inzending-delete-modal onCancel=(action (mut deleteModal) false) onConfirm=(action "confirmDelete")}} {{/if}}
 {{#if hasError}}
-  {{wu-alert message=errorMsg isError=true data-test-loket="warning-message"}}
+  {{#wu-alert isError=true data-test-loket="warning-message"}}
+    <ul>
+      {{#each errorMsg as |msg|}}
+        <li>{{msg}}</li>
+      {{/each}}
+    </ul>
+  {{/wu-alert}}
 {{/if}}
 
 <div class="u-padding--round--small container-flex--scroll">


### PR DESCRIPTION
This PR adds url validation to current form validations.
**WIP**
In the current implementation, the _validate_ task adds error messages to the _errorMsg_ parameter separated by a whitespace.Following this existing pattern, invalid urls are also added to _errorMsg_. At the end, the _errorMsg_ is rendered in one line which idoes not look nice. Fixing this patterns is beyond the scope of this PR. It may need a change to _wu-alert_ component.