### PR TITLE
Replace soon to be deprecated transitionToRoute method

### DIFF
--- a/app/controllers/bbcdr/rapporten.js
+++ b/app/controllers/bbcdr/rapporten.js
@@ -20,9 +20,9 @@ export default class BbcdrRapportenController extends Controller {
   @action
     createNewReport() {
       if (this.router.currentRouteName == 'bbcdr.rapporten.new')
-        this.transitionToRoute('bbcdr.rapporten.index');
+        this.router.transitionTo('bbcdr.rapporten.index');
       else
-        this.transitionToRoute('bbcdr.rapporten.new');
+        this.router.transitionTo('bbcdr.rapporten.new');
     }
 }
 

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -4,44 +4,45 @@ import { action } from '@ember/object';
 
 export default class IndexController extends Controller {
   @service() currentSession;
+  @service() router;
 
   @action
     goToToezicht() {
-      this.transitionToRoute('supervision.submissions');
+      this.router.transitionTo('supervision.submissions');
     }
 
   @action
     goToBbcdr() {
-      this.transitionToRoute('bbcdr.rapporten');
+      this.router.transitionTo('bbcdr.rapporten');
     }
-    
+
   @action
     goToMandatenbeheer() {
-      this.transitionToRoute('mandatenbeheer.mandatarissen');
+      this.router.transitionTo('mandatenbeheer.mandatarissen');
     }
 
   @action
     goToBerichtencentrum() {
-      this.transitionToRoute('berichtencentrum.berichten');
+      this.router.transitionTo('berichtencentrum.berichten');
     }
-    
+
   @action
     goToAdministratievegegevens() {
-      this.transitionToRoute('administratieve-gegevens');
+      this.router.transitionTo('administratieve-gegevens');
     }
-    
+
   @action
     goToLeidinggevendenbeheer() {
-      this.transitionToRoute('leidinggevendenbeheer.bestuursfuncties');
+      this.router.transitionTo('leidinggevendenbeheer.bestuursfuncties');
     }
-    
+
   @action
     goToPersoneelsbeheer() {
-      this.transitionToRoute('personeelsbeheer.personeelsaantallen.index');
+      this.router.transitionTo('personeelsbeheer.personeelsaantallen.index');
     }
-    
+
   @action
     goToSubsidiebeheer() {
-      this.transitionToRoute('subsidy.applications.index');
-    }		
+      this.router.transitionTo('subsidy.applications.index');
+    }
 }

--- a/app/controllers/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/contact-info.js
+++ b/app/controllers/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/contact-info.js
@@ -2,8 +2,10 @@ import Controller from '@ember/controller';
 import { task } from 'ember-concurrency';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
 
 export default class LeidinggevendenbeheerBestuursfunctiesBestuursfunctieContactInfoController extends Controller {
+  @service() router;
   showConfirmationDialog = false;
 
   @tracked bestuurseenheid;
@@ -15,7 +17,7 @@ export default class LeidinggevendenbeheerBestuursfunctiesBestuursfunctieContact
 
   exit() {
     this.set('showConfirmationDialog', false);
-    this.transitionToRoute('leidinggevendenbeheer.bestuursfuncties.bestuursfunctie.functionarissen',
+    this.router.transitionTo('leidinggevendenbeheer.bestuursfuncties.bestuursfunctie.functionarissen',
       this.bestuursfunctie.id);
   }
 

--- a/app/controllers/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/functionarissen/edit.js
+++ b/app/controllers/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/functionarissen/edit.js
@@ -1,8 +1,11 @@
 import Controller from '@ember/controller';
 import { task } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
 
 export default class LeidinggevendenbeheerBestuursfunctiesBestuursfunctieFunctionarissenEditController extends Controller {
+  @service() router;
+
   @tracked initialStatus;
 
   get statusIsDirty(){
@@ -28,6 +31,6 @@ export default class LeidinggevendenbeheerBestuursfunctiesBestuursfunctieFunctio
   }) resetChanges;
 
   exit() {
-    this.transitionToRoute('leidinggevendenbeheer.bestuursfuncties.bestuursfunctie.functionarissen');
+    this.router.transitionTo('leidinggevendenbeheer.bestuursfuncties.bestuursfunctie.functionarissen');
   }
 }

--- a/app/controllers/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/functionarissen/new-person.js
+++ b/app/controllers/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/functionarissen/new-person.js
@@ -1,14 +1,17 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class LeidinggevendenbeheerBestuursfunctiesBestuursfunctieFunctionarissenNewPersonController extends Controller {
+  @service() router;
+
   @action
     onCreate(user) {
-      this.transitionToRoute('leidinggevendenbeheer.bestuursfuncties.bestuursfunctie.functionarissen.new.periode', user.get('id'));
+      this.router.transitionTo('leidinggevendenbeheer.bestuursfuncties.bestuursfunctie.functionarissen.new.periode', user.get('id'));
   }
 
   @action
     onCancel() {
-      this.transitionToRoute('leidinggevendenbeheer.bestuursfuncties.bestuursfunctie.functionarissen.new');
+      this.router.transitionTo('leidinggevendenbeheer.bestuursfuncties.bestuursfunctie.functionarissen.new');
   }
 }

--- a/app/controllers/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/functionarissen/new/index.js
+++ b/app/controllers/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/functionarissen/new/index.js
@@ -1,19 +1,22 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class LeidinggevendenbeheerBestuursfunctiesBestuursfunctieFunctionarissenNewIndexController extends Controller {
+  @service() router;
+
   @action
     choosePeriode(person){
-      this.transitionToRoute('leidinggevendenbeheer.bestuursfuncties.bestuursfunctie.functionarissen.new.periode', person.get('id'));
+      this.router.transitionTo('leidinggevendenbeheer.bestuursfuncties.bestuursfunctie.functionarissen.new.periode', person.get('id'));
     }
 
   @action
     createNewPerson() {
-      this.transitionToRoute('leidinggevendenbeheer.bestuursfuncties.bestuursfunctie.functionarissen.new-person');
+      this.router.transitionTo('leidinggevendenbeheer.bestuursfuncties.bestuursfunctie.functionarissen.new-person');
     }
 
   @action
     cancel() {
-      this.transitionToRoute('leidinggevendenbeheer.bestuursfuncties.bestuursfunctie.functionarissen.index');
+      this.router.transitionTo('leidinggevendenbeheer.bestuursfuncties.bestuursfunctie.functionarissen.index');
     }
 }

--- a/app/controllers/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/functionarissen/new/periode.js
+++ b/app/controllers/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/functionarissen/new/periode.js
@@ -1,21 +1,23 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { task } from 'ember-concurrency';
+import { inject as service } from '@ember/service';
 
 export default class LeidinggevendenbeheerBestuursfunctiesBestuursfunctieFunctionarissenNewPeriodeController extends Controller {
+  @service() router;
 
   @task(function * () {
     yield this.model.save();
-    this.transitionToRoute('leidinggevendenbeheer.bestuursfuncties.bestuursfunctie.functionarissen.index');
+    this.router.transitionTo('leidinggevendenbeheer.bestuursfuncties.bestuursfunctie.functionarissen.index');
   }) save;
 
   @action
   goBackToSearch() {
-    this.transitionToRoute('leidinggevendenbeheer.bestuursfuncties.bestuursfunctie.functionarissen.new');
+    this.router.transitionTo('leidinggevendenbeheer.bestuursfuncties.bestuursfunctie.functionarissen.new');
   }
 
   @action
   cancel() {
-    this.transitionToRoute('leidinggevendenbeheer.bestuursfuncties.bestuursfunctie.functionarissen.index');
+    this.router.transitionTo('leidinggevendenbeheer.bestuursfuncties.bestuursfunctie.functionarissen.index');
   }
 }

--- a/app/controllers/mandatenbeheer/fracties.js
+++ b/app/controllers/mandatenbeheer/fracties.js
@@ -2,9 +2,12 @@ import Controller from '@ember/controller';
 import { task } from 'ember-concurrency';
 import { alias } from '@ember/object/computed';
 import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking'; 
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
 
 export default class MandatenbeheerFractiesController extends Controller {
+  @service() router;
+
   @tracked newFractie = null;
   @tracked isBusy = false;
   @tracked defaultFractieType;
@@ -31,7 +34,7 @@ export default class MandatenbeheerFractiesController extends Controller {
         this.newFractie = null;
       fractie.rollbackAttributes(); // removes model from store if it's new
     }
-  
+
   @action
     createNewFractie() {
       const fractie = this.store.createRecord('fractie', {
@@ -45,7 +48,7 @@ export default class MandatenbeheerFractiesController extends Controller {
 
   @action
     selectPeriod(startDate) {
-      this.transitionToRoute('mandatenbeheer.fracties', {
+      this.router.transitionTo('mandatenbeheer.fracties', {
         queryParams: {
           page: 0,
           startDate: startDate

--- a/app/controllers/mandatenbeheer/mandatarissen.js
+++ b/app/controllers/mandatenbeheer/mandatarissen.js
@@ -35,9 +35,9 @@ export default class MandatenbeheerMandatarissenController extends Controller {
   @action
     handleAddMandatarisClick() {
       if (this.router.currentRouteName === 'mandatenbeheer.mandatarissen.new')
-        this.transitionToRoute('mandatenbeheer.mandatarissen.index');
+        this.router.transitionTo('mandatenbeheer.mandatarissen.index');
       else
-        this.transitionToRoute('mandatenbeheer.mandatarissen.new');
+        this.router.transitionTo('mandatenbeheer.mandatarissen.new');
     }
 
   @action
@@ -45,9 +45,9 @@ export default class MandatenbeheerMandatarissenController extends Controller {
       this.router.transitionTo('mandatenbeheer.fracties');
     }
 
-  @action  
+  @action
     selectPeriod(startDate) {
-      this.transitionToRoute('mandatenbeheer.mandatarissen', {
+      this.router.transitionTo('mandatenbeheer.mandatarissen', {
         queryParams: {
           page: 0,
           startDate: startDate

--- a/app/controllers/mandatenbeheer/mandatarissen/edit.js
+++ b/app/controllers/mandatenbeheer/mandatarissen/edit.js
@@ -1,7 +1,10 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class MandatenbeheerMandatarissenEditController extends Controller {
+  @service() router;
+
   @action
     saveMandataris() {
       this.send('reloadModel');
@@ -9,6 +12,6 @@ export default class MandatenbeheerMandatarissenEditController extends Controlle
 
   @action
     finish(){
-      this.transitionToRoute('mandatenbeheer.mandatarissen');
+      this.router.transitionTo('mandatenbeheer.mandatarissen');
     }
 }

--- a/app/controllers/mandatenbeheer/mandatarissen/new-person.js
+++ b/app/controllers/mandatenbeheer/mandatarissen/new-person.js
@@ -1,14 +1,17 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class MandatenbeheerMandatarissenNewPersonController extends Controller {
+  @service() router;
+
   @action
     onCreate(user) {
-      this.transitionToRoute('mandatenbeheer.mandatarissen.edit', user.get('id'));
+      this.router.transitionTo('mandatenbeheer.mandatarissen.edit', user.get('id'));
     }
 
   @action
     onCancel() {
-      this.transitionToRoute('mandatenbeheer.mandatarissen.new');
+      this.router.transitionTo('mandatenbeheer.mandatarissen.new');
     }
 }

--- a/app/controllers/mandatenbeheer/mandatarissen/new.js
+++ b/app/controllers/mandatenbeheer/mandatarissen/new.js
@@ -1,19 +1,22 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class MandatenbeheerMandatarissenNewController extends Controller {
+  @service() router;
+
   @action
     selectPersoon(persoon){
-      this.transitionToRoute('mandatenbeheer.mandatarissen.edit', persoon.get('id'));
+      this.router.transitionTo('mandatenbeheer.mandatarissen.edit', persoon.get('id'));
     }
 
   @action
     createNewPerson() {
-      this.transitionToRoute('mandatenbeheer.mandatarissen.new-person');
+      this.router.transitionTo('mandatenbeheer.mandatarissen.new-person');
     }
 
   @action
     cancel(){
-      this.transitionToRoute('mandatenbeheer.mandatarissen');
+      this.router.transitionTo('mandatenbeheer.mandatarissen');
     }
 }

--- a/app/controllers/subsidy/applications/edit.js
+++ b/app/controllers/subsidy/applications/edit.js
@@ -15,6 +15,7 @@ import { inject as service } from '@ember/service';
 export default class SubsidyApplicationsEditController extends Controller {
   @service currentSession;
   @service store;
+  @service() router;
 
   @tracked error;
   @tracked datasetTriples = [];
@@ -122,7 +123,7 @@ export default class SubsidyApplicationsEditController extends Controller {
   * delete() {
     try {
       yield this.deleteApplicationForm.perform();
-      this.transitionToRoute('subsidy.applications');
+      this.router.transitionTo('subsidy.applications');
     } catch (exception) {
       this.error = {
         action: 'verwijderen',
@@ -164,7 +165,7 @@ export default class SubsidyApplicationsEditController extends Controller {
         yield this.saveApplicationForm.perform();
         yield this.submitApplicationForm.perform();
         yield this.model.applicationForm.save();
-        this.transitionToRoute('subsidy.applications');
+        this.router.transitionTo('subsidy.applications');
       }
     } catch (exception) {
       this.error = {

--- a/app/controllers/supervision/submissions/edit.js
+++ b/app/controllers/supervision/submissions/edit.js
@@ -10,6 +10,7 @@ import { inject as service } from '@ember/service';
 export default class SupervisionSubmissionsEditController extends Controller {
   @service currentSession;
   @service store;
+  @service() router;
 
   @tracked datasetTriples = [];
   @tracked addedTriples = [];
@@ -105,7 +106,7 @@ export default class SupervisionSubmissionsEditController extends Controller {
   @task
   *delete() {
     yield this.deleteSubmissionForm.perform();
-    this.transitionToRoute('supervision.submissions');
+    this.router.transitionTo('supervision.submissions');
   }
 
   @task
@@ -134,7 +135,7 @@ export default class SupervisionSubmissionsEditController extends Controller {
       yield this.saveSubmissionForm.perform();
       yield this.submitSubmissionForm.perform();
       yield this.model.submission.save();
-      this.transitionToRoute('supervision.submissions');
+      this.router.transitionTo('supervision.submissions');
     }
   }
 }


### PR DESCRIPTION
Replace all instances for this.transitionToRoute to this.router.transitionTo. Injecting the router service where needed ofcoarse