### PR TITLE
update syntax to octane + prevent refresh on submit action

### DIFF
--- a/app/components/leidinggevendenbeheer/functionaris-form.js
+++ b/app/components/leidinggevendenbeheer/functionaris-form.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { notEmpty } from '@ember/object/computed';
 import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 
 export default class LeidinggevendenbeheerFunctionarisFormComponent extends Component {
   @service() store;
@@ -11,8 +12,14 @@ export default class LeidinggevendenbeheerFunctionarisFormComponent extends Comp
 
   constructor() {
     super(...arguments);
-    this.getBestuursInfo()
+    this.getBestuursInfo();
   }
+
+  /**  Temporary fix until we start using new datepicker. */
+  @action
+    preventPageRefresh(e) {
+      e.preventDefault();
+    }
 
   async getBestuursInfo() {
     const bestuursfunctie = await this.args.model.get('bekleedt');

--- a/app/components/mandatenbeheer/mandataris-edit.js
+++ b/app/components/mandatenbeheer/mandataris-edit.js
@@ -187,6 +187,11 @@ export default Component.extend({
   },
 
   actions: {
+    /**  Temporary fix until we start using new datepicker. */
+    preventPageRefresh(e) {
+      e.preventDefault();
+    },
+
     setFractie(fractie){
       this.set('fractie', fractie);
     },

--- a/app/components/shared/persoon/create-persoon.js
+++ b/app/components/shared/persoon/create-persoon.js
@@ -99,6 +99,9 @@ const CreatePersoon = Component.extend({
     }
   }),
   actions: {
+    preventPageRefresh(e) {
+      e.preventDefault();
+    },
     setGender(event) {
       this.set('geslacht', event.target.value);
     }

--- a/app/components/shared/persoon/create-persoon.js
+++ b/app/components/shared/persoon/create-persoon.js
@@ -99,6 +99,7 @@ const CreatePersoon = Component.extend({
     }
   }),
   actions: {
+    /** Temporary fix until we start using new datepicker. */
     preventPageRefresh(e) {
       e.preventDefault();
     },

--- a/app/templates/components/leidinggevendenbeheer/functionaris-form.hbs
+++ b/app/templates/components/leidinggevendenbeheer/functionaris-form.hbs
@@ -8,24 +8,26 @@
     <div class="au-o-grid au-o-grid--tiny">
       <div class="au-o-grid__item au-u-1-2 au-u-1-3@medium">
         <AuLabel for="datepicker-from">Start aanstellingsperiode</AuLabel>
-          {{wu-datepicker
-            value=(mut @model.start)
-            placeholder="01.01.2019"
-            dateFormat="DD.MM.YYYY"
-            classNames="date-range__datepicker datepicker datepicker--block"
-          }}
+        <WuDatepicker
+          @value={{mut @model.start}}
+          @placeholder="01.01.2019"
+          @dateFormat="DD.MM.YYYY"
+          class="date-range__datepicker datepicker datepicker--block"
+          {{on 'submit' this.preventPageRefresh}}
+        />
         {{#unless @model.start}}
         <AuHelpText @error="true">Start aanstellingsperiode is verplicht</AuHelpText>
         {{/unless}}
       </div>
       <div class="au-o-grid__item au-u-1-2 au-u-1-3@medium">
         <AuLabel for="datepicker-from">Einde aanstellingsperiode</AuLabel>
-          {{wu-datepicker
-            value=(mut @model.einde)
-            placeholder="31.12.2019"
-            dateFormat="DD.MM.YYYY"
-            classNames="date-range__datepicker datepicker datepicker--block"
-          }}
+        <WuDatepicker
+          @value={{mut @model.einde}}
+          @placeholder="31.12.2019"
+          @dateFormat="DD.MM.YYYY"
+          class="date-range__datepicker datepicker datepicker--block"
+          {{on 'submit' this.preventPageRefresh}}
+        />
       </div>
     </div>
     {{#if (gt this.statusOptions.length 1)}}
@@ -33,9 +35,9 @@
     <div class="au-o-grid au-o-grid--tiny">
       {{#each this.statusOptions as |status|}}
       <div class="au-o-grid__item au-u-1-2 au-u-1-4@medium">
-        {{wu-radio-button 
-          label=status.label 
-          value=status 
+        {{wu-radio-button
+          label=status.label
+          value=status
           isBlock=true
           onChange=(action (mut @model.status status))
           checked=(eq status.id @model.status.id)

--- a/app/templates/components/mandatenbeheer/mandataris-edit.hbs
+++ b/app/templates/components/mandatenbeheer/mandataris-edit.hbs
@@ -59,24 +59,26 @@
           <div class="au-o-grid au-o-grid--tiny">
             <div class="au-o-grid__item au-u-1-2">
               <AuLabel @error="{{if this.startDateError 'true'}}" for="datepicker-from">Start</AuLabel>
-              {{wu-datepicker
-                placeholder="01-01-2018"
-                class=(with-error-class startDateError "date-range__datepicker datepicker datepicker--block")
-                value=(mut startDate)
-                dateFormat=dateFormat
-              }}
+              <WuDatepicker
+                @placeholder="01-01-2018"
+                @value={{mut startDate}}
+                @dateFormat={{dateFormat}}
+                class={{with-error-class startDateError "date-range__datepicker datepicker datepicker--block"}}
+                onsubmit={{action "preventPageRefresh"}}
+              />
               {{#if startDateError}}
                 <AuHelpText @error="true">{{startDateError}}</AuHelpText>
               {{/if}}
             </div>
             <div class="au-o-grid__item au-u-1-2">
               <AuLabel @error="{{if this.endDateError 'true'}}" for="datepicker-to">Einde</AuLabel>
-              {{wu-datepicker
-                placeholder="01-01-2019"
-                class=(with-error-class endDateError "date-range__datepicker datepicker datepicker--block")
-                value=endDate
-                dateFormat=dateFormat
-              }}
+              <WuDatepicker
+                @placeholder="01-01-2019"
+                @value={{endDate}}
+                @dateFormat={{dateFormat}}
+                class={{with-error-class endDateError "date-range__datepicker datepicker datepicker--block"}}
+                onsubmit={{action "preventPageRefresh"}}
+              />
               {{#if endDateError}}
                 <AuHelpText @error="true">{{endDateError}}</AuHelpText>
               {{/if}}
@@ -137,22 +139,24 @@
       <div class="au-o-grid au-o-grid--tiny">
         <div class="au-o-grid__item au-u-1-2">
           <AuLabel for="datepicker-from">Start</AuLabel>
-          {{wu-datepicker
-            placeholder="01-01-2018"
-            class=(with-error-class startDateError "date-range__datepicker datepicker input-field--disabled datepicker--block")
-            value=(mut startDate)
-            dateFormat=dateFormat
-            disabled=true
-          }}
+          <WuDatepicker
+            @placeholder="01-01-2018"
+            @value={{mut startDate}}
+            @dateFormat={{dateFormat}}
+            @disabled={{true}}
+            class={{with-error-class startDateError "date-range__datepicker datepicker input-field--disabled datepicker--block"}}
+            onsubmit={{action "preventPageRefresh"}}
+          />
         </div>
         <div class="au-o-grid__item au-u-1-2">
           <AuLabel for="datepicker-to">Einde</AuLabel>
-          {{wu-datepicker
-            placeholder="01-01-2019"
-            class=(with-error-class endDateError "date-range__datepicker datepicker datepicker--block")
-            value=endDate
-            dateFormat=dateFormat
-          }}
+          <WuDatepicker
+            @placeholder="01-01-2019"
+            @value={{endDate}}
+            @dateFormat={{dateFormat}}
+            class={{with-error-class endDateError "date-range__datepicker datepicker datepicker--block"}}
+            onsubmit={{action "preventPageRefresh"}}
+          />
           {{#if endDateError}}
             <div class="form__error">{{endDateError}}</div>
           {{/if}}
@@ -226,24 +230,26 @@
           <div class="au-o-grid au-o-grid--tiny">
             <div class="au-o-grid__item au-u-1-2">
               <AuLabel @error="{{if this.startDateError 'true'}}" for="datepicker-from">Start</AuLabel>
-              {{wu-datepicker
-                placeholder="01-01-2018"
-                class=(with-error-class startDateError "date-range__datepicker datepicker datepicker--block")
-                value=(mut startDate)
-                dateFormat=dateFormat
-              }}
+              <WuDatepicker
+                @placeholder="01-01-2018"
+                @value={{mut startDate}}
+                @dateFormat={{dateFormat}}
+                class={{with-error-class startDateError "date-range__datepicker datepicker datepicker--block"}}
+                onsubmit={{action "preventPageRefresh"}}
+              />
               {{#if startDateError}}
                 <AuHelpText @error="true">{{startDateError}}</AuHelpText>
               {{/if}}
             </div>
             <div class="au-o-grid__item au-u-1-2">
               <AuLabel @error="{{if this.endDateError 'true'}}" for="datepicker-to">Einde</AuLabel>
-              {{wu-datepicker
-                placeholder="01-01-2019"
-                class=(with-error-class endDateError "date-range__datepicker datepicker datepicker--block")
-                value=endDate
-                dateFormat=dateFormat
-              }}
+              <WuDatepicker
+                @placeholder="01-01-2019"
+                @value={{endDate}}
+                @dateFormat={{dateFormat}}
+                class={{with-error-class endDateError "date-range__datepicker datepicker datepicker--block"}}
+                onsubmit={{action "preventPageRefresh"}}
+              />
               {{#if endDateError}}
                 <AuHelpText @error="true">{{endDateError}}</AuHelpText>
               {{/if}}

--- a/app/templates/components/shared/persoon/create-persoon.hbs
+++ b/app/templates/components/shared/persoon/create-persoon.hbs
@@ -32,7 +32,15 @@
       </div>
       <div>
         <AuLabel for="mandataris-geboorte">Geboortedatum</AuLabel>
-        {{wu-datepicker class="datepicker--block u-spacer--small" dateFormat="DD.MM.YYYY" value=(mut birthDate) minDate=minDate maxDate=maxDate id="mandataris-geboorte" }}
+        <WuDatepicker
+          @dateFormat="DD.MM.YYYY"
+          @value={{mut birthDate}}
+          @minDate={{minDate}}
+          @maxDate={{maxDate}}
+          class="datepicker--block u-spacer--small"
+          id="mandataris-geboorte"
+          onsubmit={{action "preventPageRefresh"}}
+        />
       </div>
       <div>
         <AuLabel @error="{{if this.geslachtError 'true'}}">Geslacht</AuLabel>


### PR DESCRIPTION
when pressing enter while datepicker input is focused the page would refresh since the datepicker is wrapped in a form element and pressing enter triggers a submit action. Fix is to prevent the submit action from happening

Some components still use older syntax and thus require different syntax for the solution