### PR TITLE
Fix broken build because of a release of ember-get-config v1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM madnificent/ember:3.16.0 as builder
+FROM madnificent/ember:3.27.0 as builder
 
 LABEL maintainer="info@redpencil.io"
 

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM madnificent/ember:3.16.0 as builder
+FROM madnificent/ember:3.27.0 as builder
 
 LABEL maintainer="info@redpencil.io"
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "test": "npm-run-all lint test:*",
     "test:ember": "ember test"
   },
+  "overrides": {
+    "ember-get-config": "0.5.0"
+  },
   "devDependencies": {
     "@appuniversum/appuniversum": "0.0.15",
     "@appuniversum/ember-appuniversum": "0.4.3",
@@ -63,7 +66,7 @@
     "ember-cli-mirage": "^0.4.15",
     "ember-cli-moment-shim": "^3.7.1",
     "ember-cli-release": "^1.0.0-beta.2",
-    "ember-cli-sass": "^7.1.7",
+    "ember-cli-sass": "^10.0.1",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-string-helpers": "^1.8.1",
     "ember-cli-terser": "^4.0.1",
@@ -101,6 +104,7 @@
     "prettier": "^2.2.1",
     "qunit": "^2.13.0",
     "qunit-dom": "^1.6.0",
+    "sass": "^1.48.0",
     "svgxuse": "^1.2.6",
     "whatwg-fetch": "3.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-loket",
-  "version": "0.54.1",
+  "version": "0.54.2",
   "private": true,
   "description": "Frontend of loket",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:ember": "ember test"
   },
   "overrides": {
-    "ember-get-config": "0.5.0"
+    "@embroider/macros": "0.50.0"
   },
   "devDependencies": {
     "@appuniversum/appuniversum": "0.0.15",


### PR DESCRIPTION
Context : https://github.com/embroider-build/embroider/issues/1077

Needed to use a new version of docker-ember embedding npm v8.x to use `overrides` in the package.json, as well as bumping some deprecated dependencies ;
```bumping ember-cli-sass to ^10.0.1 and running edi ember g ember-cli-sass (which will add the sass package to package.json) fixes the issue
Previous versions of ember-cli-sass use node-sass under the hood which is deprecated and doesn't work
with node 16.x. New versions of ember-cli-sass use sass (alias of dart-sass) and that works with node 16.
```
