### PR TITLE
Fix subsidy error end date

### DIFF
--- a/app/templates/subsidy/applications/edit/step/edit.hbs
+++ b/app/templates/subsidy/applications/edit/step/edit.hbs
@@ -93,7 +93,7 @@
                          @alertskin="warning"
                   @alertsize="small" class="au-u-margin-bottom-small">
                   <p> Deze stap was beschikbaar tot en met
-                    {{moment-format this.subsidyProceduralStepPeriod.end 'DD-MM-YYYY'}}.
+                    {{moment-format this.step.subsidyProceduralStep.period.end 'DD-MM-YYYY'}}.
                   </p>
                   <p>Indien u een fout heeft ontdekt, of een vraag heeft, neem contact op met <a
                           href="mailto:LoketLokaalBestuur@vlaanderen.be"


### PR DESCRIPTION
I noticed the date wasn't shown anymore and I fixed the linting errors in the template while I was there :smile:.

![image](https://user-images.githubusercontent.com/3533236/142183756-58598cf9-acd6-4647-b7dc-72d40092d70f.png)
