### PR TITLE
Feature/externally processed subsidies

### DIFF
--- a/app/models/subsidy-application-flow-step.js
+++ b/app/models/subsidy-application-flow-step.js
@@ -4,7 +4,7 @@ export default class SubsidyApplicationFlowStepModel extends Model {
   @attr order;
 
   /**
-   * If no form-specification is supplied, a reference to an external form could be found here.
+   * a reference to an external process could be found here.
    */
   @attr isReplacedBy;
 

--- a/app/models/subsidy-application-flow-step.js
+++ b/app/models/subsidy-application-flow-step.js
@@ -3,6 +3,11 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 export default class SubsidyApplicationFlowStepModel extends Model {
   @attr order;
 
+  /**
+   * If no form-specification is supplied, a reference to an external form could be found here.
+   */
+  @attr isReplacedBy;
+
   @belongsTo('file') formSpecification;
   @belongsTo('subsidy-application-flow') applicationFlow;
   @belongsTo('subsidy-procedural-step') subsidyProceduralStep;

--- a/app/models/subsidy-measure-offer-series.js
+++ b/app/models/subsidy-measure-offer-series.js
@@ -19,5 +19,26 @@ export default class SubsidyMeasureOfferSeriesModel extends Model {
     const end = moment(this.period.get('end')).format('YYYY');
     return `${begin} – ${end}`;
   }
+
+  /**
+   * Returns if the series can be processed externally
+   * - when it has a reference to an outside form
+   * - when the subsidyProceduralStep of the firstApplicationStep is of type ExternallyProcessed
+   * @returns boolean
+   */
+  get isExternallyProcessed() {
+    const isReplacedBy =
+      this.activeApplicationFlow.get('firstApplicationStep.isReplacedBy');
+    const isExternallyProcessed =
+      this.activeApplicationFlow.get('firstApplicationStep.subsidyProceduralStep.isExternallyProcessed');
+    if (isReplacedBy && !isExternallyProcessed) {
+      console.warn('found a link to an external processes, but step is not marked for external processing.');
+      return false;
+    } else if (!isReplacedBy && isExternallyProcessed) {
+      console.warn('found no link to an external processes, but step is marked for external processing.');
+      return false;
+    }
+    return isReplacedBy && isExternallyProcessed;
+  }
 }
 

--- a/app/models/subsidy-measure-offer-series.js
+++ b/app/models/subsidy-measure-offer-series.js
@@ -36,7 +36,7 @@ export default class SubsidyMeasureOfferSeriesModel extends Model {
       return false;
     } else if (!isReplacedBy && isExternallyProcessed) {
       console.warn('found no link to an external processes, but step is marked for external processing.');
-      return false;
+      return true;
     }
     return isReplacedBy && isExternallyProcessed;
   }

--- a/app/models/subsidy-procedural-step.js
+++ b/app/models/subsidy-procedural-step.js
@@ -1,7 +1,15 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
+const SUBSIDY_PROCEDURE_STEP_TYPE = {
+  EXTERNALLY_PROCESSED: 'http://lblod.data.gift/concepts/3ded9eab-ff5b-4a20-a095-0825de486f42'
+};
+
 export default class SubsidyProceduralStepModel extends Model {
   @attr description;
   @attr('uri-set') type;
   @belongsTo('period-of-time') period;
+
+  get isExternallyProcessed() {
+    return this.type && this.type.includes(SUBSIDY_PROCEDURE_STEP_TYPE.EXTERNALLY_PROCESSED);
+  }
 }

--- a/app/routes/subsidy/applications/new.js
+++ b/app/routes/subsidy/applications/new.js
@@ -11,8 +11,10 @@ export default class SubsidyApplicationsNewRoute extends Route {
   @service store;
 
   async beforeModel(transition) {
+
     let seriesId = transition.to.queryParams.seriesId;
-    assert('A subsidy-measure-offer-series id needs to be provided through the `seriesId` query parameter', Boolean(seriesId));
+    assert('A subsidy-measure-offer-series id needs to be provided through the `seriesId` query parameter',
+      Boolean(seriesId));
 
     transition.data.series = await this.store.findRecord('subsidy-measure-offer-series', seriesId, {
       backgroundReload: false
@@ -23,13 +25,18 @@ export default class SubsidyApplicationsNewRoute extends Route {
       this.router.transitionTo('subsidy.applications.available-subsidies');
     }
 
+    if (transition.data.series.isExternallyProcessed) {
+      // TODO: Show a warning / error page
+      console.warn('This subsidy application should be processed externally');
+      this.router.transitionTo('subsidy.applications.available-subsidies');
+    }
+
     const statuses = await this.store.query('subsidy-measure-consumption-status', {
       page: {size: 1},
-      'filter[:uri:]': STATUS.CONCEPT,
+      'filter[:uri:]': STATUS.CONCEPT
     });
     if (statuses.length)
       this.concept = statuses.firstObject;
-
   }
 
   async model(params, transition) {

--- a/app/templates/subsidy/applications/available-subsidies.hbs
+++ b/app/templates/subsidy/applications/available-subsidies.hbs
@@ -68,9 +68,22 @@
       </td>
       <td>{{moment-format series.deadline.end "DD MMMM YYYY"}}</td>
       <td>
-        <LinkTo @route="subsidy.applications.new" @query={{hash seriesId=series.id}} class="au-c-link">
-          Start aanvraag
-        </LinkTo>
+        {{#if series.isExternallyProcessed}}
+          <a href={{series.activeApplicationFlow.firstApplicationStep.isReplacedBy}}
+             target="_blank"
+             rel="noopener noreferrer"
+             class="au-c-link">
+           Start aanvraag
+          </a>
+          <AuHelpText @skin="secondary" class="au-u-margin-top-none">
+            <AuIcon @icon="export" @alignment="left" @size="default" @ariaHidden={{true}} />
+            Externe afhandeling
+          </AuHelpText>
+        {{else}}
+          <LinkTo @route="subsidy.applications.new" @query={{hash seriesId=series.id}} class="au-c-link">
+            Start aanvraag
+          </LinkTo>
+        {{/if}}
       </td>
     </c.body>
   </t.content>

--- a/app/templates/subsidy/applications/index-loading.hbs
+++ b/app/templates/subsidy/applications/index-loading.hbs
@@ -9,9 +9,9 @@
   </AuToolbarGroup>
   <AuToolbarGroup>
     <div class="au-u-text-right">
-      <AuButton @disabled={{true}}>
+      <LinkTo @route="subsidy.applications.available-subsidies" class="au-c-button" type="button">
         Vraag nieuwe subsidie aan
-      </AuButton>
+      </LinkTo>
     </div>
   </AuToolbarGroup>
 </AuToolbar>

--- a/app/templates/subsidy/applications/index.hbs
+++ b/app/templates/subsidy/applications/index.hbs
@@ -9,8 +9,8 @@
   </AuToolbarGroup>
   <AuToolbarGroup>
     <div class="au-u-text-right">
-      <LinkTo @route="subsidy.applications.available-subsidies" class="au-c-button" type="button">Vraag nieuwe subsidie
-        aan
+      <LinkTo @route="subsidy.applications.available-subsidies" class="au-c-button" type="button">
+        Vraag nieuwe subsidie aan
       </LinkTo>
     </div>
   </AuToolbarGroup>


### PR DESCRIPTION
Introduces changes to allow the subsidy module to handel "externally processed" subsidies. This includes:
- showing up in the overview of available subsidies as a redirect
- preventing creation of new consumption off subsidies who are coincided "externally processed"

Works hand in hand with changes to the app: https://github.com/lblod/app-digitaal-loket/tree/feature/externally-processed-subsidies