### PR TITLE
Update subsidy forms initial status

### DIFF
--- a/app/controllers/subsidy/applications/edit/step/edit.js
+++ b/app/controllers/subsidy/applications/edit/step/edit.js
@@ -8,6 +8,7 @@ import { timeout } from 'ember-concurrency';
 import { dropTask, task } from 'ember-concurrency-decorators';
 import fetch from 'fetch';
 import { validateForm } from '@lblod/ember-submission-form-fields';
+import { CONCEPT_STATUS } from '../../../../../models/submission-document-status';
 
 export default class SubsidyApplicationsEditStepEditController extends Controller {
 
@@ -162,6 +163,7 @@ export default class SubsidyApplicationsEditStepEditController extends Controlle
       // NOTE update modified for the form and the consumption
       yield this.updateModified(this.semanticForm);
       yield this.updateModified(this.consumption);
+      yield this.updateStatus(this.semanticForm, CONCEPT_STATUS);
 
       this.updateRecentlySaved(); // TODO can this be done on a more "data" driven way
     } catch (exception) {
@@ -224,6 +226,17 @@ export default class SubsidyApplicationsEditStepEditController extends Controlle
     model.modified = new Date();
     model.lastModified = this.currentSession.user;
     await model.save();
+  }
+
+  async updateStatus(model, statusUri) {
+    const statuses = await this.store.query('submission-document-status', {
+      page: {size: 1},
+      'filter[:uri:]': statusUri,
+    });
+
+    if (statuses.length)
+      model.status = statuses.firstObject;
+      await model.save();
   }
 
   /**

--- a/app/controllers/subsidy/applications/edit/step/edit.js
+++ b/app/controllers/subsidy/applications/edit/step/edit.js
@@ -8,7 +8,7 @@ import { timeout } from 'ember-concurrency';
 import { dropTask, task } from 'ember-concurrency-decorators';
 import fetch from 'fetch';
 import { validateForm } from '@lblod/ember-submission-form-fields';
-import { CONCEPT_STATUS } from '../../../../../models/submission-document-status';
+import { NEW_STATUS, CONCEPT_STATUS } from '../../../../../models/submission-document-status';
 
 export default class SubsidyApplicationsEditStepEditController extends Controller {
 
@@ -163,7 +163,9 @@ export default class SubsidyApplicationsEditStepEditController extends Controlle
       // NOTE update modified for the form and the consumption
       yield this.updateModified(this.semanticForm);
       yield this.updateModified(this.consumption);
-      yield this.updateStatus(this.semanticForm, CONCEPT_STATUS);
+
+      if ((yield this.semanticForm.status.get('uri')) == NEW_STATUS)
+        yield this.updateStatus(this.semanticForm, CONCEPT_STATUS);
 
       this.updateRecentlySaved(); // TODO can this be done on a more "data" driven way
     } catch (exception) {

--- a/app/models/submission-document-status.js
+++ b/app/models/submission-document-status.js
@@ -9,11 +9,13 @@ export default class SubmissionDocumentStatus extends Model {
   }
 }
 
+const NEW_STATUS = 'http://lblod.data.gift/concepts/6b7ae118-4653-48f2-9d9a-4712f8c30da9';
 const CONCEPT_STATUS = 'http://lblod.data.gift/concepts/79a52da4-f491-4e2f-9374-89a13cde8ecd';
 const SENT_STATUS = 'http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c';
 const DELETED_STATUS = 'http://lblod.data.gift/concepts/faa5110a-fdb2-47fa-a0d2-118e5542ef05';
 
 export {
+  NEW_STATUS,
   CONCEPT_STATUS,
   SENT_STATUS,
   DELETED_STATUS

--- a/app/models/subsidy-application-flow-step.js
+++ b/app/models/subsidy-application-flow-step.js
@@ -1,9 +1,9 @@
-import Model, { attr, belongsTo } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export default class SubsidyApplicationFlowStepModel extends Model {
   @attr order;
 
-  @belongsTo('file') formSpecification;
+  @hasMany('file') formSpecifications;
   @belongsTo('subsidy-application-flow') applicationFlow;
   @belongsTo('subsidy-procedural-step') subsidyProceduralStep;
 

--- a/app/models/subsidy-application-flow-step.js
+++ b/app/models/subsidy-application-flow-step.js
@@ -1,9 +1,9 @@
-import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class SubsidyApplicationFlowStepModel extends Model {
   @attr order;
 
-  @hasMany('file') formSpecifications;
+  @belongsTo('file') formSpecification;
   @belongsTo('subsidy-application-flow') applicationFlow;
   @belongsTo('subsidy-procedural-step') subsidyProceduralStep;
 

--- a/app/routes/subsidy/applications/edit/step/new.js
+++ b/app/routes/subsidy/applications/edit/step/new.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import { CONCEPT_STATUS } from '../../../../../models/submission-document-status';
+import { NEW_STATUS } from '../../../../../models/submission-document-status';
 
 export default class SubsidyApplicationsEditStepNewRoute extends Route {
 
@@ -8,13 +8,13 @@ export default class SubsidyApplicationsEditStepNewRoute extends Route {
   @service currentSession;
 
   async beforeModel() {
-    const conceptStatuses = await this.store.query('submission-document-status', {
+    const newStatuses = await this.store.query('submission-document-status', {
       page: {size: 1},
-      'filter[:uri:]': CONCEPT_STATUS,
+      'filter[:uri:]': NEW_STATUS,
     });
 
-    if (conceptStatuses.length)
-      this.conceptStatus = conceptStatuses.firstObject;
+    if (newStatuses.length)
+      this.newStatus = newStatuses.firstObject;
   }
 
   async model() {
@@ -28,7 +28,7 @@ export default class SubsidyApplicationsEditStepNewRoute extends Route {
       lastModifier: this.currentSession.user,
       subsidyApplicationFlowStep: step,
       subsidyMeasureConsumption: consumption,
-      status: this.conceptStatus,
+      status: this.newStatus,
     });
 
     form.sources.pushObject(spec);

--- a/app/routes/subsidy/applications/edit/step/new.js
+++ b/app/routes/subsidy/applications/edit/step/new.js
@@ -21,15 +21,7 @@ export default class SubsidyApplicationsEditStepNewRoute extends Route {
     let {consumption} = this.modelFor('subsidy.applications.edit');
     let {step} = this.modelFor('subsidy.applications.edit.step');
 
-    const specs = await step.get('formSpecifications');
-
-    let latestSpec = specs.firstObject;
-    if (specs.length > 1) {
-      specs.forEach(spec => {
-        if (new Date(spec.created) > new Date(latestSpec.created))
-          latestSpec = spec;
-      });
-    }
+    const spec = await step.get('formSpecification');
 
     let form = this.store.createRecord('subsidy-application-form', {
       creator: this.currentSession.user,
@@ -39,7 +31,7 @@ export default class SubsidyApplicationsEditStepNewRoute extends Route {
       status: this.newStatus,
     });
 
-    form.sources.pushObject(latestSpec);
+    form.sources.pushObject(spec);
     await form.save();
 
     consumption.subsidyApplicationForms.pushObject(form);

--- a/app/routes/subsidy/applications/edit/step/new.js
+++ b/app/routes/subsidy/applications/edit/step/new.js
@@ -21,7 +21,15 @@ export default class SubsidyApplicationsEditStepNewRoute extends Route {
     let {consumption} = this.modelFor('subsidy.applications.edit');
     let {step} = this.modelFor('subsidy.applications.edit.step');
 
-    const spec = await step.get('formSpecification');
+    const specs = await step.get('formSpecifications');
+
+    let latestSpec = specs.firstObject;
+    if (specs.length > 1) {
+      specs.forEach(spec => {
+        if (new Date(spec.created) > new Date(latestSpec.created))
+          latestSpec = spec;
+      });
+    }
 
     let form = this.store.createRecord('subsidy-application-form', {
       creator: this.currentSession.user,
@@ -31,7 +39,7 @@ export default class SubsidyApplicationsEditStepNewRoute extends Route {
       status: this.newStatus,
     });
 
-    form.sources.pushObject(spec);
+    form.sources.pushObject(latestSpec);
     await form.save();
 
     consumption.subsidyApplicationForms.pushObject(form);


### PR DESCRIPTION
We use to put new forms in CONCEPT status. We now introduce a new status NEW for more ease when handling tailored data extraction.
A form becomes a CONCEPT when first saved.