### PR TITLE
Fix the session setup code in acceptance tests

### DIFF
--- a/tests/helpers/session.js
+++ b/tests/helpers/session.js
@@ -1,43 +1,62 @@
 import { authenticateSession } from 'ember-simple-auth/test-support';
 
-export const CLASSIFICATION_LABEL = "classificatieLabel";
+export const CLASSIFICATION_LABEL = 'classificatieLabel';
 
-const session = async function(server, options = {}) {
+const session = async function (server, options = {}) {
   const defaultOptions = {
     roles: [
-      'LoketLB-mandaatGebruiker','LoketLB-berichtenGebruiker','LoketLB-bbcdrGebruiker','LoketLB-toezichtGebruiker','LoketLB-leidinggevendenGebruiker',
-    ]};
+      'LoketLB-mandaatGebruiker',
+      'LoketLB-berichtenGebruiker',
+      'LoketLB-bbcdrGebruiker',
+      'LoketLB-toezichtGebruiker',
+      'LoketLB-leidinggevendenGebruiker',
+    ],
+  };
 
-  options = Object.assign( defaultOptions, options );
+  options = Object.assign(defaultOptions, options);
 
   await authenticateSession({
-    data:{
-      type:'sessions',
-      id:'5c86864ada98f8000c000015',
-      attributes:{ roles: options.roles }
+    data: {
+      type: 'sessions',
+      id: '5c86864ada98f8000c000015',
+      attributes: { roles: options.roles },
     },
-    relationships:{
+    relationships: {
       account: {
-        data:{
+        data: {
           type: 'accounts',
-          id: '9b875bc387960fd6efa0065bdff32877'
-        }},
+          id: '9b875bc387960fd6efa0065bdff32877',
+        },
+      },
       group: {
         data: {
           type: 'bestuurseenheden',
-          id: '974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4'
-        }}
-    }
+          id: '974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4',
+        },
+      },
+    },
   });
+
   const user = server.create('gebruiker', {
     voornaam: 'John',
-    achternaam: 'Doe'
+    achternaam: 'Doe',
   });
+
   server.create('account', {
     provider: 'https://github.com/lblod/mock-login-service',
     id: '9b875bc387960fd6efa0065bdff32877',
-    gebruiker: user
+    gebruiker: user,
   });
-}
+
+  const classification = server.create('bestuurseenheid-classificatie-code', {
+    label: 'Test',
+  });
+
+  server.create('bestuurseenheid', {
+    naam: 'ABB',
+    id: '974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4',
+    classificatie: classification,
+  });
+};
 
 export default session;


### PR DESCRIPTION
This mocks the "bestuurseenheid" that the test user belongs so the currentSession.load() method doesn't throw an exception which [immediately invalidates the session](https://github.com/lblod/frontend-loket/blob/5d7f1f1d5e27e58a788d0bb6f7cd439b296e3c1e/app/routes/application.js#L23) again. This fixes some of the acceptance tests.