### PR TITLE
Chore/footer heading

### DIFF
--- a/app/components/shared/footer-heading.hbs
+++ b/app/components/shared/footer-heading.hbs
@@ -1,0 +1,3 @@
+<AuHeading @level="3" @skin="4">
+  {{this.hostname}} is een officiële website van de Vlaamse overheid
+</AuHeading>

--- a/app/components/shared/footer-heading.js
+++ b/app/components/shared/footer-heading.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+export default class SharedFooterHeadingComponent extends Component {
+  get hostname() {
+    return document.location.hostname;
+  }
+}

--- a/app/templates/contact.hbs
+++ b/app/templates/contact.hbs
@@ -21,9 +21,7 @@
     {{outlet}}
 
     <AuMainFooter>
-      <AuHeading @level="3" @skin="4">
-        Loket.lblod.info is een officiële website van de Vlaamse overheid
-      </AuHeading>
+      <Shared::FooterHeading/>
       <AuContent @skin="small">
         <p>Uitgegeven door <a class="au-c-link" href="https://www.vlaanderen.be/organisaties/administratieve-diensten-van-de-vlaamse-overheid/beleidsdomein-kanselarij-en-bestuur/agentschap-binnenlands-bestuur">Agentschap Binnenlands Bestuur</a></p>
         <ul class="au-c-list-horizontal">

--- a/app/templates/help.hbs
+++ b/app/templates/help.hbs
@@ -1,4 +1,4 @@
-<main class="au-c-main-container" id="main">
+<main id="main">
   <div class="au-c-main-container__content au-c-main-container__content--scroll" id="content">
     <section class="au-o-region">
       <div class="au-o-layout au-o-layout--small">
@@ -139,8 +139,6 @@
     </section>
     <AuMainFooter>
       <Shared::FooterHeading/>
-        Toezicht ABB is een officiële website van de Vlaamse overheid
-      </AuHeading>
       <AuContent @skin="small">
         <p>Uitgegeven door <a class="au-c-link" href="https://www.vlaanderen.be/organisaties/administratieve-diensten-van-de-vlaamse-overheid/beleidsdomein-kanselarij-en-bestuur/agentschap-binnenlands-bestuur">Agentschap Binnenlands Bestuur</a></p>
         <ul class="au-c-list-horizontal">

--- a/app/templates/help.hbs
+++ b/app/templates/help.hbs
@@ -138,7 +138,7 @@
       </div>
     </section>
     <AuMainFooter>
-      <AuHeading @level="3" @skin="4">
+      <Shared::FooterHeading/>
         Toezicht ABB is een officiële website van de Vlaamse overheid
       </AuHeading>
       <AuContent @skin="small">

--- a/app/templates/legaal.hbs
+++ b/app/templates/legaal.hbs
@@ -7,9 +7,7 @@
     </div>
 
     <AuMainFooter>
-      <AuHeading @level="3" @skin="4">
-        Loket.lblod.info is een officiële website van de Vlaamse overheid
-      </AuHeading>
+      <Shared::FooterHeading/>
       <AuContent @skin="small">
         <p>Uitgegeven door <a class="au-c-link" href="https://www.vlaanderen.be/organisaties/administratieve-diensten-van-de-vlaamse-overheid/beleidsdomein-kanselarij-en-bestuur/agentschap-binnenlands-bestuur">Agentschap Binnenlands Bestuur</a></p>
         <ul class="au-c-list-horizontal">

--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -158,9 +158,7 @@
     </main>
 
     <AuMainFooter>
-      <AuHeading @level="3" @skin="4">
-        Loket.lblod.info is een officiële website van de Vlaamse overheid
-      </AuHeading>
+      <Shared::FooterHeading/>
       <AuContent @skin="small">
         <p>Uitgegeven door <a class="au-c-link" href="https://www.vlaanderen.be/organisaties/administratieve-diensten-van-de-vlaamse-overheid/beleidsdomein-kanselarij-en-bestuur/agentschap-binnenlands-bestuur">Agentschap Binnenlands Bestuur</a></p>
         <ul class="au-c-list-horizontal">

--- a/app/templates/switch-login.hbs
+++ b/app/templates/switch-login.hbs
@@ -27,9 +27,7 @@
     </main>
 
     <AuMainFooter>
-      <AuHeading @level="3" @skin="4">
-        Loket.lblod.info is een officiële website van de Vlaamse overheid
-      </AuHeading>
+      <Shared::FooterHeading/>
       <AuContent @skin="small">
         <p>Uitgegeven door <a class="au-c-link" href="https://www.vlaanderen.be/organisaties/administratieve-diensten-van-de-vlaamse-overheid/beleidsdomein-kanselarij-en-bestuur/agentschap-binnenlands-bestuur">Agentschap Binnenlands Bestuur</a></p>
         <ul class="au-c-list-horizontal">


### PR DESCRIPTION
- hostname now showing in footer heading.
- fix double scrollbar issue on help page.

Note: This will NOT work when using fastboot as it accesses the document object. For some reason I thought loket used fastboot but seems not to be the case? 