### PR TITLE
Add a "tiny" css modifier for the au-c-content class

### DIFF
--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -500,3 +500,16 @@ $au-non-editable-background: $au-gray-100 !default;
     flex-grow: 1;
   }
 }
+
+// "tiny" au-c-content modifier which matches the size of the help-text component
+// This is a simplified copy from the "small" modifier with a diferent font size
+// and only the styles we need at the moment.
+
+.au-c-content--tiny {
+  @include au-font-size(1.4rem); // same font size as the help-text component
+  line-height: 1.4;
+
+  > * + * {
+    margin-top: $au-unit-small;
+  }
+}


### PR DESCRIPTION
Small PR which accompanies the backend PR: https://github.com/lblod/app-digitaal-loket/pull/122

This is used in the help text section of certain form fields. This class ensures the au-c-content looks similar to the help-text component.

![image](https://user-images.githubusercontent.com/3533236/150496402-0e817d6d-3c8d-498e-9eba-1e59e6bb6147.png)
