### PR TITLE
Update the BBC DR report file list when switching reports

### DIFF
--- a/app/components/bbcdr/report-edit.js
+++ b/app/components/bbcdr/report-edit.js
@@ -4,6 +4,7 @@ import { and, not } from 'ember-awesome-macros';
 import { A } from '@ember/array';
 import { all } from 'rsvp';
 import { action } from '@ember/object';
+import { trackedReset } from 'tracked-toolbox';
 import { tracked } from '@glimmer/tracking';
 
 
@@ -14,15 +15,20 @@ export default class BbcdrReportEditComponent extends Component {
   @and('args.report.status.isConcept', not('readyToSend')) enableUpload;
 
   @tracked showExitModal = false;
-  @tracked showError = false;
-  @tracked reportFiles = A([]);
+  @trackedReset('args.report') showError = false;
+  @trackedReset({
+    memo: 'args.report',
+    update() {
+      if (this.args.reportFiles) {
+        // We make a copy of the original files so that we can safely discard
+        // changes without having to roll back any changes to the relationship itself.
+        let copiedFiles = this.args.reportFiles.toArray();
+        return A(copiedFiles);
+      }
 
-  constructor(){
-    super(...arguments);
-    if(this.args.report.get('files')){
-      this.reportFiles = this.args.report.get('files');
+      return A();
     }
-  }
+  }) reportFiles = A();
 
   get readyToSend() {
     return this.reportFiles.length == 2;

--- a/app/components/bbcdr/report-table.hbs
+++ b/app/components/bbcdr/report-table.hbs
@@ -15,11 +15,11 @@
         {{! Actions }}
       </th>
     </c.header>
-    <c.body data-test-loket='bbcdr-report-table-body' as |row|>
+    <c.body data-test-loket='bbcdr-report-table-body' as |report|>
       <td data-test-loket='bbcdr-report-table-files-column'>
-        {{#if row.files}}
+        {{#if report.files}}
           <ul>
-            {{#each row.files as |file|}}
+            {{#each report.files as |file|}}
               <li data-test-loket="bbcdr-file-miniature">
                 {{!-- TODO: Add back a file miniature once appuniversum has a solution for this --}}
                 {{file.filename}} <span class="au-c-info-text">{{file.miniatureMetadata}}</span>
@@ -31,14 +31,14 @@
         {{/if}}
       </td>
       {{#unless @displaySubset}}
-      <td class="au-u-visible-medium-up">{{row.lastModifier.fullName}}</td>
-      <td class="au-u-visible-medium-up">{{moment-format row.modified 'DD-MM-YYYY'}}</td>
+      <td class="au-u-visible-medium-up">{{report.lastModifier.fullName}}</td>
+      <td class="au-u-visible-medium-up">{{moment-format report.modified 'DD-MM-YYYY'}}</td>
       {{/unless}}
       <td class="au-u-visible-small-up">
-        {{shared/document-status-pill row.status}}
+        {{shared/document-status-pill report.status}}
       </td>
       <td data-test-loket='bbcdr-report-table-open-details-column'>
-        <LinkTo @route='bbcdr.rapporten.edit' @model={{row}} class="au-c-link">Bekijk</LinkTo>
+        <LinkTo @route='bbcdr.rapporten.edit' @model={{report.id}} class="au-c-link">Bekijk</LinkTo>
       </td>
     </c.body>
   </t.content>

--- a/app/routes/bbcdr/rapporten/edit.js
+++ b/app/routes/bbcdr/rapporten/edit.js
@@ -1,13 +1,14 @@
 import Route from '@ember/routing/route';
 
 export default class BbcdrRapportenEditRoute extends Route {
-  model(params) {
-    return this.store.findRecord('bbcdr-report', params.id, {
-      include: [
-        'files',
-        'last-modifier',
-        'status'
-      ].join(',')
+  async model(params) {
+    let report = await this.store.findRecord('bbcdr-report', params.id, {
+      include: ['files', 'last-modifier', 'status'].join(','),
     });
+
+    return {
+      report,
+      reportFiles: await report.files,
+    };
   }
 }

--- a/app/templates/bbcdr/rapporten/edit.hbs
+++ b/app/templates/bbcdr/rapporten/edit.hbs
@@ -1,6 +1,7 @@
 <Bbcdr::ReportEdit
   class='au-o-grid__item au-u-2-5@medium'
-  @report={{this.model}}
+  @report={{@model.report}}
+  @reportFiles={{@model.reportFiles}}
 />
 
 {{outlet}}

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "qunit-dom": "^2.0.0",
     "sass": "^1.49.7",
     "svgxuse": "^1.2.6",
+    "tracked-toolbox": "^1.2.3",
     "webpack": "^5.68.0"
   },
   "engines": {


### PR DESCRIPTION
This fixes the problem where switching between reports didn't update the list of uploaded files.

The updated code also fixes the issue we noticed [with Ember Data 3.28](https://github.com/lblod/frontend-loket/issues/78) so that's one less thing to worry about when doing the update.