### PR TITLE
Remove the Datepicker section on the "Toegankelijkheidsverklaring" page

### DIFF
--- a/app/templates/legaal/toegankelijkheidsverklaring.hbs
+++ b/app/templates/legaal/toegankelijkheidsverklaring.hbs
@@ -9,10 +9,6 @@
   <h2>Niet-toegankelijke inhoud</h2>
   <ul>
     <li>
-      <strong>Datepicker:</strong> de volledige datepicker functionaliteit is niet toegankelijk via het toetsenbord (<a href="https://www.w3.org/Translations/WCAG21-nl/#toetsenbord-geen-uitzondering" target="_blank" rel="noopener noreferrer">Succescriterium 2.1.3 Toetsenbord</a>). <br>
-      <em>Alternatief:</em> de datum kan manueel ingevoerd worden in het datum veld.
-    </li>
-    <li>
       <strong>Multiple select/Search select:</strong> slechts een deel van select functionaliteit is toegankelijk via het toetsenbord (<a href="https://www.w3.org/Translations/WCAG21-nl/#toetsenbord-geen-uitzondering" target="_blank" rel="noopener noreferrer">Succescriterium 2.1.3 Toetsenbord</a>). <br>
       <em>Alternatief:</em> de waarden kunnen manueel ingevoerd worden in het select input veld.
     </li>


### PR DESCRIPTION
The new datepicker is keyboard accessible so this section was out-of-date.