### PR TITLE
Rename all occurances of store.find

### DIFF
--- a/app/routes/berichtencentrum/berichten/conversatie.js
+++ b/app/routes/berichtencentrum/berichten/conversatie.js
@@ -2,6 +2,6 @@ import Route from '@ember/routing/route';
 
 export default class BerichtencentrumBerichtenConversatieRoute extends Route {
   model(params) {
-    return this.store.find('conversatie', params.id);
+    return this.store.findRecord('conversatie', params.id);
   }
 }

--- a/app/routes/personeelsbeheer/personeelsaantallen/periodes.js
+++ b/app/routes/personeelsbeheer/personeelsaantallen/periodes.js
@@ -2,6 +2,6 @@ import Route from '@ember/routing/route';
 
 export default class PersoneelsbeheerPersoneelsaantallenPeriodesRoute extends Route {
   model(params) {
-    return this.store.find('employee-dataset', params.dataset_id);
+    return this.store.findRecord('employee-dataset', params.dataset_id);
   }
 }

--- a/app/routes/subsidy/applications/edit.js
+++ b/app/routes/subsidy/applications/edit.js
@@ -14,7 +14,7 @@ const SOURCE_GRAPH = new rdflib.NamedNode(`http://data.lblod.info/sourcegraph`);
 export default class SubsidyApplicationsEditRoute extends Route {
   async model(params) {
     // Fetch data from backend
-    const applicationForm = await this.store.find('application-form', params.id);
+    const applicationForm = await this.store.findRecord('application-form', params.id);
     const applicationFormStatus = await applicationForm.status;
 
     if (!applicationForm) {

--- a/app/routes/supervision/submissions/edit.js
+++ b/app/routes/supervision/submissions/edit.js
@@ -12,7 +12,7 @@ export default class SupervisionSubmissionsEditRoute extends Route {
   async model(params) {
     // Fetch data from backend
 
-    const submission = await this.store.find('submission', params.id);
+    const submission = await this.store.findRecord('submission', params.id);
     const submissionDocument = await submission.submissionDocument;
     const submissionStatus = await submission.status;
 

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -11,9 +11,9 @@ export default class CurrentSessionService extends Service {
   async load() {
     if (this.session.isAuthenticated) {
       const session = this.session;
-      const account = await this.store.find('account', get(session, 'data.authenticated.relationships.account.data.id'));
+      const account = await this.store.findRecord('account', get(session, 'data.authenticated.relationships.account.data.id'));
       const user = await account.get('gebruiker');
-      const group = await this.store.find('bestuurseenheid', get(session, 'data.authenticated.relationships.group.data.id'));
+      const group = await this.store.findRecord('bestuurseenheid', get(session, 'data.authenticated.relationships.group.data.id'));
       const roles = await get(session, 'data.authenticated.data.attributes.roles');
       this.set('_account', account);
       this.set('_user', user);


### PR DESCRIPTION
`store.find` is a private API method and only there to support Ember's default model data loading behavior.

It's just an alias for `store.findRecord` though, so an easy one to find and replace! :smile: 