### PR TITLE
Fix exit problem in contact info form

### DIFF
--- a/app/templates/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/contact-info.hbs
+++ b/app/templates/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/contact-info.hbs
@@ -42,6 +42,6 @@
   <Leidinggevendenbeheer::FunctionarisCloseConfirmation
     @cancel={{action (mut showConfirmationDialog false)}}
     @save={{perform this.save}}
-    @reset={{this.perform this.resetChanges}}
+    @reset={{perform this.resetChanges}}
   />
 {{/if}}


### PR DESCRIPTION
This fixes an issue where a console error is thrown when the user presses the exit button while having unsaved changes.