### PR TITLE
Added queryParam to ease testing of subsidies

### DIFF
--- a/app/controllers/subsidy/applications/edit/step/edit.js
+++ b/app/controllers/subsidy/applications/edit/step/edit.js
@@ -11,10 +11,15 @@ import { validateForm } from '@lblod/ember-submission-form-fields';
 
 export default class SubsidyApplicationsEditStepEditController extends Controller {
 
+  // To mimic user testing as much as possible
+  // we introduce testMode queryparam, which skips some of the (blocking) frontend business logic.
+  queryParams = [ 'testMode' ];
+
   @service currentSession;
   @service store;
   @service router;
 
+  @tracked testMode;
   @tracked error;
   @tracked datasetTriples = [];
   @tracked addedTriples = [];
@@ -64,7 +69,7 @@ export default class SubsidyApplicationsEditStepEditController extends Controlle
   }
 
   get canSubmit(){
-    return !this.submitted && this.isActiveStep && this.isInSubmittablePeriod;
+    return (!this.submitted && this.isActiveStep && this.isInSubmittablePeriod) || this.testMode;
   }
 
   get isInSubmittablePeriod(){

--- a/app/routes/subsidy/applications/available-subsidies.js
+++ b/app/routes/subsidy/applications/available-subsidies.js
@@ -5,21 +5,38 @@ import DataTableRouteMixin from 'ember-data-table/mixins/route';
 export default class SubsidyApplicationsAvailableSubsidiesRoute extends Route.extend(DataTableRouteMixin) {
   modelName = 'subsidy-measure-offer-series';
 
-  mergeQueryOptions() {
+  // To mimic user testing as much as possible
+  // we introduce testMode queryparam, which skips some of the (blocking) frontend business logic.
+  // Note: Re-definition of the params specified by the mixin, since I didn't find a way to merge params from both sources.
+  queryParams = {
+    testMode: { refreshModel: true },
+    filter: { refreshModel: true },
+    page: { refreshModel: true },
+    size: { refreshModel: true },
+    sort: { refreshModel: true }
+  };
 
-    const today = new Date();
-
-    return {
+  mergeQueryOptions(params) {
+    const query = {
       include: [
         'period',
         'subsidy-measure-offer',
         // 'active-application-flow.first-application-step.subsidy-procedural-step.period' // This is so expensive to call
-      ].join(','),
-      'filter[active-application-flow][first-application-step][subsidy-procedural-step][period]': {
+      ].join(',')
+    };
+
+    if(params.testMode){
+      return query;
+    }
+    else {
+      //Add extra rules to available subsidies
+      const today = new Date();
+
+      query['filter[active-application-flow][first-application-step][subsidy-procedural-step][period]'] = {
         ':lte:begin': today.toISOString(),
-        ':gte:end': today.toISOString(),
-      },
+        ':gte:end': today.toISOString()
+      };
+      return query;
     };
   }
-
 }


### PR DESCRIPTION
For subidies, a lot of forms flow (will) depend on custom business rules,
which are not always satisfied at the moment of testing.

The most concrete example: start date of a subsidy. A user is not
allowed to submit if the start date is still in the future. This
parameter allows this to bypass this. Probably in the future it might
be elaborated, although we really hope this parameter (which
introduces a custom code path) is used sparsely.