### PR TITLE
Fix a problem where the subsidy deletion button was shown when it shouldn't be

### DIFF
--- a/app/controllers/subsidy/applications/edit.js
+++ b/app/controllers/subsidy/applications/edit.js
@@ -20,7 +20,7 @@ export default class SubsidyApplicationsEditController extends Controller {
   }
 
   get canDelete() {
-    return this.model.consumptionStatus.isConcept;
+    return this.model.consumption.get('status.isConcept');
   }
 
   @task

--- a/app/routes/subsidy/applications/edit.js
+++ b/app/routes/subsidy/applications/edit.js
@@ -21,8 +21,7 @@ export default class SubsidyApplicationsEditRoute extends Route {
 
     return {
       consumption,
-      organization: this.currentSession.group,
-      consumptionStatus: await consumption.status,
+      organization: this.currentSession.group
     };
   }
 }


### PR DESCRIPTION
This fixes the problem where the subsidy deletion button was shown after the subsidy was already submitted. The consumption status was never updated after the first load due to the way we stored the data. Making this state derived solves the issue.