### PR TITLE
Add and register the custom table form fields

### DIFF
--- a/app/components/rdf-form-fields/application-form-table/edit.hbs
+++ b/app/components/rdf-form-fields/application-form-table/edit.hbs
@@ -1,0 +1,127 @@
+<AuLabel>
+  Vul in per organisator: het aantal opgevangen kinderen voor alle volle en halve dagen en het aantal kinderen dat in
+  aanmerking komt voor infrastructuursubsidies.
+</AuLabel>
+<AuHelpText class="au-u-margin-bottom-small">
+  Niet zeker wat u moet invullen? Ga naar de <a
+  href="https://lokaalbestuur.vlaanderen.be/loket-lokaal-bestuur-module-subsidies" target="_blank" rel="noopener noreferrer">informatiepagina
+  over subsidies</a> die u kan indienen via het loket.
+</AuHelpText>
+<AuLabel @error={{this.hasErrors}} @required={{this.isRequired}} for={{this.inputFor}}>
+  {{@field.label}}
+</AuLabel>
+<table class="data-table data-table--zebra data-table--tight au-u-margin-top-small">
+  <caption class="au-u-hidden-visually">Vul het aantal opgevangen kinderen voor alle volle en halve dagen en het aantal
+    kinderen dat in aanmerking komt voor infrastructuursubsidies per organisator in
+  </caption>
+  <thead>
+  <tr>
+    <th scope="col">
+      Naam&nbsp;organisator
+      <AuHelpText>bv. school, jeugdvereniging</AuHelpText>
+    </th>
+    <th scope="col">
+      Aantal kinderen voor alle volle dagen
+    </th>
+    <th scope="col">
+      Aantal kinderen voor alle halve dagen
+    </th>
+    <th scope="col">
+      Aantal kinderen in aanmerking voor infrastructuursubsidies
+    </th>
+    <td></td>
+    <td>&nbsp;</td>
+  </tr>
+  </thead>
+  <tbody>
+  {{#each this.sortedEntries as |entry index|}}
+    <tr>
+      <td>
+        <AuLabel for="actor-name-{{index}}" class="au-u-hidden-visually">Naam organisator</AuLabel>
+        <AuInput id="actor-name-{{index}}" @width="block" @value={{entry.actorName.value}}
+                 class={{if entry.actorName.errors "au-c-input--error"}}
+          {{on "blur" (fn this.updateActorNameValue entry)}}
+        />
+        {{#each entry.actorName.errors as |error|}}
+          <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+        {{/each}}
+      </td>
+      <td>
+        <AuLabel for="all-day-{{index}}" class="au-u-hidden-visually">
+          Kinderen voor <em>alle volle dagen</em>,
+          <br>
+          met personeel
+        </AuLabel>
+        <AuInput id="all-day-{{index}}" @width="block" @value={{entry.numberChildrenForFullDay.value}}
+                 class={{if entry.numberChildrenForFullDay.errors "au-c-input--error"}}
+          {{on "blur" (fn this.updateNumberChildrenForFullDayValue entry)}}
+        />
+        {{#each entry.numberChildrenForFullDay.errors as |error|}}
+          <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+        {{/each}}
+      </td>
+      <td>
+        <AuLabel for="half-day-{{index}}" class="au-u-hidden-visually">
+          Kinderen voor alle halve dagen,
+          <br>
+          met personeel
+        </AuLabel>
+        <AuInput id="half-day-{{index}}" @width="block" @value={{entry.numberChildrenForHalfDay.value}}
+                 class={{if entry.numberChildrenForHalfDay.errors "au-c-input--error"}}
+          {{on "blur" (fn this.updateNumberChildrenForHalfDayValue entry)}}
+        />
+        {{#each entry.numberChildrenForHalfDay.errors as |error|}}
+          <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+        {{/each}}
+      </td>
+      <td>
+        <AuLabel for="per-infra-{{index}}" class="au-u-hidden-visually">
+          Kinderen per infrastructuur per dag,
+          <br>
+          met of zonder personeel
+        </AuLabel>
+        <AuInput id="per-infra-{{index}}" @width="block" @value={{entry.numberChildrenPerInfrastructure.value}}
+                 class={{if entry.numberChildrenPerInfrastructure.errors "au-c-input--error"}}
+          {{on "blur" (fn this.updateNumberChildrenPerInfrastructureValue entry)}}
+        />
+        {{#each entry.numberChildrenPerInfrastructure.errors as |error|}}
+          <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+        {{/each}}
+      </td>
+      <td style="white-space: nowrap; vertical-align: middle;" {{!template-lint-disable no-inline-styles}}>
+        €{{entry.totalAmount}}
+      </td>
+      <td style="vertical-align: middle;" {{!template-lint-disable no-inline-styles}}>
+        <AuButton @hideText="true" @icon="bin" @skin="tertiary" @alert="true"
+          {{on "click" (fn this.removeEntry entry)}}>
+          <AuIcon @icon="bin" @alignment="left"/>
+          Verwijder rij
+        </AuButton>
+      </td>
+    </tr>
+  {{/each}}
+  <tr>
+    <td colspan="6" class="data-table__add-row u-align-center">
+      <AuButton @iconAlignment="left" @icon="add" {{on "click" this.addEntry}}>Voeg organisator toe</AuButton>
+    </td>
+  </tr>
+  {{#if this.usedParentalContribution}}
+    <tr>
+      <td colspan="3" class="data-table__add-row u-align-center"></td>
+      <td class="data-table__add-row u-align-right au-u-medium">
+        Ouderbijdrage:
+      </td>
+      <td class="au-u-medium">-50%</td>
+      <td></td>
+    </tr>
+  {{/if}}
+  <tr>
+    <td colspan="3" class="u-align-center"></td>
+    <td class="u-align-right au-u-medium">Totaal:</td>
+    <td class="u-align-center au-u-medium">€{{this.totalAmount}}</td>
+    <td></td>
+  </tr>
+  </tbody>
+</table>
+
+{{yield}}

--- a/app/components/rdf-form-fields/application-form-table/edit.js
+++ b/app/components/rdf-form-fields/application-form-table/edit.js
@@ -1,0 +1,613 @@
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { triplesForPath, XSD } from '@lblod/submission-form-helpers';
+import rdflib from 'browser-rdflib';
+import { v4 as uuidv4 } from 'uuid';
+import { RDF } from '@lblod/submission-form-helpers';
+import { next } from '@ember/runloop';
+import { guidFor } from '@ember/object/internals';
+
+const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+
+const applicationFormTableBaseUri =
+  'http://data.lblod.info/application-form-tables';
+const applicationFormEntryBaseUri =
+  'http://data.lblod.info/application-form-entries';
+const lblodSubsidieBaseUri = 'http://lblod.data.gift/vocabularies/subsidie/';
+const extBaseUri = 'http://mu.semte.ch/vocabularies/ext/';
+
+const ApplicationFormTableType = new rdflib.NamedNode(
+  `${lblodSubsidieBaseUri}ApplicationFormTable`
+);
+const ApplicationFormEntryType = new rdflib.NamedNode(
+  `${extBaseUri}ApplicationFormEntry`
+);
+const applicationFormTablePredicate = new rdflib.NamedNode(
+  `${lblodSubsidieBaseUri}applicationFormTable`
+);
+const applicationFormEntryPredicate = new rdflib.NamedNode(
+  `${extBaseUri}applicationFormEntry`
+);
+const actorNamePredicate = new rdflib.NamedNode(
+  'http://mu.semte.ch/vocabularies/ext/actorName'
+);
+const numberChildrenForFullDayPredicate = new rdflib.NamedNode(
+  'http://mu.semte.ch/vocabularies/ext/numberChildrenForFullDay'
+);
+const numberChildrenForHalfDayPredicate = new rdflib.NamedNode(
+  'http://mu.semte.ch/vocabularies/ext/numberChildrenForHalfDay'
+);
+const numberChildrenPerInfrastructurePredicate = new rdflib.NamedNode(
+  'http://mu.semte.ch/vocabularies/ext/numberChildrenPerInfrastructure'
+);
+const totalAmountPredicate = new rdflib.NamedNode(
+  'http://lblod.data.gift/vocabularies/subsidie/totalAmount'
+);
+const createdPredicate = new rdflib.NamedNode(
+  'http://purl.org/dc/terms/created'
+);
+
+const LBLOD_SUBSIDIE = new rdflib.Namespace(
+  'http://lblod.data.gift/vocabularies/subsidie/'
+);
+
+const inputFieldNames = [
+  'actorName',
+  'numberChildrenForFullDay',
+  'numberChildrenForHalfDay',
+  'numberChildrenPerInfrastructure',
+];
+
+class EntryProperties {
+  @tracked value;
+  @tracked oldValue;
+  @tracked errors = [];
+
+  constructor(value, predicate) {
+    this.value = value;
+    this.oldValue = value;
+    this.predicate = predicate;
+    this.errors = [];
+  }
+}
+
+class ApplicationFormEntry {
+  @tracked applicationFormEntrySubject;
+  @tracked totalAmount = 0;
+
+  calculateEntryTotal() {
+    this.totalAmount =
+      this.numberChildrenForFullDay.value * 20 +
+      this.numberChildrenForHalfDay.value * 10 +
+      this.numberChildrenPerInfrastructure.value * 10;
+  }
+
+  constructor({
+    applicationFormEntrySubject,
+    actorName,
+    numberChildrenForFullDay,
+    numberChildrenForHalfDay,
+    numberChildrenPerInfrastructure,
+    created,
+  }) {
+    this.applicationFormEntrySubject = applicationFormEntrySubject;
+
+    this.actorName = new EntryProperties(actorName, actorNamePredicate);
+    this.numberChildrenForFullDay = new EntryProperties(
+      numberChildrenForFullDay,
+      numberChildrenForFullDayPredicate
+    );
+    this.numberChildrenForHalfDay = new EntryProperties(
+      numberChildrenForHalfDay,
+      numberChildrenForHalfDayPredicate
+    );
+    this.numberChildrenPerInfrastructure = new EntryProperties(
+      numberChildrenPerInfrastructure,
+      numberChildrenPerInfrastructurePredicate
+    );
+    this.created = new EntryProperties(created, createdPredicate);
+    this.calculateEntryTotal();
+  }
+}
+
+export default class RdfFormFieldsApplicationFormTableEditComponent extends InputFieldComponent {
+  id = `application-form-table-${guidFor(this)}`;
+
+  @tracked usedParentalContribution;
+  @tracked applicationFormTableSubject = null;
+  @tracked entries = [];
+  @tracked totalAmount = 0;
+
+  constructor() {
+    super(...arguments);
+    this.loadProvidedValue();
+
+    this.calculateTotal(this.entries);
+
+    // Add an entry by default as an example
+    next(this, () => {
+      if (this.entries.length == 0) {
+        this.addEntry();
+        this.hasBeenFocused = false;
+      }
+    });
+
+    /**
+     * NOTE: registering hook to keep parent contribution in sync.
+     */
+    const observe = ({ inserts = [], deletes = [] } = {}) => {
+      const predicate = LBLOD_SUBSIDIE('usedParentalContribution');
+      const changes = [...inserts, ...deletes];
+      /**
+       * NOTE: we only want to trigger the observer when changes happened
+       *       to the predicate lblodSubsidie:usedParentalContribution
+       */
+      if (changes.map((t) => t.predicate).find((p) => p.equals(predicate))) {
+        const { store, sourceNode, sourceGraph } = this.storeOptions;
+        this.usedParentalContribution = !!store.any(
+          sourceNode,
+          predicate,
+          undefined,
+          sourceGraph
+        );
+        this.updateAangevraagdBedrag();
+      }
+    };
+    this.args.formStore.registerObserver((delta) => {
+      observe(delta);
+    }, this.id);
+  }
+
+  get hasApplicationFormTable() {
+    if (!this.applicationFormTableSubject) return false;
+    else
+      return (
+        this.storeOptions.store.match(
+          this.sourceNode,
+          applicationFormTablePredicate,
+          this.applicationFormTableSubject,
+          this.storeOptions.sourceGraph
+        ).length > 0
+      );
+  }
+
+  get hasEntries() {
+    return (
+      this.storeOptions.store.match(
+        this.applicationFormTableSubject,
+        applicationFormEntryPredicate,
+        undefined,
+        this.storeOptions.sourceGraph
+      ).length > 0
+    );
+  }
+
+  get sortedEntries() {
+    return this.entries.sort((a, b) =>
+      a.created.value.localeCompare(b.created.value)
+    );
+  }
+
+  loadProvidedValue() {
+    const matches = triplesForPath(this.storeOptions);
+    const triples = matches.triples;
+
+    if (triples.length) {
+      this.usedParentalContribution = !!this.storeOptions.store.any(
+        this.storeOptions.sourceNode,
+        LBLOD_SUBSIDIE('usedParentalContribution'),
+        undefined,
+        this.storeOptions.sourceGraph
+      );
+      this.applicationFormTableSubject = triples[0].object; // assuming only one per form
+
+      const entriesMatches = triplesForPath({
+        store: this.storeOptions.store,
+        path: applicationFormEntryPredicate,
+        formGraph: this.storeOptions.formGraph,
+        sourceNode: this.applicationFormTableSubject,
+        sourceGraph: this.storeOptions.sourceGraph,
+      });
+      const entriesTriples = entriesMatches.triples;
+
+      if (entriesTriples.length > 0) {
+        for (let entry of entriesTriples) {
+          const entryProperties = this.storeOptions.store.match(
+            entry.object,
+            undefined,
+            undefined,
+            this.storeOptions.sourceGraph
+          );
+
+          const parsedEntry = this.parseEntryProperties(entryProperties);
+
+          this.entries.pushObject(
+            new ApplicationFormEntry({
+              applicationFormEntrySubject: entry.object,
+              actorName: parsedEntry.actorName ? parsedEntry.actorName : '',
+              numberChildrenForFullDay: parsedEntry.numberChildrenForFullDay
+                ? parsedEntry.numberChildrenForFullDay
+                : 0,
+              numberChildrenForHalfDay: parsedEntry.numberChildrenForHalfDay
+                ? parsedEntry.numberChildrenForHalfDay
+                : 0,
+              numberChildrenPerInfrastructure:
+                parsedEntry.numberChildrenPerInfrastructure
+                  ? parsedEntry.numberChildrenPerInfrastructure
+                  : 0,
+              created: parsedEntry.created,
+            })
+          );
+        }
+      }
+    }
+  }
+
+  willDestroy() {
+    this.args.formStore.deregisterObserver(this.id);
+  }
+
+  /**
+   * Parse entry properties from triples to a simple object with the triple values
+   */
+  parseEntryProperties(entryProperties) {
+    let entry = {};
+    if (
+      entryProperties.find(
+        (entry) => entry.predicate.value == actorNamePredicate.value
+      )
+    )
+      entry.actorName = entryProperties.find(
+        (entry) => entry.predicate.value == actorNamePredicate.value
+      ).object.value;
+    if (
+      entryProperties.find(
+        (entry) =>
+          entry.predicate.value == numberChildrenForFullDayPredicate.value
+      )
+    )
+      entry.numberChildrenForFullDay = entryProperties.find(
+        (entry) =>
+          entry.predicate.value == numberChildrenForFullDayPredicate.value
+      ).object.value;
+    if (
+      entryProperties.find(
+        (entry) =>
+          entry.predicate.value == numberChildrenForHalfDayPredicate.value
+      )
+    )
+      entry.numberChildrenForHalfDay = entryProperties.find(
+        (entry) =>
+          entry.predicate.value == numberChildrenForHalfDayPredicate.value
+      ).object.value;
+    if (
+      entryProperties.find(
+        (entry) =>
+          entry.predicate.value ==
+          numberChildrenPerInfrastructurePredicate.value
+      )
+    )
+      entry.numberChildrenPerInfrastructure = entryProperties.find(
+        (entry) =>
+          entry.predicate.value ==
+          numberChildrenPerInfrastructurePredicate.value
+      ).object.value;
+    if (
+      entryProperties.find(
+        (entry) => entry.predicate.value == createdPredicate.value
+      )
+    )
+      entry.created = entryProperties.find(
+        (entry) => entry.predicate.value == createdPredicate.value
+      ).object.value;
+    return entry;
+  }
+
+  createApplicationFormTable() {
+    const uuid = uuidv4();
+    this.applicationFormTableSubject = new rdflib.NamedNode(
+      `${applicationFormTableBaseUri}/${uuid}`
+    );
+    const triples = [
+      {
+        subject: this.applicationFormTableSubject,
+        predicate: RDF('type'),
+        object: ApplicationFormTableType,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: this.applicationFormTableSubject,
+        predicate: MU('uuid'),
+        object: uuid,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: this.storeOptions.sourceNode,
+        predicate: applicationFormTablePredicate,
+        object: this.applicationFormTableSubject,
+        graph: this.storeOptions.sourceGraph,
+      },
+    ];
+    this.storeOptions.store.addAll(triples);
+  }
+
+  createApplicationFormEntry() {
+    const uuid = uuidv4();
+    const applicationFormEntrySubject = new rdflib.NamedNode(
+      `${applicationFormEntryBaseUri}/${uuid}`
+    );
+    const triples = [
+      {
+        subject: applicationFormEntrySubject,
+        predicate: RDF('type'),
+        object: ApplicationFormEntryType,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: applicationFormEntrySubject,
+        predicate: MU('uuid'),
+        object: uuid,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: this.applicationFormTableSubject,
+        predicate: applicationFormEntryPredicate,
+        object: applicationFormEntrySubject,
+        graph: this.storeOptions.sourceGraph,
+      },
+    ];
+    this.storeOptions.store.addAll(triples);
+    return applicationFormEntrySubject;
+  }
+
+  removeApplicationFormTable() {
+    const applicationFormTableTriples = this.storeOptions.store.match(
+      this.applicationFormTableSubject,
+      undefined,
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+    const triples = [
+      ...applicationFormTableTriples,
+      {
+        subject: this.storeOptions.sourceNode,
+        predicate: applicationFormTablePredicate,
+        object: this.applicationFormTableSubject,
+        graph: this.storeOptions.sourceGraph,
+      },
+    ];
+    this.storeOptions.store.removeStatements(triples);
+  }
+
+  removeEntryTriples(entry) {
+    inputFieldNames.forEach((key) => {
+      const propertiesTriples = [
+        {
+          subject: entry.applicationFormEntrySubject,
+          predicate: entry[key].predicate,
+          object: entry[key].oldValue,
+          graph: this.storeOptions.sourceGraph,
+        },
+      ];
+      this.storeOptions.store.removeStatements(propertiesTriples);
+    });
+
+    const entryTriples = [
+      {
+        subject: this.applicationFormTableSubject,
+        predicate: applicationFormEntryPredicate,
+        object: entry.applicationFormEntrySubject,
+        graph: this.storeOptions.sourceGraph,
+      },
+    ];
+    this.storeOptions.store.removeStatements(entryTriples);
+  }
+
+  updateFieldValueTriple(entry, field) {
+    const fieldValueTriples = this.storeOptions.store.match(
+      entry.applicationFormEntrySubject,
+      entry[field].predicate,
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+    const triples = [...fieldValueTriples];
+    this.storeOptions.store.removeStatements(triples);
+
+    if (entry[field].value.toString().length > 0) {
+      this.storeOptions.store.addAll([
+        {
+          subject: entry.applicationFormEntrySubject,
+          predicate: entry[field].predicate,
+          object: entry[field].value,
+          graph: this.storeOptions.sourceGraph,
+        },
+      ]);
+    }
+  }
+
+  updateAangevraagdBedrag() {
+    this.totalAmount = this.calculateTotal(this.entries);
+    const aangevraagdBedragTriples = this.storeOptions.store.match(
+      this.storeOptions.sourceNode,
+      totalAmountPredicate,
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+    const triples = [...aangevraagdBedragTriples];
+    this.storeOptions.store.removeStatements(triples);
+
+    this.storeOptions.store.addAll([
+      {
+        subject: this.storeOptions.sourceNode,
+        predicate: totalAmountPredicate,
+        object: rdflib.literal(
+          Number.parseFloat(this.totalAmount).toFixed(2),
+          XSD('float')
+        ),
+        graph: this.storeOptions.sourceGraph,
+      },
+    ]);
+  }
+
+  calculateTotal(entries) {
+    let total = 0;
+    entries.forEach((entry) => {
+      total += entry.totalAmount;
+    });
+    if (this.usedParentalContribution) {
+      total = total / 2;
+    }
+    if (total !== this.totalAmount) this.totalAmount = total;
+    return total;
+  }
+
+  @action
+  addEntry() {
+    if (!this.hasApplicationFormTable) this.createApplicationFormTable();
+
+    const applicationFormEntrySubject = this.createApplicationFormEntry();
+    const newEntry = new ApplicationFormEntry({
+      applicationFormEntrySubject,
+      actorName: '',
+      numberChildrenForFullDay: 0,
+      numberChildrenForHalfDay: 0,
+      numberChildrenPerInfrastructure: 0,
+      created: new Date().toISOString(),
+    });
+
+    this.entries.pushObject(newEntry);
+
+    this.updateDefaultEntryFields(newEntry);
+    super.updateValidations(); // Updates validation of the table
+  }
+
+  @action
+  updateActorNameValue(entry) {
+    entry.actorName.errors = [];
+    this.updateFieldValueTriple(entry, 'actorName');
+    if (this.isEmpty(entry.actorName.value)) {
+      entry.actorName.errors.pushObject({
+        message: 'Naam actor is verplicht.',
+      });
+    }
+    this.hasBeenFocused = true; // Allows errors to be shown in canShowErrors()
+    super.updateValidations(); // Updates validation of the table
+  }
+
+  @action
+  updateNumberChildrenForFullDayValue(entry) {
+    entry.numberChildrenForFullDay.errors = [];
+    const parsedValue = parseInt(entry.numberChildrenForFullDay.value);
+    entry.numberChildrenForFullDay.value = !isNaN(parsedValue)
+      ? parsedValue
+      : entry.numberChildrenForFullDay.value;
+    entry.calculateEntryTotal();
+    this.updateFieldValueTriple(entry, 'numberChildrenForFullDay');
+    this.updateAangevraagdBedrag();
+
+    if (this.isEmpty(entry.numberChildrenForFullDay.value)) {
+      entry.numberChildrenForFullDay.errors.pushObject({
+        message: 'Aantal kinderen voor alle volle dagen is verplicht.',
+      });
+    } else if (!this.isPositiveInteger(entry.numberChildrenForFullDay.value)) {
+      entry.numberChildrenForFullDay.errors.pushObject({
+        message:
+          'Aantal kinderen voor alle volle dagen is niet een positief nummer.',
+      });
+    }
+    this.hasBeenFocused = true; // Allows errors to be shown in canShowErrors()
+    super.updateValidations(); // Updates validation of the table
+  }
+
+  @action
+  updateNumberChildrenForHalfDayValue(entry) {
+    entry.numberChildrenForHalfDay.errors = [];
+    const parsedValue = parseInt(entry.numberChildrenForHalfDay.value);
+    entry.numberChildrenForHalfDay.value = !isNaN(parsedValue)
+      ? parsedValue
+      : entry.numberChildrenForHalfDay.value;
+    entry.calculateEntryTotal();
+    this.updateFieldValueTriple(entry, 'numberChildrenForHalfDay');
+    this.updateAangevraagdBedrag();
+
+    if (this.isEmpty(entry.numberChildrenForHalfDay.value)) {
+      entry.numberChildrenForHalfDay.errors.pushObject({
+        message: 'Aantal kinderen voor alle halve dagen is verplicht.',
+      });
+    } else if (!this.isPositiveInteger(entry.numberChildrenForHalfDay.value)) {
+      entry.numberChildrenForHalfDay.errors.pushObject({
+        message:
+          'Aantal kinderen voor alle halve dagen is niet een positief nummer.',
+      });
+    }
+    this.hasBeenFocused = true; // Allows errors to be shown in canShowErrors()
+    super.updateValidations(); // Updates validation of the table
+  }
+
+  @action
+  updateNumberChildrenPerInfrastructureValue(entry) {
+    entry.numberChildrenPerInfrastructure.errors = [];
+    const parsedValue = parseInt(entry.numberChildrenPerInfrastructure.value);
+    entry.numberChildrenPerInfrastructure.value = !isNaN(parsedValue)
+      ? parsedValue
+      : entry.numberChildrenPerInfrastructure.value;
+    entry.calculateEntryTotal();
+    this.updateFieldValueTriple(entry, 'numberChildrenPerInfrastructure');
+    this.updateAangevraagdBedrag();
+
+    if (this.isEmpty(entry.numberChildrenPerInfrastructure.value)) {
+      entry.numberChildrenPerInfrastructure.errors.pushObject({
+        message: 'Aantal kinderen per infrastructuur per dag is verplicht.',
+      });
+    } else if (
+      !this.isPositiveInteger(entry.numberChildrenPerInfrastructure.value)
+    ) {
+      entry.numberChildrenPerInfrastructure.errors.pushObject({
+        message:
+          'Aantal kinderen per infrastructuur per dag is niet een positief nummer.',
+      });
+    }
+    this.hasBeenFocused = true; // Allows errors to be shown in canShowErrors()
+    super.updateValidations(); // Updates validation of the table
+  }
+
+  @action
+  updateCreatedValue(entry) {
+    this.updateFieldValueTriple(entry, 'created');
+  }
+
+  @action
+  removeEntry(entry) {
+    if (this.applicationFormTableSubject) {
+      this.removeEntryTriples(entry);
+
+      if (!this.hasEntries) this.removeApplicationFormTable();
+    }
+    this.entries.removeObject(entry);
+    this.updateAangevraagdBedrag();
+
+    this.hasBeenFocused = true; // Allows errors to be shown in canShowErrors()
+    super.updateValidations(); // Updates validation of the table
+  }
+
+  isEmpty(value) {
+    return value.toString().length == 0;
+  }
+
+  isPositiveInteger(value) {
+    return value === parseInt(value) && value >= 0;
+  }
+
+  /**
+   * Update entry default fields.
+   * We update numbers to default them to 0 as well as the creation time of the entry.
+   * The actor name doesn't have a default value, it'll be entered by the user.
+   */
+  updateDefaultEntryFields(entry) {
+    this.updateNumberChildrenForFullDayValue(entry);
+    this.updateNumberChildrenForHalfDayValue(entry);
+    this.updateNumberChildrenPerInfrastructureValue(entry);
+    this.updateCreatedValue(entry);
+  }
+}

--- a/app/components/rdf-form-fields/application-form-table/show.hbs
+++ b/app/components/rdf-form-fields/application-form-table/show.hbs
@@ -1,0 +1,80 @@
+<AuLabel>
+  Vul in per organisator: het aantal opgevangen kinderen voor alle volle dagen, voor alle halve dagen en voor infrastructuur.
+</AuLabel>
+<AuHelpText class="au-u-margin-bottom-small">
+  Niet zeker wat u moet invullen? Ga naar de <a href="https://lokaalbestuur.vlaanderen.be/loket-lokaal-bestuur-module-subsidies" target="_blank" rel="noopener noreferrer">informatiepagina over subsidies</a> die u kan indienen via het loket.
+</AuHelpText>
+<table class="data-table data-table--zebra data-table--tight au-u-margin-top-small ">
+  <caption class="au-u-hidden-visually">Vul het aantal opgevangen kinderen voor alle volle en halve dagen en het aantal kinderen dat in aanmerking komt voor infrastructuursubsidies per organisator in</caption>
+  <thead>
+    <tr>
+      <th scope="col">
+        Naam&nbsp;organisator
+        <AuHelpText>bv. school, jeugdvereniging</AuHelpText>
+      </th>
+      <th scope="col">
+        Aantal kinderen voor alle volle dagen
+      </th>
+      <th scope="col">
+        Aantal kinderen voor alle halve dagen
+      </th>
+      <th scope="col">
+        Aantal kinderen in aanmerking voor infrastructuursubsidies
+      </th>
+      <td></td>
+    </tr>
+  </thead>
+  <tbody>
+    {{#each this.sortedEntries as |entry index|}}
+      <tr>
+        <td>
+          <AuLabel for="actor-name-{{index}}" class="au-u-hidden-visually">Naam organisator</AuLabel>
+          <AuInput id="actor-name-{{index}}" @width="block" @value={{entry.actorName.value}} @disabled={{true}}/>
+        </td>
+        <td>
+          <AuLabel for="all-day-{{index}}" class="au-u-hidden-visually">
+            Kinderen voor <em>alle volle dagen</em>,
+            <br>
+            met personeel
+          </AuLabel>
+          <AuInput id="all-day-{{index}}" @width="block" @value={{entry.numberChildrenForFullDay.value}} @disabled={{true}}/>
+        </td>
+        <td>
+          <AuLabel for="half-day-{{index}}"  class="au-u-hidden-visually">
+            Kinderen voor alle halve dagen,
+            <br>
+            met personeel
+          </AuLabel>
+          <AuInput id="half-day-{{index}}" @width="block" @value={{entry.numberChildrenForHalfDay.value}} @disabled={{true}}/>
+        </td>
+        <td>
+          <AuLabel for="per-infra-{{index}}" class="au-u-hidden-visually">
+            Kinderen per infrastructuur per dag,
+            <br>
+            met of zonder personeel
+          </AuLabel>
+          <AuInput id="per-infra-{{index}}" @width="block" @value={{entry.numberChildrenPerInfrastructure.value}} @disabled={{true}}/>
+        </td>
+        <td style="white-space: nowrap; vertical-align: middle;" {{! template-lint-disable no-inline-styles }}>
+          €&hairsp;{{entry.totalAmount}}
+        </td>
+      </tr>
+    {{/each}}
+    {{#if this.usedParentalContribution}}
+      <tr>
+        <th colspan="3" class="data-table__add-row u-align-center"></th>
+        <th class="data-table__add-row u-align-right">
+          Ouderbijdrage:
+        </th>
+        <th>-50%</th>
+      </tr>
+    {{/if}}
+    <tr>
+      <th colspan="3" class="data-table__add-row u-align-center"></th>
+      <th class="data-table__add-row u-align-right">Totaal:</th>
+      <th class="data-table__add-row u-align-center">€&hairsp;{{this.aangevraagdBedrag}}</th>
+    </tr>
+  </tbody>
+</table>
+
+{{yield}}

--- a/app/components/rdf-form-fields/application-form-table/show.js
+++ b/app/components/rdf-form-fields/application-form-table/show.js
@@ -1,0 +1,213 @@
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+import { tracked } from '@glimmer/tracking';
+import { triplesForPath } from '@lblod/submission-form-helpers';
+import rdflib from 'browser-rdflib';
+
+const extBaseUri = 'http://mu.semte.ch/vocabularies/ext/';
+
+const applicationFormEntryPredicate = new rdflib.NamedNode(
+  `${extBaseUri}applicationFormEntry`
+);
+const actorNamePredicate = new rdflib.NamedNode(
+  `http://mu.semte.ch/vocabularies/ext/actorName`
+);
+const numberChildrenForFullDayPredicate = new rdflib.NamedNode(
+  `http://mu.semte.ch/vocabularies/ext/numberChildrenForFullDay`
+);
+const numberChildrenForHalfDayPredicate = new rdflib.NamedNode(
+  `http://mu.semte.ch/vocabularies/ext/numberChildrenForHalfDay`
+);
+const numberChildrenPerInfrastructurePredicate = new rdflib.NamedNode(
+  `http://mu.semte.ch/vocabularies/ext/numberChildrenPerInfrastructure`
+);
+const createdPredicate = new rdflib.NamedNode(
+  'http://purl.org/dc/terms/created'
+);
+
+const LBLOD_SUBSIDIE = new rdflib.Namespace(
+  'http://lblod.data.gift/vocabularies/subsidie/'
+);
+
+class EntryProperties {
+  @tracked value;
+  @tracked oldValue;
+
+  constructor(value, predicate) {
+    this.value = value;
+    this.oldValue = value;
+    this.predicate = predicate;
+  }
+}
+
+class ApplicationFormEntry {
+  @tracked applicationFormEntrySubject;
+
+  get totalAmount() {
+    return (
+      this.numberChildrenForFullDay.value * 20 +
+      this.numberChildrenForHalfDay.value * 10 +
+      this.numberChildrenPerInfrastructure.value * 10
+    );
+  }
+
+  constructor({
+    applicationFormEntrySubject,
+    actorName,
+    numberChildrenForFullDay,
+    numberChildrenForHalfDay,
+    numberChildrenPerInfrastructure,
+    created,
+  }) {
+    this.applicationFormEntrySubject = applicationFormEntrySubject;
+
+    this.actorName = new EntryProperties(actorName, actorNamePredicate);
+    this.numberChildrenForFullDay = new EntryProperties(
+      numberChildrenForFullDay,
+      numberChildrenForFullDayPredicate
+    );
+    this.numberChildrenForHalfDay = new EntryProperties(
+      numberChildrenForHalfDay,
+      numberChildrenForHalfDayPredicate
+    );
+    this.numberChildrenPerInfrastructure = new EntryProperties(
+      numberChildrenPerInfrastructure,
+      numberChildrenPerInfrastructurePredicate
+    );
+    this.created = new EntryProperties(created, createdPredicate);
+  }
+}
+
+export default class RdfFormFieldsApplicationFormTableShowComponent extends InputFieldComponent {
+  @tracked applicationFormTableSubject = null;
+  @tracked entries = [];
+
+  constructor() {
+    super(...arguments);
+    this.loadProvidedValue();
+  }
+
+  get aangevraagdBedrag() {
+    let total = 0;
+    this.entries.forEach((entry) => {
+      total += entry.totalAmount;
+    });
+    if (this.usedParentalContribution) {
+      total = total / 2;
+    }
+    return total;
+  }
+
+  get sortedEntries() {
+    return this.entries.sort((a, b) =>
+      a.created.value.localeCompare(b.created.value)
+    );
+  }
+
+  loadProvidedValue() {
+    const matches = triplesForPath(this.storeOptions);
+    const triples = matches.triples;
+
+    if (triples.length) {
+      this.applicationFormTableSubject = triples[0].object; // assuming only one per form
+
+      const entriesMatches = triplesForPath({
+        store: this.storeOptions.store,
+        path: applicationFormEntryPredicate,
+        formGraph: this.storeOptions.formGraph,
+        sourceNode: this.applicationFormTableSubject,
+        sourceGraph: this.storeOptions.sourceGraph,
+      });
+      const entriesTriples = entriesMatches.triples;
+
+      if (entriesTriples.length > 0) {
+        for (let entry of entriesTriples) {
+          const entryProperties = this.storeOptions.store.match(
+            entry.object,
+            undefined,
+            undefined,
+            this.storeOptions.sourceGraph
+          );
+
+          const parsedEntry = this.parseEntryProperties(entryProperties);
+
+          this.entries.pushObject(
+            new ApplicationFormEntry({
+              applicationFormEntrySubject: entry.object,
+              actorName: parsedEntry.actorName,
+              numberChildrenForFullDay: parsedEntry.numberChildrenForFullDay,
+              numberChildrenForHalfDay: parsedEntry.numberChildrenForHalfDay,
+              numberChildrenPerInfrastructure:
+                parsedEntry.numberChildrenPerInfrastructure,
+              created: parsedEntry.created,
+            })
+          );
+        }
+      }
+
+      const { store, sourceNode, sourceGraph } = this.storeOptions;
+      const predicate = LBLOD_SUBSIDIE('usedParentalContribution');
+      this.usedParentalContribution = !!store.any(
+        sourceNode,
+        predicate,
+        undefined,
+        sourceGraph
+      );
+    }
+  }
+
+  /**
+   * Parse entry properties from triples to a simple object with the triple values
+   */
+  parseEntryProperties(entryProperties) {
+    let entry = {};
+    if (
+      entryProperties.find(
+        (entry) => entry.predicate.value == actorNamePredicate.value
+      )
+    )
+      entry.actorName = entryProperties.find(
+        (entry) => entry.predicate.value == actorNamePredicate.value
+      ).object.value;
+    if (
+      entryProperties.find(
+        (entry) =>
+          entry.predicate.value == numberChildrenForFullDayPredicate.value
+      )
+    )
+      entry.numberChildrenForFullDay = entryProperties.find(
+        (entry) =>
+          entry.predicate.value == numberChildrenForFullDayPredicate.value
+      ).object.value;
+    if (
+      entryProperties.find(
+        (entry) =>
+          entry.predicate.value == numberChildrenForHalfDayPredicate.value
+      )
+    )
+      entry.numberChildrenForHalfDay = entryProperties.find(
+        (entry) =>
+          entry.predicate.value == numberChildrenForHalfDayPredicate.value
+      ).object.value;
+    if (
+      entryProperties.find(
+        (entry) =>
+          entry.predicate.value ==
+          numberChildrenPerInfrastructurePredicate.value
+      )
+    )
+      entry.numberChildrenPerInfrastructure = entryProperties.find(
+        (entry) =>
+          entry.predicate.value ==
+          numberChildrenPerInfrastructurePredicate.value
+      ).object.value;
+    if (
+      entryProperties.find(
+        (entry) => entry.predicate.value == createdPredicate.value
+      )
+    )
+      entry.created = entryProperties.find(
+        (entry) => entry.predicate.value == createdPredicate.value
+      ).object.value;
+    return entry;
+  }
+}

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table.hbs
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table.hbs
@@ -1,0 +1,570 @@
+<dl class="au-o-grid au-u-margin-bottom-large">
+  <div class="au-o-grid__item au-u-1-2 au-u-1-6@medium">
+    <dt class="au-c-label">Aantal inwoners</dt>
+    <dd>{{this.populationCount}}</dd>
+  </div>
+
+  <div class="au-o-grid__item au-u-1-2 au-u-2-6@medium">
+    <dt class="au-c-label">Totaal trekkingsrecht</dt>
+    <dd>{{convert-to-currency this.drawingRight}}</dd>
+  </div>
+
+  <div class="au-o-grid__item au-u-1-2 au-u-2-6@medium">
+    <dt class="au-c-label">Trekkingsrecht te verdelen</dt>
+    <dd class={{if this.hasErrors "au-u-error"}}>
+      {{convert-to-currency this.restitutionToDestribute}}
+    </dd>
+  </div>
+</dl>
+
+<AuLabel @error={{this.hasErrors}} for={{this.inputFor}}>
+  {{@field.label}}
+</AuLabel>
+{{#each this.errors as |error|}}
+  <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+{{/each}}
+
+<table
+  class="data-table data-table--zebra data-table--tight au-u-margin-top-small"
+>
+  <caption class="au-u-hidden-visually">Simuleer het te verdelen trekkingsrecht
+    voor de klimaat subsidies</caption>
+  <thead>
+    <tr>
+      <th scope="col">
+        Omschrijving actie
+      </th>
+      <th scope="col">
+        Waarde per item in euro
+        <br />
+        <span class="au-u-regular">Te bepalen door bestuur</span>
+      </th>
+      <th scope="col">
+        Te realiseren items
+      </th>
+      <th scope="col">
+        Ingeschatte waarde
+      </th>
+      <th scope="col">
+        Voorgestelde cofinanciering (50%)
+      </th>
+      {{#if this.canAddNewActions}}
+        <th scope="col"></th>
+      {{/if}}
+    </tr>
+  </thead>
+  <tbody>
+    {{#if this.climateTableSubject}}
+      <RdfFormFields::ClimateSubsidyCostsTable::TableRowBurgemeesters
+        @disabled={{@show}}
+        @storeOptions={{this.storeOptions}}
+        @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/0f4e3cff-4fb8-4892-9dca-1d582a433c77"
+        @climateTableSubject={{this.climateTableSubject}}
+        @populationCount={{this.populationCount}}
+        @updateTotalRestitution={{this.updateTotaleRestitution}}
+        @onUpdateRow={{this.validate}}
+        @showDeleteColumn={{this.canAddNewActions}}
+        as |row|
+      >
+        <row.actionDescription>
+          <RdfFormFields::ClimateSubsidyCostsTable::Accordion
+            @label="Algemene beleidsdoelstellingen:"
+            @subtitle="Opmaak, uitvoering en opvolging Burgemeestersconvenant actieplan 2030"
+          >
+            <p>
+              Na ondertekening van het Burgemeestersconvenant 2030 kunnen deze
+              middelen gebruikt worden voor de bijsturing, uitvoering,
+              opvolging, kennisuitwisseling en samenwerking met stakeholders
+              t.a.v. het duurzame energie- en klimaatactieplan 2030. Een
+              college- of gemeenteraadsbesluit moet aantonen op welke wijze de
+              middelen werden benut. Dit wordt opgeladen in deze tool vanaf
+              oktober 2021.
+            </p>
+            <AuLinkExternal
+              href="https://www.vvsg.be/netwerkklimaat/lokaal-energie-en-klimaatpact"
+            >
+              www.vvsg.be/netwerkklimaat/lokaal-energie-en-klimaatpact
+            </AuLinkExternal>
+          </RdfFormFields::ClimateSubsidyCostsTable::Accordion>
+        </row.actionDescription>
+      </RdfFormFields::ClimateSubsidyCostsTable::TableRowBurgemeesters>
+
+      <RdfFormFields::ClimateSubsidyCostsTable::TableRowVastgoedplan
+        @disabled={{@show}}
+        @storeOptions={{this.storeOptions}}
+        @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/6469df9c-b933-45c3-9457-4958c33935ca"
+        @climateTableSubject={{this.climateTableSubject}}
+        @populationCount={{this.populationCount}}
+        @updateTotalRestitution={{this.updateTotaleRestitution}}
+        @onUpdateRow={{this.validate}}
+        @showDeleteColumn={{this.canAddNewActions}}
+        as |row|
+      >
+        <row.actionDescription>
+          <RdfFormFields::ClimateSubsidyCostsTable::Accordion
+            @label="Algemene beleidsdoelstellingen:"
+            @subtitle="Ondersteuning Strategisch Vastgoedplan"
+          >
+            <p>
+              Een strategisch vastgoedplan omvat minstens 75% van het publiek
+              patrimonium en bevat minstens een behoefte analyse,
+              inventarisatie, doelstellingen en de aanbestedingsstrategie. Een
+              indicatieve template en checklist (volledigheidstoets) worden ter
+              beschikking gesteld via Netwerk Klimaat en het SURE2050 project.
+            </p>
+            <AuLinkExternal
+              href="https://www.vvsg.be/netwerkklimaat/lokaal-energie-en-klimaatpact"
+            >
+              www.vvsg.be/netwerkklimaat/lokaal-energie-en-klimaatpact
+            </AuLinkExternal>
+          </RdfFormFields::ClimateSubsidyCostsTable::Accordion>
+        </row.actionDescription>
+
+      </RdfFormFields::ClimateSubsidyCostsTable::TableRowVastgoedplan>
+
+      <RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf
+        @disabled={{@show}}
+        @storeOptions={{this.storeOptions}}
+        @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/384b2567-ab54-4b6f-b19c-a438829b3666"
+        @climateTableSubject={{this.climateTableSubject}}
+        @updateTotalRestitution={{this.updateTotaleRestitution}}
+        @onUpdateRow={{this.validate}}
+        @showDeleteColumn={{this.canAddNewActions}}
+        as |row|
+      >
+        <row.actionDescription>
+          <RdfFormFields::ClimateSubsidyCostsTable::Accordion
+            @label="Werf 1 - Vergroening:"
+            @subtitle="Investeringssteun voor het planten van bomen op publiek"
+          >
+            <AuLinkExternal
+              href="https://www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening"
+            >
+              www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening
+            </AuLinkExternal>
+          </RdfFormFields::ClimateSubsidyCostsTable::Accordion>
+        </row.actionDescription>
+        <row.costPerUnitDescription>
+          per boom op publiek domein
+          <br />
+          <span class="au-c-info-text">Indicatie: € 150,00</span>
+        </row.costPerUnitDescription>
+      </RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf>
+
+      <RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf
+        @disabled={{@show}}
+        @storeOptions={{this.storeOptions}}
+        @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/e6339d50-0969-4911-924c-bb0c629c7b00"
+        @climateTableSubject={{this.climateTableSubject}}
+        @updateTotalRestitution={{this.updateTotaleRestitution}}
+        @onUpdateRow={{this.validate}}
+        @showDeleteColumn={{this.canAddNewActions}}
+        as |row|
+      >
+        <row.actionDescription>
+          <RdfFormFields::ClimateSubsidyCostsTable::Accordion
+            @label="Werf 1 - Vergroening:"
+            @subtitle="Investeringssteun voor het planten van bomen op privaat domein (door particulieren, verenigingen, KMO's)"
+          >
+            <AuLinkExternal
+              href="https://www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening"
+            >
+              www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening
+            </AuLinkExternal>
+          </RdfFormFields::ClimateSubsidyCostsTable::Accordion>
+        </row.actionDescription>
+        <row.costPerUnitDescription>
+          per boom op privaat domein<br />
+          <span class="au-c-info-text">Indicatie: € 50,00</span>
+        </row.costPerUnitDescription>
+      </RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf>
+
+      <RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf
+        @disabled={{@show}}
+        @storeOptions={{this.storeOptions}}
+        @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/396fe1bd-0a13-4823-8824-05ea3a527337"
+        @climateTableSubject={{this.climateTableSubject}}
+        @updateTotalRestitution={{this.updateTotaleRestitution}}
+        @onUpdateRow={{this.validate}}
+        @showDeleteColumn={{this.canAddNewActions}}
+        as |row|
+      >
+        <row.actionDescription>
+          <RdfFormFields::ClimateSubsidyCostsTable::Accordion
+            @label="Werf 1 - Vergroening:"
+            @subtitle="Investeringssteun voor het planten van hagen (per meter) op publiek domein"
+          >
+            <AuLinkExternal
+              href="https://www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening"
+            >
+              www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening
+            </AuLinkExternal>
+          </RdfFormFields::ClimateSubsidyCostsTable::Accordion>
+        </row.actionDescription>
+        <row.costPerUnitDescription>
+          per meter haag op publiek domein<br />
+          <span class="au-c-info-text">Indicatie: € 13,50</span>
+        </row.costPerUnitDescription>
+      </RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf>
+
+      <RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf
+        @disabled={{@show}}
+        @storeOptions={{this.storeOptions}}
+        @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/75ad483c-b7cb-411c-b9b1-07af31bfc0e6"
+        @climateTableSubject={{this.climateTableSubject}}
+        @updateTotalRestitution={{this.updateTotaleRestitution}}
+        @onUpdateRow={{this.validate}}
+        @showDeleteColumn={{this.canAddNewActions}}
+        as |row|
+      >
+        <row.actionDescription>
+          <RdfFormFields::ClimateSubsidyCostsTable::Accordion
+            @label="Werf 1 - Vergroening:"
+            @subtitle="Investeringssteun voor het planten van hagen (per meter) op privaat domein (door particulieren, verenigingen en KMO's)"
+          >
+            <AuLinkExternal
+              href="https://www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening"
+            >
+              www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening
+            </AuLinkExternal>
+          </RdfFormFields::ClimateSubsidyCostsTable::Accordion>
+        </row.actionDescription>
+        <row.costPerUnitDescription>
+          per meter haag op privaat domein
+          <br />
+          <span class="au-c-info-text">Indicatie: € 5,00</span>
+        </row.costPerUnitDescription>
+      </RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf>
+
+      <RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf
+        @disabled={{@show}}
+        @storeOptions={{this.storeOptions}}
+        @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/75b3a2d2-bf33-49e7-9ced-c166213970bb"
+        @climateTableSubject={{this.climateTableSubject}}
+        @updateTotalRestitution={{this.updateTotaleRestitution}}
+        @onUpdateRow={{this.validate}}
+        @showDeleteColumn={{this.canAddNewActions}}
+        as |row|
+      >
+        <row.actionDescription>
+          <RdfFormFields::ClimateSubsidyCostsTable::Accordion
+            @label="Werf 1 - Vergroening:"
+            @subtitle="Investeringssteun geveltuinbeplanting (type geveltuin, per meter) door particulieren"
+          >
+            <AuLinkExternal
+              href="https://www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening"
+            >
+              www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening
+            </AuLinkExternal>
+          </RdfFormFields::ClimateSubsidyCostsTable::Accordion>
+        </row.actionDescription>
+        <row.costPerUnitDescription>
+          per gerealiseerde geveltuin
+          <br />
+          <span class="au-c-info-text">Indicatie: € 38,50</span>
+        </row.costPerUnitDescription>
+      </RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf>
+
+      <RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf
+        @disabled={{@show}}
+        @storeOptions={{this.storeOptions}}
+        @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/567c8492-c587-4876-b910-f6bbcd25c971"
+        @climateTableSubject={{this.climateTableSubject}}
+        @updateTotalRestitution={{this.updateTotaleRestitution}}
+        @onUpdateRow={{this.validate}}
+        @showDeleteColumn={{this.canAddNewActions}}
+        as |row|
+      >
+        <row.actionDescription>
+          <RdfFormFields::ClimateSubsidyCostsTable::Accordion
+            @label="Werf 1 - Vergroening:"
+            @subtitle="Investeringssteun aanleg natuurgroenperk van minimaal 10 m² op openbaar toegankelijk domein"
+          >
+            <AuLinkExternal
+              href="https://www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening"
+            >
+              www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening
+            </AuLinkExternal>
+          </RdfFormFields::ClimateSubsidyCostsTable::Accordion>
+        </row.actionDescription>
+        <row.costPerUnitDescription>
+          per publiek toegankelijk natuurgroenperk van minimaal 10m²
+          <br />
+          <span class="au-c-info-text">Indicatie: € 540,00</span>
+        </row.costPerUnitDescription>
+      </RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf>
+
+      <RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf
+        @disabled={{@show}}
+        @storeOptions={{this.storeOptions}}
+        @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/0eb27f0d-bbe3-41c1-8793-b1b13b1b8715"
+        @climateTableSubject={{this.climateTableSubject}}
+        @updateTotalRestitution={{this.updateTotaleRestitution}}
+        @onUpdateRow={{this.validate}}
+        @showDeleteColumn={{this.canAddNewActions}}
+        as |row|
+      >
+        <row.actionDescription>
+          <RdfFormFields::ClimateSubsidyCostsTable::Accordion
+            @label="Werf 2 - Verrijk je wijk"
+            @subtitle="Ondersteuning traject collectieve renovaties"
+          >
+            <p>
+              Een collectief renovatieproject kan worden gestimuleerd via een
+              ondersteunende tool of platform die alle stakeholders verbindt.
+              Energiehuizen kunnen samenwerken met collectieve
+              renovatiebegeleiders en VME-begeleiders. Gemeentes kunnen voorzien
+              in een wijkaanpak, stimuleringscampagnes en doelgroepenbeleid (bv.
+              begeleiding van renovaties i.h.k.v. het noodkoopfonds.)
+            </p>
+            <AuLinkExternal
+              href="https://www.vvsg.be/kennisitem/vvsg/verrijk-je-wijk-energie"
+            >
+              www.vvsg.be/kennisitem/vvsg/verrijk-je-wijk-energie
+            </AuLinkExternal>
+          </RdfFormFields::ClimateSubsidyCostsTable::Accordion>
+        </row.actionDescription>
+        <row.costPerUnitDescription>
+          per wooneenheid die opgevolgd wordt via ondersteunend platform voor
+          een collectieve renovatie<br />
+          <span class="au-c-info-text">Indicatie: € 125,00</span>
+        </row.costPerUnitDescription>
+      </RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf>
+
+      <RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf
+        @disabled={{@show}}
+        @storeOptions={{this.storeOptions}}
+        @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/23e94ba7-57cf-4ad4-8f5e-b4a8dcc6f816"
+        @climateTableSubject={{this.climateTableSubject}}
+        @updateTotalRestitution={{this.updateTotaleRestitution}}
+        @onUpdateRow={{this.validate}}
+        @showDeleteColumn={{this.canAddNewActions}}
+        as |row|
+      >
+        <row.actionDescription>
+          <RdfFormFields::ClimateSubsidyCostsTable::Accordion
+            @label="Werf 2 - Verrijk je wijk"
+            @subtitle="Aanbestedingskosten en facilitatie participatieve hernieuwbare energie (per realisatie van 18kWp)"
+          >
+            <p>
+              Uitgevoerde projecten kunnen worden aangemeld via de Energiekaart
+              op
+              <AuLinkExternal href="https://energiesparen.be">
+                Energiesparen.be
+              </AuLinkExternal>
+              <AuLinkExternal
+                href="https://apps.energiesparen.be/energiekaart/vlaanderen/cooperaties"
+              >(https://apps.energiesparen.be/energiekaart/vlaanderen/cooperaties).</AuLinkExternal>
+            </p>
+            <AuLinkExternal
+              href="https://www.vvsg.be/kennisitem/vvsg/verrijk-je-wijk-energie"
+            >www.vvsg.be/kennisitem/vvsg/verrijk-je-wijk-energie</AuLinkExternal>
+          </RdfFormFields::ClimateSubsidyCostsTable::Accordion>
+        </row.actionDescription>
+        <row.costPerUnitDescription>
+          per realisatie van 18kWp<br />
+          <span class="au-c-info-text">Indicatie: € 990,00</span>
+        </row.costPerUnitDescription>
+      </RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf>
+
+      <RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf
+        @disabled={{@show}}
+        @storeOptions={{this.storeOptions}}
+        @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/38d6d2bd-e42b-4d7e-8fea-9a371d9cf22f"
+        @climateTableSubject={{this.climateTableSubject}}
+        @updateTotalRestitution={{this.updateTotaleRestitution}}
+        @onUpdateRow={{this.validate}}
+        @showDeleteColumn={{this.canAddNewActions}}
+        as |row|
+      >
+        <row.actionDescription>
+          <RdfFormFields::ClimateSubsidyCostsTable::Accordion
+            @label="Werf 2 - Verrijk je wijk"
+            @subtitle="Facilitatie energiegemeenschappen en energiedelen"
+          >
+            <p>
+              Gefaciliteerd door een dienstverlener kan de gemeente
+              opstarttrajecten lanceren voor activiteiten van
+              energiegemeenschappen: collectieve renovaties, participatieve
+              hernieuwbare energie opwekken en delen, flexibiliteitsdiensten en
+              de integratie met laad- en mobiliteitsoplossingen op wijkniveau.
+            </p>
+            <AuLinkExternal
+              href="https://www.vvsg.be/kennisitem/vvsg/verrijk-je-wijk-energie"
+            >www.vvsg.be/kennisitem/vvsg/verrijk-je-wijk-energie</AuLinkExternal>
+          </RdfFormFields::ClimateSubsidyCostsTable::Accordion>
+        </row.actionDescription>
+        <row.costPerUnitDescription>
+          per opstart traject<br />
+          <span class="au-c-info-text">Indicatie: € 20.000,00</span>
+        </row.costPerUnitDescription>
+      </RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf>
+
+      <RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf
+        @disabled={{@show}}
+        @storeOptions={{this.storeOptions}}
+        @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/3b939085-ea60-468e-9fb8-ee0b54f1d73c"
+        @climateTableSubject={{this.climateTableSubject}}
+        @updateTotalRestitution={{this.updateTotaleRestitution}}
+        @onUpdateRow={{this.validate}}
+        @showDeleteColumn={{this.canAddNewActions}}
+        as |row|
+      >
+        <row.actionDescription>
+          <RdfFormFields::ClimateSubsidyCostsTable::Accordion
+            @label="Werf 3 - Iedere buurt deelt"
+            @subtitle="Afnamegarantie per jaar of ander ondersteuningskanaal per toegangspunt voor koosltofvrije deelsystemen (1 toegangspunt leidt tot 2 deelwagens)"
+          >
+            <p>
+              Via o.a. afnamegarantiecontracten, het opzetten van een
+              kansentarief, een burgerbudget, de installatie van een
+              autodeelloket of door het voeren van een wervingscampagne kunnen
+              de aantal toegangspunten voor koolstofvrije deelsystemen toenemen.
+              Een toegangspunt leidt gemiddeld tot twee extra (koolstofvrije)
+              deelwagens. Via een bevraging door Autodelen.net zullen de
+              toegenomen aantal toegangspunten tot deelsystemen worden
+              opgevolgd.
+            </p>
+            <AuLinkExternal
+              href="https://www.vvsg.be/kennisitem/vvsg/elke-buurt-deelt-en-is-duurzaam-bereikbaar"
+            >www.vvsg.be/kennisitem/vvsg/elke-buurt-deelt-en-is-duurzaam-bereikbaar</AuLinkExternal>
+          </RdfFormFields::ClimateSubsidyCostsTable::Accordion>
+        </row.actionDescription>
+        <row.costPerUnitDescription>
+          per toegangspunt dat leidt tot 2 deelwagens<br />
+          <span class="au-c-info-text">Indicatie: € 4.800,00 tot € 12.000,00</span>
+        </row.costPerUnitDescription>
+      </RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf>
+
+      <RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf
+        @disabled={{@show}}
+        @storeOptions={{this.storeOptions}}
+        @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/f4956772-fd3e-48f5-b546-e5298fff78ad"
+        @climateTableSubject={{this.climateTableSubject}}
+        @updateTotalRestitution={{this.updateTotaleRestitution}}
+        @onUpdateRow={{this.validate}}
+        @showDeleteColumn={{this.canAddNewActions}}
+        as |row|
+      >
+        <row.actionDescription>
+          <RdfFormFields::ClimateSubsidyCostsTable::Accordion
+            @label="Werf 4 - Water het nieuwe goud"
+            @subtitle="Investeringssteun per 1m² ontharding publiek domein "
+          >
+            <p>Verharding stemt overeen met de term ‘bodemafdekking’ zoals
+              Vlaanderenbreed geïnventariseerd door AGIV.
+            </p>
+            <AuLinkExternal
+              href="https://www.vvsg.be/kennisitem/vvsg/water-het-nieuwe-goud-droogteproblematiek"
+            >www.vvsg.be/kennisitem/vvsg/water-het-nieuwe-goud-droogteproblematiek</AuLinkExternal>
+          </RdfFormFields::ClimateSubsidyCostsTable::Accordion>
+        </row.actionDescription>
+        <row.costPerUnitDescription>
+          per 1m² ontharding op publiek domein<br />
+          <span class="au-c-info-text">Indicatie: € 50,00</span>
+        </row.costPerUnitDescription>
+      </RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf>
+
+      <RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf
+        @disabled={{@show}}
+        @storeOptions={{this.storeOptions}}
+        @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/0efb6b57-2ab4-4526-b71e-ec3568f01d1b"
+        @climateTableSubject={{this.climateTableSubject}}
+        @updateTotalRestitution={{this.updateTotaleRestitution}}
+        @onUpdateRow={{this.validate}}
+        @showDeleteColumn={{this.canAddNewActions}}
+        as |row|
+      >
+        <row.actionDescription>
+          <RdfFormFields::ClimateSubsidyCostsTable::Accordion
+            @label="Werf 4 - Water het nieuwe goud"
+            @subtitle="Investeringssteun per 1m² ontharding privaat domein"
+          >
+            <p>Verharding stemt overeen met de term ‘bodemafdekking’ zoals
+              Vlaanderenbreed geïnventariseerd door AGIV.</p>
+            <AuLinkExternal
+              href="https://www.vvsg.be/kennisitem/vvsg/water-het-nieuwe-goud-droogteproblematiek"
+            >www.vvsg.be/kennisitem/vvsg/water-het-nieuwe-goud-droogteproblematiek</AuLinkExternal>
+          </RdfFormFields::ClimateSubsidyCostsTable::Accordion>
+        </row.actionDescription>
+        <row.costPerUnitDescription>
+          per 1m² ontharding op privaat domein<br />
+          <span class="au-c-info-text">Indicatie: € 35,00</span>
+        </row.costPerUnitDescription>
+      </RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf>
+
+      <RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf
+        @disabled={{@show}}
+        @storeOptions={{this.storeOptions}}
+        @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/5d485edc-3352-4bbe-a74c-e50cc0e22dec"
+        @climateTableSubject={{this.climateTableSubject}}
+        @updateTotalRestitution={{this.updateTotaleRestitution}}
+        @onUpdateRow={{this.validate}}
+        @showDeleteColumn={{this.canAddNewActions}}
+        as |row|
+      >
+        <row.actionDescription>
+          <RdfFormFields::ClimateSubsidyCostsTable::Accordion
+            @label="Werf 4 - Water het nieuwe goud"
+            @subtitle="Steun voor opvang van hemelwater voor hergebruik, buffering en infiltratie per m³ op privaat of publiek toegankelijk domein"
+          >
+            <p>
+              Hier wordt gedoeld op de netto-toename van hemelwateropvang voor
+              hergebruik, buffering en infiltratie binnen de huidige bebouwde
+              omgeving. Opvang of infiltratie dat voorzien wordt in nieuwe
+              verkavelingsbuurten door verplichtingen (bv. uitvoering
+              stedenbouwkundige verordening of opgelegde lasten binnen
+              verkaveling) worden niet meegeteld. Additionele capaciteit die
+              voorzien wordt bij appartementsgebouwen, wordt wel meegeteld.
+            </p>
+            <AuLinkExternal
+              href="https://https://www.vvsg.be/kennisitem/vvsg/water-het-nieuwe-goud-droogteproblematiek"
+            >www.vvsg.be/kennisitem/vvsg/water-het-nieuwe-goud-droogteproblematiek</AuLinkExternal>
+          </RdfFormFields::ClimateSubsidyCostsTable::Accordion>
+        </row.actionDescription>
+        <row.costPerUnitDescription>
+          per 1m²<br />
+          <span class="au-c-info-text">
+            Indicatie: € 500,00 voor hemelwaterput met infiltratiecapaciteit en
+            €1.000,00 voor hemelwaterbuffers
+          </span>
+        </row.costPerUnitDescription>
+      </RdfFormFields::ClimateSubsidyCostsTable::TableRowWerf>
+
+      {{#each this.customActions as |action|}}
+        <RdfFormFields::ClimateSubsidyCostsTable::TableRowCustomAction
+          @disabled={{@show}}
+          @storeOptions={{this.storeOptions}}
+          @businessRuleUri={{action.businessRuleUri}}
+          @order={{action.order}}
+          @climateTableSubject={{this.climateTableSubject}}
+          @updateTotalRestitution={{this.updateTotaleRestitution}}
+          @onUpdateRow={{this.validate}}
+          @onDelete={{fn this.removeCustomAction action}}
+          @showDeleteColumn={{this.canAddNewActions}}
+        />
+      {{/each}}
+    {{/if}}
+  </tbody>
+</table>
+
+{{#if this.canAddNewActions}}
+  <div class="au-u-margin-top au-u-text-center">
+    <AuButton
+      @icon="plus"
+      @iconAlignment="left"
+      class="au-u-margin-bottom-tiny"
+      {{on "click" this.addNewAction}}
+    >
+      Voeg acties toe
+    </AuButton>
+    <div class="au-u-margin-bottom-tiny au-u-margin-top-tiny">
+      <AuHelpText>
+        Via deze knop kan u eigen lokale acties toevoegen aan deze tabel.
+        <AuLinkExternal href="https://www.vvsg.be/kennisitem/vvsg/veelgestelde-vragen-klimaatpact">
+          Lees hierover meer.
+        </AuLinkExternal>
+      </AuHelpText>
+    </div>
+  </div>
+{{/if}}

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table.js
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table.js
@@ -1,0 +1,317 @@
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+import { tracked } from '@glimmer/tracking';
+import { A } from '@ember/array';
+import { action } from '@ember/object';
+import { triplesForPath } from '@lblod/submission-form-helpers';
+import { scheduleOnce } from '@ember/runloop';
+import rdflib from 'browser-rdflib';
+import { v4 as uuidv4 } from 'uuid';
+import { RDF } from '@lblod/submission-form-helpers';
+
+const LBLOD_SUBSIDIE = new rdflib.Namespace(
+  'http://lblod.data.gift/vocabularies/subsidie/'
+);
+const DBPEDIA = new rdflib.Namespace('http://dbpedia.org/ontology/');
+const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+
+const climateTableBaseUri = 'http://data.lblod.info/climate-tables';
+const lblodSubsidieBaseUri = 'http://lblod.data.gift/vocabularies/subsidie/';
+const climateBaseUri = 'http://data.lblod.info/vocabularies/subsidie/climate/';
+
+const climateTableType = new rdflib.NamedNode(
+  `${lblodSubsidieBaseUri}ClimateTable`
+);
+const climateTablePredicate = new rdflib.NamedNode(
+  `${lblodSubsidieBaseUri}climateTable`
+);
+const hasInvalidRowPredicate = new rdflib.NamedNode(
+  `${climateTableBaseUri}/hasInvalidClimateTableEntry`
+);
+const validClimateTable = new rdflib.NamedNode(
+  `${lblodSubsidieBaseUri}validClimateTable`
+);
+const totalBudgettedAmount = new rdflib.NamedNode(
+  `${lblodSubsidieBaseUri}totalBudgettedAmount`
+);
+const allowNewActions = new rdflib.NamedNode(
+  `${climateTableBaseUri}/allowNewActions`
+);
+const climateEntryCustomAction = new rdflib.NamedNode(
+  `${climateBaseUri}customAction`
+);
+
+/*
+ * Component wrapping the big subsidy table for climate action.
+ * Some notes
+ *  ---------
+ * - The business rule URI are in the database. So if the rules change, you will have to maintain these too.
+ *   In that case, you will have to create a new instance of a business rule.
+ *   -  Please note, they mainly are stored as documentation, so we know what numbers mean when making reports.
+ *   - Your main question is, why don't use this information to render data in the components?
+ *     Well, NOW, this could be considered, but when we started, the rules were more complicated and given
+ *     the huge time constraints, the unknow randomness of the upcoming changes in rules,
+ *     we didn't want to lock ourselves to engineering a solution that wouldn't work for an custom rule.
+ *     So yes, this implies double bookkeeping. And hopefuly we can refactor this a bit.
+ *    - The same argumentation is valid for the custom rows here. Yes, these could be abstracted NOW, but that wasn't the case a the start.
+ */
+export default class RdfFormFieldsClimateSubsidyCostsTableComponent extends InputFieldComponent {
+  @tracked climateTableSubject = null;
+  @tracked entries = A();
+  @tracked restitutionToDestribute;
+  @tracked errors = A();
+  @tracked populationCount;
+  @tracked drawingRight;
+  @tracked customActions = [];
+  orderCounter = 0;
+
+  get hasClimateTable() {
+    if (!this.climateTableSubject) return false;
+    else
+      return (
+        this.storeOptions.store.match(
+          this.sourceNode,
+          climateTablePredicate,
+          this.climateTableSubject,
+          this.storeOptions.sourceGraph
+        ).length > 0
+      );
+  }
+
+  get canAddNewActions() {
+    if (this.args.show) {
+      return false;
+    }
+
+    let triples = this.args.formStore.match(
+      undefined,
+      allowNewActions,
+      undefined,
+      this.args.graphs.formGraph
+    );
+
+    if (triples.length > 0) {
+      return triples[0].object.value === '1';
+    } else {
+      return false;
+    }
+  }
+
+  constructor() {
+    super(...arguments);
+    scheduleOnce('actions', this, this.initializeTable);
+  }
+
+  initializeTable() {
+    this.loadProvidedValue();
+
+    if (!this.hasClimateTable) {
+      this.createClimateTable();
+    }
+
+    this.validate();
+  }
+
+  loadProvidedValue() {
+    const matches = triplesForPath(this.storeOptions);
+    const triples = matches.triples;
+
+    if (triples.length) {
+      this.climateTableSubject = triples[0].object; // assuming only one per form
+    }
+
+    const metaGraph = this.args.graphs.metaGraph;
+    this.populationCount = this.args.formStore.match(
+      undefined,
+      DBPEDIA('populationTotal'),
+      undefined,
+      metaGraph
+    )[0].object.value;
+
+    const drawingRight = this.args.formStore.match(
+      undefined,
+      LBLOD_SUBSIDIE('drawingRight'),
+      undefined,
+      metaGraph
+    )[0].object.value;
+
+    this.drawingRight = drawingRight;
+    this.restitutionToDestribute = drawingRight;
+
+    this.loadCustomActions();
+  }
+
+  loadCustomActions() {
+    let store = this.args.formStore;
+    let sourceGraph = this.args.graphs.sourceGraph;
+
+    let triples = store.match(
+      undefined,
+      climateEntryCustomAction,
+      undefined,
+      sourceGraph
+    );
+
+    if (triples.length > 0) {
+      let tableEntryUris = triples.map((result) => {
+        return result.subject;
+      });
+
+      this.customActions = tableEntryUris
+        .map((entryUri) => {
+          let triples = store.match(entryUri, undefined, undefined);
+
+          let order = triples.find(
+            ({ predicate }) =>
+              predicate.value === 'http://purl.org/linked-data/cube#order'
+          )?.object.value;
+          order = parseInt(order);
+
+          let businessRuleUri = triples.find(
+            ({ predicate }) =>
+              predicate.value === `${climateBaseUri}actionDescription`
+          )?.object;
+
+          return {
+            businessRuleUri,
+            order,
+          };
+        })
+        .sort(sortByOrder);
+    }
+  }
+
+  createClimateTable() {
+    const uuid = uuidv4();
+    this.climateTableSubject = new rdflib.NamedNode(
+      `${climateTableBaseUri}/${uuid}`
+    );
+    const triples = [
+      {
+        subject: this.climateTableSubject,
+        predicate: RDF('type'),
+        object: climateTableType,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: this.climateTableSubject,
+        predicate: MU('uuid'),
+        object: uuid,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: this.storeOptions.sourceNode,
+        predicate: climateTablePredicate,
+        object: this.climateTableSubject,
+        graph: this.storeOptions.sourceGraph,
+      },
+    ];
+    this.storeOptions.store.addAll(triples);
+  }
+
+  //TODO: move to some common code
+  updateTripleObject(subject, predicate, newObject = null) {
+    const triples = this.storeOptions.store.match(
+      subject,
+      predicate,
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+
+    this.storeOptions.store.removeStatements([...triples]);
+
+    if (newObject) {
+      this.storeOptions.store.addAll([
+        {
+          subject: subject,
+          predicate: predicate,
+          object: newObject,
+          graph: this.storeOptions.sourceGraph,
+        },
+      ]);
+    }
+  }
+
+  @action
+  updateTotaleRestitution(value) {
+    this.restitutionToDestribute = this.restitutionToDestribute - value;
+    const totalBudgettedAmountValue = (
+      this.drawingRight - this.restitutionToDestribute
+    ).toFixed(2);
+    this.updateTripleObject(
+      this.climateTableSubject,
+      totalBudgettedAmount,
+      totalBudgettedAmountValue
+    );
+  }
+
+  @action
+  validate() {
+    this.errors = A();
+    const invalidRow = this.storeOptions.store.any(
+      this.climateTableSubject,
+      hasInvalidRowPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    );
+    if (invalidRow) {
+      this.errors.pushObject({
+        message: 'Een van de rijen is niet correct ingevuld',
+      });
+      this.updateTripleObject(
+        this.climateTableSubject,
+        validClimateTable,
+        null
+      );
+    } else if (!this.isPositiveInteger(this.restitutionToDestribute)) {
+      this.errors.pushObject({
+        message: 'Trekkingsrecht te verdelen moet groter of gelijk aan 0 zijn',
+      });
+      this.updateTripleObject(
+        this.climateTableSubject,
+        validClimateTable,
+        null
+      );
+    } else {
+      this.updateTripleObject(
+        this.climateTableSubject,
+        validClimateTable,
+        true
+      );
+    }
+  }
+
+  @action
+  addNewAction() {
+    let uuid = uuidv4();
+
+    let highestOrderValue = this.customActions.length
+      ? this.customActions[this.customActions.length - 1].order
+      : 0;
+
+    this.customActions = [
+      ...this.customActions,
+      {
+        businessRuleUri: new rdflib.NamedNode(
+          `http://data.lblod.info/id/subsidies/rules/custom/${uuid}`
+        ),
+        order: highestOrderValue + 1,
+      },
+    ];
+  }
+
+  @action
+  removeCustomAction(actionToRemove) {
+    this.customActions = this.customActions.filter(
+      (action) => action !== actionToRemove
+    );
+    this.validate();
+  }
+
+  isPositiveInteger(value) {
+    return parseInt(value) >= 0;
+  }
+}
+
+function sortByOrder(actionA, actionB) {
+  return actionA?.order - actionB?.order;
+}

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table/accordion.hbs
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table/accordion.hbs
@@ -1,0 +1,8 @@
+<AuAccordion
+  @iconOpen="nav-up"
+  @iconClosed="nav-down"
+  @buttonLabel={{@label}}
+  @subtitle={{@subtitle}}
+>
+  {{yield}}
+</AuAccordion>

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table/table-cell-data.hbs
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table/table-cell-data.hbs
@@ -1,0 +1,6 @@
+{{! template-lint-disable no-yield-only }}
+{{!
+  TODO: It seems this is used as a DIY named-blocks replacement.
+  Since named-blocks is a thing now, and a polyfill exists, we should switch to that setup instead.
+}}
+{{yield}}

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-burgemeesters.hbs
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-burgemeesters.hbs
@@ -1,0 +1,52 @@
+<tr>
+  <th scope="row" class="au-u-regular">
+    {{yield
+      (hash
+        actionDescription=(component
+          "rdf-form-fields/climate-subsidy-costs-table/table-cell-data"
+        )
+      )
+    }}
+  </th>
+  <td>
+    <AuInput
+      @disabled={{@disabled}}
+      @width="block"
+      @value={{this.costPerUnit}}
+      @error={{if this.costPerUnitErrors true false}}
+      @type="number"
+      lang="nl-BE"
+      {{on "blur" this.update}}
+    />
+    per actieplan
+    <br />
+    <span class="au-c-info-text">Indicatie:
+      {{convert-to-currency this.indication}}</span>
+    {{#each this.costPerUnitErrors as |error|}}
+      <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+    {{/each}}
+  </td>
+  <td>
+    <AuInput
+      @disabled={{@disabled}}
+      @width="block"
+      @value={{this.toRealiseUnits}}
+      @error={{if this.toRealiseUnitsErrors true false}}
+      @type="number"
+      lang="nl-BE"
+      {{on "blur" this.update}}
+    />
+    {{#each this.toRealiseUnitsErrors as |error|}}
+      <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+    {{/each}}
+  </td>
+  <td>
+    {{convert-to-currency this.amount}}
+  </td>
+  <td>
+    {{convert-to-currency this.restitution}}
+  </td>
+  {{#if @showDeleteColumn}}
+    <td></td>
+  {{/if}}
+</tr>

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-burgemeesters.js
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-burgemeesters.js
@@ -1,0 +1,342 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import rdflib from 'browser-rdflib';
+import { A } from '@ember/array';
+import { scheduleOnce } from '@ember/runloop';
+import { v4 as uuidv4 } from 'uuid';
+import { RDF, XSD } from '@lblod/submission-form-helpers';
+
+const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+
+const climateBaseUri = 'http://data.lblod.info/vocabularies/subsidie/climate/';
+const climateTableBaseUri = 'http://data.lblod.info/climate-tables';
+
+const tableEntryBaseUri = 'http://data.lblod.info/id/climate-table/row-entry';
+const ClimateEntryType = new rdflib.NamedNode(`${climateBaseUri}ClimateEntry`);
+const climateEntryPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}climateEntry`
+);
+const actionDescriptionPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}actionDescription`
+);
+const amountPerActionPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}amountPerAction`
+);
+const restitutionPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}restitution`
+);
+const hasInvalidRowPredicate = new rdflib.NamedNode(
+  `${climateTableBaseUri}/hasInvalidClimateTableEntry`
+);
+const toRealiseUnitsPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}toRealiseUnits`
+);
+const costPerUnitPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}costPerUnit`
+);
+
+export default class RdfFormFieldsClimateSubsidyCostsTableTableRowBurgemeestersComponent extends Component {
+  @tracked tableEntryUri = null;
+  @tracked amount = null;
+  @tracked restitution = null;
+  @tracked toRealiseUnits = null;
+  @tracked costPerUnit = null;
+  @tracked toRealiseUnitsErrors = A();
+  @tracked costPerUnitErrors = A();
+  @tracked isValidRow = true;
+
+  get storeOptions() {
+    return this.args.storeOptions;
+  }
+
+  get climateTableSubject() {
+    return this.args.climateTableSubject;
+  }
+
+  get businessRuleUri() {
+    return new rdflib.NamedNode(this.args.businessRuleUriStr);
+  }
+
+  get onUpdateRow() {
+    return this.args.onUpdateRow;
+  }
+
+  get population() {
+    return this.args.populationCount;
+  }
+
+  get indication() {
+    const populationBasedCostMultiplier = 0.15;
+    const cost = populationBasedCostMultiplier * this.population;
+
+    if (cost > 20000) {
+      return 20000;
+    } else {
+      return cost;
+    }
+  }
+
+  constructor() {
+    super(...arguments);
+    scheduleOnce('actions', this, this.initializeTableRow);
+  }
+
+  initializeTableRow() {
+    if (this.hasValues()) {
+      this.loadProvidedValue();
+      this.args.updateTotalRestitution(this.restitution);
+      this.onUpdateRow();
+    } else {
+      this.initializeDefault();
+    }
+  }
+
+  hasValues() {
+    const values = this.storeOptions.store.match(
+      null,
+      actionDescriptionPredicate,
+      this.businessRuleUri,
+      this.storeOptions.sourceGraph
+    );
+    return values.length;
+  }
+
+  loadProvidedValue() {
+    const values = this.storeOptions.store.match(
+      null,
+      actionDescriptionPredicate,
+      this.businessRuleUri,
+      this.storeOptions.sourceGraph
+    );
+    if (values.length > 1) {
+      throw `Expected single value for ${this.businessRuleUri}`;
+    } else {
+      this.setComponentValues(values[0].subject);
+    }
+  }
+
+  initializeDefault() {
+    const uuid = uuidv4();
+    const tableEntryUri = new rdflib.NamedNode(`${tableEntryBaseUri}/${uuid}`);
+
+    let triples = [
+      {
+        subject: tableEntryUri,
+        predicate: RDF('type'),
+        object: ClimateEntryType,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: tableEntryUri,
+        predicate: MU('uuid'),
+        object: uuid,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: this.climateTableSubject,
+        predicate: climateEntryPredicate,
+        object: tableEntryUri,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: tableEntryUri,
+        predicate: actionDescriptionPredicate,
+        object: this.businessRuleUri,
+        graph: this.storeOptions.sourceGraph,
+      },
+    ];
+
+    triples.push({
+      subject: tableEntryUri,
+      predicate: amountPerActionPredicate,
+      object: 0,
+      graph: this.storeOptions.sourceGraph,
+    });
+
+    triples.push({
+      subject: tableEntryUri,
+      predicate: restitutionPredicate,
+      object: 0,
+      graph: this.storeOptions.sourceGraph,
+    });
+
+    triples.push({
+      subject: tableEntryUri,
+      predicate: toRealiseUnitsPredicate,
+      object: 0,
+      graph: this.storeOptions.sourceGraph,
+    });
+
+    triples.push({
+      subject: tableEntryUri,
+      predicate: costPerUnitPredicate,
+      object: 0,
+      graph: this.storeOptions.sourceGraph,
+    });
+
+    this.storeOptions.store.addAll(triples);
+    this.setComponentValues(tableEntryUri);
+  }
+
+  setComponentValues(subject) {
+    this.tableEntryUri = subject;
+    this.amount = this.storeOptions.store.match(
+      this.tableEntryUri,
+      amountPerActionPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    )[0].object.value;
+    this.restitution = this.storeOptions.store.match(
+      this.tableEntryUri,
+      restitutionPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    )[0].object.value;
+    this.toRealiseUnits = this.storeOptions.store.match(
+      this.tableEntryUri,
+      toRealiseUnitsPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    )[0].object.value;
+    this.costPerUnit = this.storeOptions.store.match(
+      this.tableEntryUri,
+      costPerUnitPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    )[0].object.value;
+  }
+
+  updateTripleObject(subject, predicate, newObject = null) {
+    const triples = this.storeOptions.store.match(
+      subject,
+      predicate,
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+
+    this.storeOptions.store.removeStatements([...triples]);
+
+    if (newObject) {
+      this.storeOptions.store.addAll([
+        {
+          subject: subject,
+          predicate: predicate,
+          object: newObject,
+          graph: this.storeOptions.sourceGraph,
+        },
+      ]);
+    }
+  }
+
+  validateToRealiseUnits(toRealiseUnits) {
+    this.toRealiseUnitsErrors = [];
+
+    if (!this.isPositiveInteger(toRealiseUnits)) {
+      this.toRealiseUnitsErrors.pushObject({
+        message: 'Aantal items moeten groter of gelijk aan 0 zijn.',
+      });
+      this.updateTripleObject(
+        this.climateTableSubject,
+        hasInvalidRowPredicate,
+        this.tableEntryUri
+      );
+      return false;
+    } else if (!this.isValidInteger(toRealiseUnits)) {
+      this.toRealiseUnitsErrors.pushObject({
+        message: 'Aantal items moeten een geheel getal vormen.',
+      });
+      this.updateTripleObject(
+        this.climateTableSubject,
+        hasInvalidRowPredicate,
+        this.tableEntryUri
+      );
+      return false;
+    } else if (toRealiseUnits > 1) {
+      this.toRealiseUnitsErrors.pushObject({
+        message:
+          'Er is maximaal 1 te realiseren item mogelijk voor deze actie.',
+      });
+      this.updateTripleObject(
+        this.climateTableSubject,
+        hasInvalidRowPredicate,
+        this.tableEntryUri
+      );
+      return false;
+    } else {
+      this.updateTripleObject(
+        this.climateTableSubject,
+        hasInvalidRowPredicate,
+        null
+      );
+      return true;
+    }
+  }
+
+  validateCostPerUnit(valuePerItem) {
+    this.costPerUnitErrors = [];
+
+    if (!this.isPositiveInteger(valuePerItem)) {
+      this.costPerUnitErrors.pushObject({
+        message: 'Waarde per item moeten groter of gelijk aan 0 zijn.',
+      });
+      this.updateTripleObject(
+        this.climateTableSubject,
+        hasInvalidRowPredicate,
+        this.tableEntryUri
+      );
+      return false;
+    }
+  }
+
+  isPositiveInteger(value) {
+    return parseInt(value) >= 0;
+  }
+
+  isValidInteger(value) {
+    return parseFloat(value) % 1 === 0;
+  }
+
+  @action
+  update(e) {
+    if (e && typeof e.preventDefault === 'function') e.preventDefault();
+
+    /** start validation **/
+    this.validateToRealiseUnits(this.toRealiseUnits);
+    this.validateCostPerUnit(this.costPerUnit);
+
+    if (this.costPerUnitErrors.length) return this.onUpdateRow();
+    if (this.toRealiseUnitsErrors.length) return this.onUpdateRow();
+    /** end validation **/
+
+    const amount = this.costPerUnit * this.toRealiseUnits;
+    const currentRestitution = this.restitution;
+    const newRestitution = amount / 2;
+
+    this.updateTripleObject(
+      this.tableEntryUri,
+      toRealiseUnitsPredicate,
+      rdflib.literal(this.toRealiseUnits, XSD('integer'))
+    );
+    this.updateTripleObject(
+      this.tableEntryUri,
+      amountPerActionPredicate,
+      rdflib.literal(amount, XSD('integer'))
+    );
+    this.updateTripleObject(
+      this.tableEntryUri,
+      restitutionPredicate,
+      rdflib.literal(newRestitution, XSD('float'))
+    );
+    this.updateTripleObject(
+      this.tableEntryUri,
+      costPerUnitPredicate,
+      rdflib.literal(this.costPerUnit, XSD('float'))
+    );
+    this.setComponentValues(this.tableEntryUri);
+
+    // Updates the "Trekkingsrecht te verdelen" value
+    this.args.updateTotalRestitution(newRestitution - currentRestitution);
+    return this.onUpdateRow();
+  }
+}

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-custom-action.hbs
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-custom-action.hbs
@@ -1,0 +1,69 @@
+<tr>
+  <th scope="row" class="au-u-regular">
+    <label class="au-u-hidden-visually" for="description-{{this.id}}">
+      Omschrijving actie
+    </label>
+    <AuTextarea
+      @error={{if this.descriptionErrors true false}}
+      @value={{this.description}}
+      @disabled={{@disabled}}
+      @width="block"
+      placeholder="Omschrijving actie"
+      id="description-{{this.id}}"
+      style="resize: vertical;"
+      {{!template-lint-disable no-inline-styles}}
+      {{on "blur" this.update}}
+      {{auto-focus}}
+    />
+    {{#each this.descriptionErrors as |error|}}
+      <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+    {{/each}}
+  </th>
+  <td>
+    <AuInput
+      @disabled={{@disabled}}
+      @width="block"
+      @value={{this.costPerUnit}}
+      @error={{if this.costPerUnitErrors true false}}
+      @type="number"
+      lang="nl-BE"
+      {{on "blur" this.update}}
+    />
+    {{#each this.costPerUnitErrors as |error|}}
+      <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+    {{/each}}
+  </td>
+  <td>
+    <AuInput
+      @disabled={{@disabled}}
+      @width="block"
+      @value={{this.toRealiseUnits}}
+      @error={{if this.toRealiseUnitsErrors true false}}
+      @type="number"
+      lang="nl-BE"
+      {{on "blur" this.update}}
+    />
+    {{#each this.toRealiseUnitsErrors as |error|}}
+      <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+    {{/each}}
+  </td>
+  <td>
+    {{convert-to-currency this.amount}}
+  </td>
+  <td>
+    {{convert-to-currency this.restitution}}
+  </td>
+  {{#if @showDeleteColumn}}
+    <td>
+      <AuButton
+        @skin="link"
+        @alert={{true}}
+        @icon="bin"
+        @iconAlignment="left"
+        {{on "click" this.deleteAction}}
+      >
+        Verwijder
+      </AuButton>
+    </td>
+  {{/if}}
+</tr>

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-custom-action.js
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-custom-action.js
@@ -1,0 +1,402 @@
+import Component from '@glimmer/component';
+import rdflib from 'browser-rdflib';
+import { v4 as uuidv4 } from 'uuid';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import { scheduleOnce } from '@ember/runloop';
+
+import {
+  RDF,
+  XSD,
+  removeSimpleFormValue,
+} from '@lblod/submission-form-helpers';
+
+const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+const QB = new rdflib.Namespace('http://purl.org/linked-data/cube#');
+
+const climateBaseUri = 'http://data.lblod.info/vocabularies/subsidie/climate/';
+const climateTableBaseUri = 'http://data.lblod.info/climate-tables';
+
+const tableEntryBaseUri = 'http://data.lblod.info/id/climate-table/row-entry';
+const ClimateEntryType = new rdflib.NamedNode(`${climateBaseUri}ClimateEntry`);
+const climateEntryPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}climateEntry`
+);
+const climateEntryCustomAction = new rdflib.NamedNode(
+  `${climateBaseUri}customAction`
+);
+const actionDescriptionPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}actionDescription`
+);
+const amountPerActionPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}amountPerAction`
+);
+const restitutionPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}restitution`
+);
+const hasInvalidRowPredicate = new rdflib.NamedNode(
+  `${climateTableBaseUri}/hasInvalidClimateTableEntry`
+);
+const customDescriptionPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}customDescription`
+);
+const toRealiseUnitsPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}toRealiseUnits`
+);
+const costPerUnitPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}costPerUnit`
+);
+
+export default class RdfFormFieldsClimateSubsidyCostsTableTableRowCustomDataComponent extends Component {
+  id = guidFor(this);
+  @tracked tableEntryUri = null;
+  @tracked description = '';
+  @tracked amount = null;
+  @tracked restitution = null;
+  @tracked toRealiseUnits = null;
+  @tracked costPerUnit = null;
+  @tracked descriptionErrors = [];
+  @tracked toRealiseUnitsErrors = [];
+  @tracked costPerUnitErrors = [];
+
+  get storeOptions() {
+    return this.args.storeOptions;
+  }
+
+  get businessRuleUri() {
+    return this.args.businessRuleUri;
+  }
+
+  get climateTableSubject() {
+    return this.args.climateTableSubject;
+  }
+
+  get hasValues() {
+    const values = this.storeOptions.store.match(
+      null,
+      actionDescriptionPredicate,
+      this.businessRuleUri,
+      this.storeOptions.sourceGraph
+    );
+    return values.length;
+  }
+
+  constructor() {
+    super(...arguments);
+    scheduleOnce('actions', this, this.initializeTableRow);
+  }
+
+  initializeTableRow() {
+    if (this.hasValues) {
+      this.loadProvidedValue();
+      this.args.updateTotalRestitution(this.restitution);
+      this.args.onUpdateRow();
+    } else {
+      this.initializeDefault();
+    }
+  }
+
+  loadProvidedValue() {
+    const values = this.storeOptions.store.match(
+      null,
+      actionDescriptionPredicate,
+      this.businessRuleUri,
+      this.storeOptions.sourceGraph
+    );
+    if (values.length > 1) {
+      throw `Expected single value for ${this.businessRuleUri}`;
+    } else {
+      this.setComponentValues(values[0].subject);
+    }
+  }
+
+  setComponentValues(subject) {
+    this.tableEntryUri = subject;
+    this.description = this.storeOptions.store.match(
+      this.tableEntryUri,
+      customDescriptionPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    )[0].object.value;
+    this.amount = this.storeOptions.store.match(
+      this.tableEntryUri,
+      amountPerActionPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    )[0].object.value;
+    this.costPerUnit = this.storeOptions.store.match(
+      this.tableEntryUri,
+      costPerUnitPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    )[0].object.value;
+    this.restitution = this.storeOptions.store.match(
+      this.tableEntryUri,
+      restitutionPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    )[0].object.value; // TODO: this seems to always return a string?
+    this.toRealiseUnits = this.storeOptions.store.match(
+      this.tableEntryUri,
+      toRealiseUnitsPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    )[0].object.value;
+  }
+
+  initializeDefault() {
+    const uuid = uuidv4();
+    const tableEntryUri = new rdflib.NamedNode(`${tableEntryBaseUri}/${uuid}`);
+
+    let triples = [
+      {
+        subject: tableEntryUri,
+        predicate: RDF('type'),
+        object: ClimateEntryType,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: tableEntryUri,
+        predicate: MU('uuid'),
+        object: uuid,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: tableEntryUri,
+        predicate: climateEntryCustomAction,
+        object: true,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: this.climateTableSubject,
+        predicate: climateEntryPredicate,
+        object: tableEntryUri,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: tableEntryUri,
+        predicate: actionDescriptionPredicate,
+        object: this.businessRuleUri,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: tableEntryUri,
+        predicate: customDescriptionPredicate,
+        object: '',
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: tableEntryUri,
+        predicate: costPerUnitPredicate,
+        object: 0,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: tableEntryUri,
+        predicate: amountPerActionPredicate,
+        object: 0,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: tableEntryUri,
+        predicate: restitutionPredicate,
+        object: 0,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: tableEntryUri,
+        predicate: toRealiseUnitsPredicate,
+        object: 0,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: tableEntryUri,
+        predicate: QB('order'),
+        object: this.args.order,
+        graph: this.storeOptions.sourceGraph,
+      },
+    ];
+
+    this.storeOptions.store.addAll(triples);
+    this.setComponentValues(tableEntryUri);
+  }
+
+  updateTripleObject(subject, predicate, newObject = null) {
+    const triples = this.storeOptions.store.match(
+      subject,
+      predicate,
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+
+    this.storeOptions.store.removeStatements([...triples]);
+
+    if (newObject) {
+      this.storeOptions.store.addAll([
+        {
+          subject: subject,
+          predicate: predicate,
+          object: newObject,
+          graph: this.storeOptions.sourceGraph,
+        },
+      ]);
+    }
+  }
+
+  isPositiveInteger(value) {
+    return parseInt(value) >= 0;
+  }
+
+  isValidInteger(value) {
+    return parseFloat(value) % 1 === 0;
+  }
+
+  @action
+  update(e) {
+    if (e && typeof e.preventDefault === 'function') e.preventDefault();
+
+    let isValidDescription = this.validateDescription();
+    let isValidToRealiseUnits = this.validateToRealiseUnits();
+    let isValidCostPerUnit = this.validateCostPerUnit();
+
+    if (isValidDescription && isValidToRealiseUnits && isValidCostPerUnit) {
+      this.markRowAsValid();
+
+      const amount = this.costPerUnit * this.toRealiseUnits;
+      const currentRestitution = this.restitution;
+      const newRestitution = amount / 2;
+
+      this.updateTripleObject(
+        this.tableEntryUri,
+        customDescriptionPredicate,
+        rdflib.literal(this.description.trim())
+      );
+      this.updateTripleObject(
+        this.tableEntryUri,
+        toRealiseUnitsPredicate,
+        rdflib.literal(this.toRealiseUnits, XSD('integer'))
+      );
+      this.updateTripleObject(
+        this.tableEntryUri,
+        amountPerActionPredicate,
+        rdflib.literal(amount, XSD('integer'))
+      );
+      this.updateTripleObject(
+        this.tableEntryUri,
+        restitutionPredicate,
+        rdflib.literal(newRestitution, XSD('float'))
+      );
+      this.updateTripleObject(
+        this.tableEntryUri,
+        costPerUnitPredicate,
+        rdflib.literal(this.costPerUnit, XSD('float'))
+      );
+      this.setComponentValues(this.tableEntryUri);
+
+      this.args.updateTotalRestitution(newRestitution - currentRestitution);
+    } else {
+      this.markRowAsInvalid();
+    }
+
+    return this.args.onUpdateRow();
+  }
+
+  @action
+  deleteAction() {
+    const triples = this.storeOptions.store.match(
+      this.tableEntryUri,
+      undefined,
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+
+    if (triples.length) {
+      this.storeOptions.store.removeStatements(triples);
+    }
+    removeSimpleFormValue(this.tableEntryUri, this.storeOptions); // remove hasPart
+
+    this.markRowAsValid();
+
+    // Add the value we removed from the total restitution
+    this.args.updateTotalRestitution(-this.restitution);
+
+    this.args.onDelete();
+  }
+
+  validateDescription() {
+    let description = this.description.trim();
+    this.descriptionErrors = [];
+
+    if (description.length === 0) {
+      this.descriptionErrors.push({
+        message: 'Dit veld is verplicht.',
+      });
+      this.markRowAsInvalid();
+
+      return false;
+    }
+
+    return true;
+  }
+
+  validateCostPerUnit() {
+    let costPerUnit = this.costPerUnit;
+    this.costPerUnitErrors = [];
+
+    if (!this.isPositiveInteger(costPerUnit)) {
+      this.costPerUnitErrors.push({
+        message: 'Waarde per item moeten groter of gelijk aan 0 zijn.',
+      });
+
+      return false;
+    }
+
+    return true;
+  }
+
+  validateToRealiseUnits() {
+    let toRealiseUnits = this.toRealiseUnits;
+    this.toRealiseUnitsErrors = [];
+
+    if (!this.isPositiveInteger(toRealiseUnits)) {
+      this.toRealiseUnitsErrors.push({
+        message: 'Aantal items moeten groter of gelijk aan 0 zijn.',
+      });
+
+      return false;
+    } else if (!this.isValidInteger(toRealiseUnits)) {
+      this.toRealiseUnitsErrors.push({
+        message: 'Aantal items moeten een geheel getal vormen.',
+      });
+
+      return false;
+    }
+
+    return true;
+  }
+
+  markRowAsValid() {
+    const triples = this.storeOptions.store.match(
+      this.climateTableSubject,
+      hasInvalidRowPredicate,
+      this.tableEntryUri,
+      this.storeOptions.sourceGraph
+    );
+
+    if (triples.length) {
+      this.storeOptions.store.removeStatements(triples);
+    }
+  }
+
+  markRowAsInvalid() {
+    this.storeOptions.store.addAll([
+      {
+        subject: this.climateTableSubject,
+        predicate: hasInvalidRowPredicate,
+        object: this.tableEntryUri,
+        graph: this.storeOptions.sourceGraph,
+      },
+    ]);
+  }
+}

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-vastgoedplan.hbs
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-vastgoedplan.hbs
@@ -1,0 +1,53 @@
+<tr>
+  <th scope="row" class="au-u-regular">
+    {{yield
+      (hash
+        actionDescription=(component
+          "rdf-form-fields/climate-subsidy-costs-table/table-cell-data"
+        )
+      )
+    }}
+  </th>
+  <td>
+    <AuInput
+      @disabled={{@disabled}}
+      @width="block"
+      @value={{this.costPerUnit}}
+      @error={{if this.costPerUnitErrors true false}}
+      @type="number"
+      lang="nl-BE"
+      {{on "blur" this.update}}
+    />
+    per Strategisch Vastgoedplan
+    <br />
+    <span class="au-c-info-text">Indicatie:
+      {{convert-to-currency this.indication}}</span>
+    {{#each this.costPerUnitErrors as |error|}}
+      <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+    {{/each}}
+  </td>
+  <td>
+    <AuInput
+      @disabled={{@disabled}}
+      @width="block"
+      @value={{this.toRealiseUnits}}
+      @error={{if this.toRealiseUnitsErrors true false}}
+      @type="number"
+      lang="nl-BE"
+      {{on "blur" this.update}}
+    />
+    <span class="au-c-info-text">max 1</span>
+    {{#each this.toRealiseUnitsErrors as |error|}}
+      <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+    {{/each}}
+  </td>
+  <td>
+    {{convert-to-currency this.amount}}
+  </td>
+  <td>
+    {{convert-to-currency this.restitution}}
+  </td>
+  {{#if @showDeleteColumn}}
+    <td></td>
+  {{/if}}
+</tr>

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-vastgoedplan.js
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-vastgoedplan.js
@@ -1,0 +1,341 @@
+import Component from '@glimmer/component';
+import rdflib from 'browser-rdflib';
+import { v4 as uuidv4 } from 'uuid';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { A } from '@ember/array';
+import { scheduleOnce } from '@ember/runloop';
+
+import { RDF, XSD } from '@lblod/submission-form-helpers';
+
+const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+
+const climateBaseUri = 'http://data.lblod.info/vocabularies/subsidie/climate/';
+const climateTableBaseUri = 'http://data.lblod.info/climate-tables';
+
+const tableEntryBaseUri = 'http://data.lblod.info/id/climate-table/row-entry';
+const ClimateEntryType = new rdflib.NamedNode(`${climateBaseUri}ClimateEntry`);
+const climateEntryPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}climateEntry`
+);
+const actionDescriptionPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}actionDescription`
+);
+const amountPerActionPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}amountPerAction`
+);
+const costPerUnitPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}costPerUnit`
+);
+const restitutionPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}restitution`
+);
+const hasInvalidRowPredicate = new rdflib.NamedNode(
+  `${climateTableBaseUri}/hasInvalidClimateTableEntry`
+);
+const toRealiseUnitsPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}toRealiseUnits`
+);
+
+export default class RdfFormFieldsClimateSubsidyCostsTableTableRowVastgoedplanComponent extends Component {
+  @tracked tableEntryUri = null;
+  @tracked amount = null;
+  @tracked restitution = null;
+  @tracked costPerUnit = null;
+  @tracked toRealiseUnits = null;
+  @tracked toRealiseUnitsErrors = A();
+  @tracked costPerUnitErrors = A();
+  @tracked isValidRow = true;
+
+  get storeOptions() {
+    return this.args.storeOptions;
+  }
+
+  get populationCount() {
+    return this.args.populationCount;
+  }
+
+  get businessRuleUri() {
+    return new rdflib.NamedNode(this.args.businessRuleUriStr);
+  }
+
+  get climateTableSubject() {
+    return this.args.climateTableSubject;
+  }
+
+  get indication() {
+    if (this.populationCount < 25000) {
+      return 15000;
+    } else if (this.populationCount >= 25000 && this.populationCount < 100000) {
+      return 40000;
+    } else {
+      return 60000;
+    }
+  }
+
+  get onUpdateRow() {
+    return this.args.onUpdateRow;
+  }
+
+  constructor() {
+    super(...arguments);
+    scheduleOnce('actions', this, this.initializeTableRow);
+  }
+
+  initializeTableRow() {
+    if (this.hasValues()) {
+      this.loadProvidedValue();
+      this.args.updateTotalRestitution(this.restitution);
+      this.onUpdateRow();
+    } else {
+      this.initializeDefault();
+    }
+  }
+
+  hasValues() {
+    const values = this.storeOptions.store.match(
+      null,
+      actionDescriptionPredicate,
+      this.businessRuleUri,
+      this.storeOptions.sourceGraph
+    );
+    return values.length;
+  }
+
+  loadProvidedValue() {
+    const values = this.storeOptions.store.match(
+      null,
+      actionDescriptionPredicate,
+      this.businessRuleUri,
+      this.storeOptions.sourceGraph
+    );
+    if (values.length > 1) {
+      throw `Expected single value for ${this.businessRuleUri}`;
+    } else {
+      this.setComponentValues(values[0].subject);
+    }
+  }
+
+  setComponentValues(subject) {
+    this.tableEntryUri = subject;
+    this.amount = this.storeOptions.store.match(
+      this.tableEntryUri,
+      amountPerActionPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    )[0].object.value;
+    this.costPerUnit = this.storeOptions.store.match(
+      this.tableEntryUri,
+      costPerUnitPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    )[0].object.value;
+    this.restitution = this.storeOptions.store.match(
+      this.tableEntryUri,
+      restitutionPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    )[0].object.value;
+    this.toRealiseUnits = this.storeOptions.store.match(
+      this.tableEntryUri,
+      toRealiseUnitsPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    )[0].object.value;
+  }
+
+  initializeDefault() {
+    const uuid = uuidv4();
+    const tableEntryUri = new rdflib.NamedNode(`${tableEntryBaseUri}/${uuid}`);
+
+    let triples = [
+      {
+        subject: tableEntryUri,
+        predicate: RDF('type'),
+        object: ClimateEntryType,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: tableEntryUri,
+        predicate: MU('uuid'),
+        object: uuid,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: this.climateTableSubject,
+        predicate: climateEntryPredicate,
+        object: tableEntryUri,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: tableEntryUri,
+        predicate: actionDescriptionPredicate,
+        object: this.businessRuleUri,
+        graph: this.storeOptions.sourceGraph,
+      },
+    ];
+
+    triples.push({
+      subject: tableEntryUri,
+      predicate: costPerUnitPredicate,
+      object: 0,
+      graph: this.storeOptions.sourceGraph,
+    });
+    triples.push({
+      subject: tableEntryUri,
+      predicate: amountPerActionPredicate,
+      object: 0,
+      graph: this.storeOptions.sourceGraph,
+    });
+
+    triples.push({
+      subject: tableEntryUri,
+      predicate: restitutionPredicate,
+      object: 0,
+      graph: this.storeOptions.sourceGraph,
+    });
+
+    triples.push({
+      subject: tableEntryUri,
+      predicate: toRealiseUnitsPredicate,
+      object: 0,
+      graph: this.storeOptions.sourceGraph,
+    });
+
+    this.storeOptions.store.addAll(triples);
+    this.setComponentValues(tableEntryUri);
+  }
+
+  updateTripleObject(subject, predicate, newObject = null) {
+    const triples = this.storeOptions.store.match(
+      subject,
+      predicate,
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+
+    this.storeOptions.store.removeStatements([...triples]);
+
+    if (newObject) {
+      this.storeOptions.store.addAll([
+        {
+          subject: subject,
+          predicate: predicate,
+          object: newObject,
+          graph: this.storeOptions.sourceGraph,
+        },
+      ]);
+    }
+  }
+
+  validateToRealiseUnits(toRealiseUnits) {
+    this.toRealiseUnitsErrors = A();
+
+    if (!this.isPositiveInteger(toRealiseUnits)) {
+      this.toRealiseUnitsErrors.pushObject({
+        message: 'Aantal items moeten groter of gelijk aan 0 zijn.',
+      });
+      this.updateTripleObject(
+        this.climateTableSubject,
+        hasInvalidRowPredicate,
+        this.tableEntryUri
+      );
+      return false;
+    } else if (!this.isValidInteger(toRealiseUnits)) {
+      this.toRealiseUnitsErrors.pushObject({
+        message: 'Aantal items moeten een geheel getal vormen.',
+      });
+      this.updateTripleObject(
+        this.climateTableSubject,
+        hasInvalidRowPredicate,
+        this.tableEntryUri
+      );
+      return false;
+    } else if (toRealiseUnits > 1) {
+      this.toRealiseUnitsErrors.pushObject({
+        message:
+          'Er is maximaal 1 te realiseren item mogelijk voor deze actie.',
+      });
+      this.updateTripleObject(
+        this.climateTableSubject,
+        hasInvalidRowPredicate,
+        this.tableEntryUri
+      );
+      return false;
+    } else {
+      this.updateTripleObject(
+        this.climateTableSubject,
+        hasInvalidRowPredicate,
+        null
+      );
+      return true;
+    }
+  }
+
+  validateCostPerUnit(valuePerItem) {
+    this.costPerUnitErrors = A();
+
+    if (!this.isPositiveInteger(valuePerItem)) {
+      this.costPerUnitErrors.pushObject({
+        message: 'Waarde per item moeten groter of gelijk aan 0 zijn.',
+      });
+      this.updateTripleObject(
+        this.climateTableSubject,
+        hasInvalidRowPredicate,
+        this.tableEntryUri
+      );
+      return false;
+    }
+  }
+
+  isPositiveInteger(value) {
+    return parseInt(value) >= 0;
+  }
+
+  isValidInteger(value) {
+    return parseFloat(value) % 1 === 0;
+  }
+
+  @action
+  update(e) {
+    if (e && typeof e.preventDefault === 'function') e.preventDefault();
+
+    /** start validation **/
+    this.validateToRealiseUnits(this.toRealiseUnits);
+    this.validateCostPerUnit(this.costPerUnit);
+
+    if (this.costPerUnitErrors.length) return this.onUpdateRow();
+    if (this.toRealiseUnitsErrors.length) return this.onUpdateRow();
+    /** end validation **/
+
+    const amount = this.costPerUnit * this.toRealiseUnits;
+    const currentRestitution = this.restitution;
+    const newRestitution = amount / 2;
+
+    this.updateTripleObject(
+      this.tableEntryUri,
+      toRealiseUnitsPredicate,
+      rdflib.literal(this.toRealiseUnits, XSD('integer'))
+    );
+    this.updateTripleObject(
+      this.tableEntryUri,
+      amountPerActionPredicate,
+      rdflib.literal(amount, XSD('integer'))
+    );
+    this.updateTripleObject(
+      this.tableEntryUri,
+      restitutionPredicate,
+      rdflib.literal(newRestitution, XSD('float'))
+    );
+    this.updateTripleObject(
+      this.tableEntryUri,
+      costPerUnitPredicate,
+      rdflib.literal(this.costPerUnit, XSD('float'))
+    );
+    this.setComponentValues(this.tableEntryUri);
+
+    // Updates the "Trekkingsrecht te verdelen" value
+    this.args.updateTotalRestitution(newRestitution - currentRestitution);
+    return this.onUpdateRow();
+  }
+}

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-werf.hbs
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-werf.hbs
@@ -1,0 +1,55 @@
+<tr>
+  <th scope="row" class="au-u-regular">
+    {{yield
+      (hash
+        actionDescription=(component
+          "rdf-form-fields/climate-subsidy-costs-table/table-cell-data"
+        )
+      )
+    }}
+  </th>
+  <td>
+    <AuInput
+      @disabled={{@disabled}}
+      @width="block"
+      @value={{this.costPerUnit}}
+      @error={{if this.costPerUnitErrors true false}}
+      @type="number"
+      lang="nl-BE"
+      {{on "blur" this.update}}
+    />
+    {{yield
+      (hash
+        costPerUnitDescription=(component
+          "rdf-form-fields/climate-subsidy-costs-table/table-cell-data"
+        )
+      )
+    }}
+    {{#each this.costPerUnitErrors as |error|}}
+      <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+    {{/each}}
+  </td>
+  <td>
+    <AuInput
+      @disabled={{@disabled}}
+      @width="block"
+      @value={{this.toRealiseUnits}}
+      @error={{if this.toRealiseUnitsErrors true false}}
+      @type="number"
+      lang="nl-BE"
+      {{on "blur" this.update}}
+    />
+    {{#each this.toRealiseUnitsErrors as |error|}}
+      <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+    {{/each}}
+  </td>
+  <td>
+    {{convert-to-currency this.amount}}
+  </td>
+  <td>
+    {{convert-to-currency this.restitution}}
+  </td>
+  {{#if @showDeleteColumn}}
+    <td></td>
+  {{/if}}
+</tr>

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-werf.js
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-werf.js
@@ -1,0 +1,335 @@
+import Component from '@glimmer/component';
+import rdflib from 'browser-rdflib';
+import { v4 as uuidv4 } from 'uuid';
+import { tracked } from '@glimmer/tracking';
+import { A } from '@ember/array';
+import { action } from '@ember/object';
+import { scheduleOnce } from '@ember/runloop';
+
+import { RDF, XSD } from '@lblod/submission-form-helpers';
+
+const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+
+const climateBaseUri = 'http://data.lblod.info/vocabularies/subsidie/climate/';
+const climateTableBaseUri = 'http://data.lblod.info/climate-tables';
+
+const tableEntryBaseUri = 'http://data.lblod.info/id/climate-table/row-entry';
+const ClimateEntryType = new rdflib.NamedNode(`${climateBaseUri}ClimateEntry`);
+const climateEntryPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}climateEntry`
+);
+const actionDescriptionPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}actionDescription`
+);
+const amountPerActionPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}amountPerAction`
+);
+const restitutionPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}restitution`
+);
+const hasInvalidRowPredicate = new rdflib.NamedNode(
+  `${climateTableBaseUri}/hasInvalidClimateTableEntry`
+);
+const toRealiseUnitsPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}toRealiseUnits`
+);
+const costPerUnitPredicate = new rdflib.NamedNode(
+  `${climateBaseUri}costPerUnit`
+);
+
+export default class RdfFormFieldsClimateSubsidyCostsTableTableRowWerfComponent extends Component {
+  @tracked tableEntryUri = null;
+  @tracked amount = null;
+  @tracked restitution = null;
+  @tracked toRealiseUnits = null;
+  @tracked costPerUnit = null;
+  @tracked toRealiseUnitsErrors = A();
+  @tracked costPerUnitErrors = A();
+  @tracked isValidRow = true;
+
+  get storeOptions() {
+    return this.args.storeOptions;
+  }
+
+  get businessRuleUri() {
+    return new rdflib.NamedNode(this.args.businessRuleUriStr);
+  }
+
+  get climateTableSubject() {
+    return this.args.climateTableSubject;
+  }
+
+  get onUpdateRow() {
+    return this.args.onUpdateRow;
+  }
+
+  constructor() {
+    super(...arguments);
+    scheduleOnce('actions', this, this.initializeTableRow);
+  }
+
+  initializeTableRow() {
+    if (this.hasValues()) {
+      this.loadProvidedValue();
+      this.args.updateTotalRestitution(this.restitution);
+      this.onUpdateRow();
+    } else {
+      this.initializeDefault();
+    }
+  }
+
+  hasValues() {
+    const values = this.storeOptions.store.match(
+      null,
+      actionDescriptionPredicate,
+      this.businessRuleUri,
+      this.storeOptions.sourceGraph
+    );
+    return values.length;
+  }
+
+  loadProvidedValue() {
+    const values = this.storeOptions.store.match(
+      null,
+      actionDescriptionPredicate,
+      this.businessRuleUri,
+      this.storeOptions.sourceGraph
+    );
+    if (values.length > 1) {
+      throw `Expected single value for ${this.businessRuleUri}`;
+    } else {
+      this.setComponentValues(values[0].subject);
+    }
+  }
+
+  setComponentValues(subject) {
+    this.tableEntryUri = subject;
+    this.amount = this.storeOptions.store.match(
+      this.tableEntryUri,
+      amountPerActionPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    )[0].object.value;
+    this.costPerUnit = this.storeOptions.store.match(
+      this.tableEntryUri,
+      costPerUnitPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    )[0].object.value;
+    this.restitution = this.storeOptions.store.match(
+      this.tableEntryUri,
+      restitutionPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    )[0].object.value;
+    this.toRealiseUnits = this.storeOptions.store.match(
+      this.tableEntryUri,
+      toRealiseUnitsPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    )[0].object.value;
+  }
+
+  initializeDefault() {
+    const uuid = uuidv4();
+    const tableEntryUri = new rdflib.NamedNode(`${tableEntryBaseUri}/${uuid}`);
+
+    let triples = [
+      {
+        subject: tableEntryUri,
+        predicate: RDF('type'),
+        object: ClimateEntryType,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: tableEntryUri,
+        predicate: MU('uuid'),
+        object: uuid,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: this.climateTableSubject,
+        predicate: climateEntryPredicate,
+        object: tableEntryUri,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: tableEntryUri,
+        predicate: actionDescriptionPredicate,
+        object: this.businessRuleUri,
+        graph: this.storeOptions.sourceGraph,
+      },
+    ];
+
+    triples.push({
+      subject: tableEntryUri,
+      predicate: costPerUnitPredicate,
+      object: 0,
+      graph: this.storeOptions.sourceGraph,
+    });
+
+    triples.push({
+      subject: tableEntryUri,
+      predicate: amountPerActionPredicate,
+      object: 0,
+      graph: this.storeOptions.sourceGraph,
+    });
+
+    triples.push({
+      subject: tableEntryUri,
+      predicate: restitutionPredicate,
+      object: 0,
+      graph: this.storeOptions.sourceGraph,
+    });
+
+    triples.push({
+      subject: tableEntryUri,
+      predicate: toRealiseUnitsPredicate,
+      object: 0,
+      graph: this.storeOptions.sourceGraph,
+    });
+
+    this.storeOptions.store.addAll(triples);
+    this.setComponentValues(tableEntryUri);
+  }
+
+  updateTripleObject(subject, predicate, newObject = null) {
+    const triples = this.storeOptions.store.match(
+      subject,
+      predicate,
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+
+    this.storeOptions.store.removeStatements([...triples]);
+
+    if (newObject) {
+      this.storeOptions.store.addAll([
+        {
+          subject: subject,
+          predicate: predicate,
+          object: newObject,
+          graph: this.storeOptions.sourceGraph,
+        },
+      ]);
+    }
+  }
+
+  validateToRealiseUnits(toRealiseUnits) {
+    this.toRealiseUnitsErrors = A();
+
+    if (!this.isPositiveInteger(toRealiseUnits)) {
+      this.toRealiseUnitsErrors.pushObject({
+        message: 'Aantal items moeten groter of gelijk aan 0 zijn.',
+      });
+      this.updateTripleObject(
+        this.climateTableSubject,
+        hasInvalidRowPredicate,
+        this.tableEntryUri
+      );
+      return false;
+    } else if (!this.isValidInteger(toRealiseUnits)) {
+      this.toRealiseUnitsErrors.pushObject({
+        message: 'Aantal items moeten een geheel getal vormen.',
+      });
+      this.updateTripleObject(
+        this.climateTableSubject,
+        hasInvalidRowPredicate,
+        this.tableEntryUri
+      );
+      return false;
+    }
+
+    //OpstartTraject lokale energiegemeentschap
+    else if (
+      toRealiseUnits > 1 &&
+      'http://data.lblod.info/id/subsidies/rules/38d6d2bd-e42b-4d7e-8fea-9a371d9cf22f' ==
+        this.businessRuleUri.value
+    ) {
+      this.toRealiseUnitsErrors.pushObject({
+        message:
+          'Er is maximaal 1 te realiseren item mogelijk voor deze actie.',
+      });
+      this.updateTripleObject(
+        this.climateTableSubject,
+        hasInvalidRowPredicate,
+        this.tableEntryUri
+      );
+      return false;
+    } else {
+      this.updateTripleObject(
+        this.climateTableSubject,
+        hasInvalidRowPredicate,
+        null
+      );
+      return true;
+    }
+  }
+
+  validateCostPerUnit(valuePerItem) {
+    this.costPerUnitErrors = A();
+
+    if (!this.isPositiveInteger(valuePerItem)) {
+      this.costPerUnitErrors.pushObject({
+        message: 'Waarde per item moeten groter of gelijk aan 0 zijn.',
+      });
+      this.updateTripleObject(
+        this.climateTableSubject,
+        hasInvalidRowPredicate,
+        this.tableEntryUri
+      );
+      return false;
+    }
+  }
+
+  isPositiveInteger(value) {
+    return parseInt(value) >= 0;
+  }
+
+  isValidInteger(value) {
+    return parseFloat(value) % 1 === 0;
+  }
+
+  @action
+  update(e) {
+    if (e && typeof e.preventDefault === 'function') e.preventDefault();
+
+    /** start validation **/
+    this.validateToRealiseUnits(this.toRealiseUnits);
+    this.validateCostPerUnit(this.costPerUnit);
+
+    if (this.costPerUnitErrors.length) return this.onUpdateRow();
+    if (this.toRealiseUnitsErrors.length) return this.onUpdateRow();
+    /** end validation **/
+
+    const amount = this.costPerUnit * this.toRealiseUnits;
+    const currentRestitution = this.restitution;
+    const newRestitution = amount / 2;
+
+    this.updateTripleObject(
+      this.tableEntryUri,
+      toRealiseUnitsPredicate,
+      rdflib.literal(this.toRealiseUnits, XSD('integer'))
+    );
+    this.updateTripleObject(
+      this.tableEntryUri,
+      amountPerActionPredicate,
+      rdflib.literal(amount, XSD('integer'))
+    );
+    this.updateTripleObject(
+      this.tableEntryUri,
+      restitutionPredicate,
+      rdflib.literal(newRestitution, XSD('float'))
+    );
+    this.updateTripleObject(
+      this.tableEntryUri,
+      costPerUnitPredicate,
+      rdflib.literal(this.costPerUnit, XSD('float'))
+    );
+    this.setComponentValues(this.tableEntryUri);
+
+    // Updates the "Trekkingsrecht te verdelen" value
+    this.args.updateTotalRestitution(newRestitution - currentRestitution);
+    return this.onUpdateRow();
+  }
+}

--- a/app/components/rdf-form-fields/engagement-table/edit.hbs
+++ b/app/components/rdf-form-fields/engagement-table/edit.hbs
@@ -1,0 +1,86 @@
+<AuLabel>
+  Welke was, ruw geschat, de gemiddelde maandelijkse personeelsinzet (VTE)
+</AuLabel>
+<AuLabel
+  @error={{this.hasErrors}}
+  @required={{this.isRequired}}
+  for={{this.inputFor}}
+>
+  {{@field.label}}
+</AuLabel>
+<table
+  class="data-table data-table--zebra data-table--tight au-u-margin-top-small"
+>
+  <thead>
+    <tr>
+      <th>
+        Bestaand personeelskader
+      </th>
+      <th>
+        (Tijdelijk) extra aangeworven betaald personeel
+      </th>
+      <th>
+        Vrijwilligers
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    {{#each this.entries as |entry index|}}
+      <tr>
+        <td>
+          <AuLabel for="existing-staff-{{index}}" class="au-u-hidden-visually">
+            Bestaand personeelskader
+          </AuLabel>
+          <AuInput
+            @width="block"
+            @value={{entry.existingStaff.value}}
+            @type="number"
+            id="existing-staff-{{index}}"
+            class={{if entry.existingStaff.errors "au-c-input--error"}}
+            {{on "change" (fn this.updateExistingStaffValue entry)}}
+          />
+          {{#each entry.existingStaff.errors as |error|}}
+            <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+          {{/each}}
+        </td>
+        <td>
+          <AuLabel
+            for="additional-staff-{{index}}"
+            class="au-u-hidden-visually"
+          >
+            (Tijdelijk) extra aangeworven betaald personeel
+          </AuLabel>
+          <AuInput
+            @width="block"
+            @value={{entry.additionalStaff.value}}
+            @type="number"
+            id="additional-staff-{{index}}"
+            class={{if entry.additionalStaff.errors "au-c-input--error"}}
+            {{on "change" (fn this.updateAdditionalStaffValue entry)}}
+          />
+          {{#each entry.additionalStaff.errors as |error|}}
+            <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+          {{/each}}
+        </td>
+        <td>
+          <AuLabel for="volunteers-{{index}}" class="au-u-hidden-visually">
+            Vrijwilligers
+          </AuLabel>
+          <AuInput
+            @width="block"
+            @value={{entry.volunteers.value}}
+            @type="number"
+            id="volunteers-{{index}}"
+            class={{if entry.volunteers.errors "au-c-input--error"}}
+            {{on "change" (fn this.updateVolunteersValue entry)}}
+          />
+          {{#each entry.volunteers.errors as |error|}}
+            <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+          {{/each}}
+        </td>
+      </tr>
+    {{/each}}
+  </tbody>
+</table>
+
+{{yield}}

--- a/app/components/rdf-form-fields/engagement-table/edit.js
+++ b/app/components/rdf-form-fields/engagement-table/edit.js
@@ -1,0 +1,394 @@
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { triplesForPath } from '@lblod/submission-form-helpers';
+import rdflib from 'browser-rdflib';
+import { v4 as uuidv4 } from 'uuid';
+import { RDF } from '@lblod/submission-form-helpers';
+import { next } from '@ember/runloop';
+
+const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+
+const engagementTableBaseUri = 'http://data.lblod.info/engagement-tables';
+const engagementEntryBaseUri = 'http://data.lblod.info/engagement-entries';
+const lblodSubsidieBaseUri = 'http://lblod.data.gift/vocabularies/subsidie/';
+const extBaseUri = 'http://mu.semte.ch/vocabularies/ext/';
+
+const EngagementTableType = new rdflib.NamedNode(
+  `${lblodSubsidieBaseUri}EngagementTable`
+);
+const EngagementEntryType = new rdflib.NamedNode(
+  `${extBaseUri}EngagementEntry`
+);
+const engagementTablePredicate = new rdflib.NamedNode(
+  `${lblodSubsidieBaseUri}engagementTable`
+);
+const engagementEntryPredicate = new rdflib.NamedNode(
+  `${extBaseUri}engagementEntry`
+);
+const existingStaffPredicate = new rdflib.NamedNode(
+  'http://mu.semte.ch/vocabularies/ext/existingStaff'
+);
+const additionalStaffPredicate = new rdflib.NamedNode(
+  'http://mu.semte.ch/vocabularies/ext/additionalStaff'
+);
+const volunteersPredicate = new rdflib.NamedNode(
+  'http://mu.semte.ch/vocabularies/ext/volunteers'
+);
+
+class EntryProperties {
+  @tracked value;
+  @tracked errors = [];
+
+  constructor(value, predicate) {
+    this.value = value;
+    this.predicate = predicate;
+    this.errors = [];
+  }
+}
+
+class EngagementEntry {
+  @tracked engagementEntrySubject;
+
+  constructor({
+    engagementEntrySubject,
+    existingStaff,
+    additionalStaff,
+    volunteers,
+  }) {
+    this.engagementEntrySubject = engagementEntrySubject;
+    this.existingStaff = new EntryProperties(
+      existingStaff,
+      existingStaffPredicate
+    );
+    this.additionalStaff = new EntryProperties(
+      additionalStaff,
+      additionalStaffPredicate
+    );
+    this.volunteers = new EntryProperties(volunteers, volunteersPredicate);
+  }
+}
+
+export default class RdfFormFieldsEngagementTableEditComponent extends InputFieldComponent {
+  @tracked engagementTableSubject = null;
+  @tracked entries = [];
+
+  constructor() {
+    super(...arguments);
+    this.loadProvidedValue();
+
+    // Create table and entries in the store if not already existing
+    next(this, () => {
+      this.initializeTable();
+    });
+  }
+
+  get hasEngagementTable() {
+    if (!this.engagementTableSubject) return false;
+    else
+      return (
+        this.storeOptions.store.match(
+          this.sourceNode,
+          engagementTablePredicate,
+          this.engagementTableSubject,
+          this.storeOptions.sourceGraph
+        ).length > 0
+      );
+  }
+
+  loadProvidedValue() {
+    const matches = triplesForPath(this.storeOptions);
+    const triples = matches.triples;
+
+    if (triples.length) {
+      this.engagementTableSubject = triples[0].object; // assuming only one per form
+
+      const entriesMatches = triplesForPath({
+        store: this.storeOptions.store,
+        path: engagementEntryPredicate,
+        formGraph: this.storeOptions.formGraph,
+        sourceNode: this.engagementTableSubject,
+        sourceGraph: this.storeOptions.sourceGraph,
+      });
+      const entriesTriples = entriesMatches.triples;
+
+      if (entriesTriples.length > 0) {
+        for (let entry of entriesTriples) {
+          const entryProperties = this.storeOptions.store.match(
+            entry.object,
+            undefined,
+            undefined,
+            this.storeOptions.sourceGraph
+          );
+
+          const parsedEntry = this.parseEntryProperties(entryProperties);
+
+          this.entries.pushObject(
+            new EngagementEntry({
+              engagementEntrySubject: entry.object,
+              existingStaff: parsedEntry.existingStaff,
+              additionalStaff: parsedEntry.additionalStaff,
+              volunteers: parsedEntry.volunteers,
+            })
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * Parse entry properties from triples to a simple object with the triple values
+   */
+  parseEntryProperties(entryProperties) {
+    let entry = {};
+    if (
+      entryProperties.find(
+        (entry) => entry.predicate.value == existingStaffPredicate.value
+      )
+    )
+      entry.existingStaff = entryProperties.find(
+        (entry) => entry.predicate.value == existingStaffPredicate.value
+      ).object.value;
+    if (
+      entryProperties.find(
+        (entry) => entry.predicate.value == additionalStaffPredicate.value
+      )
+    )
+      entry.additionalStaff = entryProperties.find(
+        (entry) => entry.predicate.value == additionalStaffPredicate.value
+      ).object.value;
+    if (
+      entryProperties.find(
+        (entry) => entry.predicate.value == volunteersPredicate.value
+      )
+    )
+      entry.volunteers = entryProperties.find(
+        (entry) => entry.predicate.value == volunteersPredicate.value
+      ).object.value;
+    return entry;
+  }
+
+  initializeTable() {
+    if (!this.hasEngagementTable) {
+      this.createEngagementTable();
+      this.entries = this.createEntries();
+      super.updateValidations(); // Updates validation of the table
+    }
+  }
+
+  createEngagementTable() {
+    const uuid = uuidv4();
+    this.engagementTableSubject = new rdflib.NamedNode(
+      `${engagementTableBaseUri}/${uuid}`
+    );
+    const triples = [
+      {
+        subject: this.engagementTableSubject,
+        predicate: RDF('type'),
+        object: EngagementTableType,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: this.engagementTableSubject,
+        predicate: MU('uuid'),
+        object: uuid,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: this.storeOptions.sourceNode,
+        predicate: engagementTablePredicate,
+        object: this.engagementTableSubject,
+        graph: this.storeOptions.sourceGraph,
+      },
+    ];
+    this.storeOptions.store.addAll(triples);
+  }
+
+  createEntries() {
+    let entries = [];
+    const engagementEntrySubject = this.createEngagementEntry();
+
+    const newEntry = new EngagementEntry({
+      engagementEntrySubject: engagementEntrySubject,
+      existingStaff: 0,
+      additionalStaff: 0,
+      volunteers: 0,
+    });
+    entries.pushObject(newEntry);
+
+    this.initializeEntriesFields(entries);
+    return entries;
+  }
+
+  createEngagementEntry() {
+    let triples = [];
+
+    const uuid = uuidv4();
+    const engagementEntrySubject = new rdflib.NamedNode(
+      `${engagementEntryBaseUri}/${uuid}`
+    );
+
+    triples.push(
+      {
+        subject: engagementEntrySubject,
+        predicate: RDF('type'),
+        object: EngagementEntryType,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: engagementEntrySubject,
+        predicate: MU('uuid'),
+        object: uuid,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: this.engagementTableSubject,
+        predicate: engagementEntryPredicate,
+        object: engagementEntrySubject,
+        graph: this.storeOptions.sourceGraph,
+      }
+    );
+
+    this.storeOptions.store.addAll(triples);
+    return engagementEntrySubject;
+  }
+
+  updateFieldValueTriple(entry, field) {
+    const fieldValueTriples = this.storeOptions.store.match(
+      entry.engagementEntrySubject,
+      entry[field].predicate,
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+    const triples = [...fieldValueTriples];
+    this.storeOptions.store.removeStatements(triples);
+
+    if (entry[field].value.toString().length > 0) {
+      this.storeOptions.store.addAll([
+        {
+          subject: entry.engagementEntrySubject,
+          predicate: entry[field].predicate,
+          object: entry[field].value,
+          graph: this.storeOptions.sourceGraph,
+        },
+      ]);
+    }
+  }
+
+  @action
+  updateExistingStaffValue(entry) {
+    entry.existingStaff.errors = [];
+    const parsedValue = Number(entry.existingStaff.value);
+    entry.existingStaff.value = !isNaN(parsedValue)
+      ? parsedValue
+      : entry.existingStaff.value;
+    this.updateFieldValueTriple(entry, 'existingStaff');
+
+    if (this.isEmpty(entry.existingStaff.value)) {
+      entry.existingStaff.errors.pushObject({
+        message: 'Bestaand personeelskader is verplicht.',
+      });
+    } else if (!this.isPositiveNumber(entry.existingStaff.value)) {
+      entry.existingStaff.errors.pushObject({
+        message: 'Bestaand personeelskader is niet een positief nummer.',
+      });
+    }
+    this.hasBeenFocused = true; // Allows errors to be shown in canShowErrors()
+    super.updateValidations(); // Updates validation of the table
+  }
+
+  @action
+  updateAdditionalStaffValue(entry) {
+    entry.additionalStaff.errors = [];
+    const parsedValue = Number(entry.additionalStaff.value);
+    entry.additionalStaff.value = !isNaN(parsedValue)
+      ? parsedValue
+      : entry.additionalStaff.value;
+    this.updateFieldValueTriple(entry, 'additionalStaff');
+
+    if (this.isEmpty(entry.additionalStaff.value)) {
+      entry.additionalStaff.errors.pushObject({
+        message: 'Extra aangetrokken betaald personeel is verplicht.',
+      });
+    } else if (!this.isPositiveNumber(entry.additionalStaff.value)) {
+      entry.additionalStaff.errors.pushObject({
+        message:
+          'Extra aangetrokken betaald personeel is niet een positief nummer.',
+      });
+    }
+    this.hasBeenFocused = true; // Allows errors to be shown in canShowErrors()
+    super.updateValidations(); // Updates validation of the table
+  }
+
+  @action
+  updateVolunteersValue(entry) {
+    entry.volunteers.errors = [];
+    const parsedValue = Number(entry.volunteers.value);
+    entry.volunteers.value = !isNaN(parsedValue)
+      ? parsedValue
+      : entry.volunteers.value;
+    this.updateFieldValueTriple(entry, 'volunteers');
+
+    if (this.isEmpty(entry.volunteers.value)) {
+      entry.volunteers.errors.pushObject({
+        message: 'Ingezette vrijwilligers is verplicht.',
+      });
+    } else if (!this.isPositiveNumber(entry.volunteers.value)) {
+      entry.volunteers.errors.pushObject({
+        message: 'Ingezette vrijwilligers is niet een positief nummer.',
+      });
+    }
+    this.hasBeenFocused = true; // Allows errors to be shown in canShowErrors()
+    super.updateValidations(); // Updates validation of the table
+  }
+
+  initializeEntriesFields(entries) {
+    let triples = [];
+    entries.forEach((entry) => {
+      triples.push(
+        {
+          subject: entry.engagementEntrySubject,
+          predicate: entry['existingStaff'].predicate,
+          object: entry['existingStaff'].value,
+          graph: this.storeOptions.sourceGraph,
+        },
+        {
+          subject: entry.engagementEntrySubject,
+          predicate: entry['additionalStaff'].predicate,
+          object: entry['additionalStaff'].value,
+          graph: this.storeOptions.sourceGraph,
+        },
+        {
+          subject: entry.engagementEntrySubject,
+          predicate: entry['volunteers'].predicate,
+          object: entry['volunteers'].value,
+          graph: this.storeOptions.sourceGraph,
+        }
+      );
+    });
+    this.storeOptions.store.addAll(triples);
+  }
+
+  /**
+   * Update entry fields in the store.
+   */
+  updateEntryFields(entry) {
+    this.updateExistingStaffValue(entry);
+    this.updateAdditionalStaffValue(entry);
+    this.updateVolunteersValue(entry);
+    this.updateEstimatedCostValue(entry);
+  }
+
+  // ------------------
+  // FIELDS VALIDATIONS
+
+  isEmpty(value) {
+    return value.toString().length == 0;
+  }
+
+  isPositiveNumber(value) {
+    const number = Number(value);
+    if (isNaN(number)) return false;
+    return number >= 0;
+  }
+}

--- a/app/components/rdf-form-fields/engagement-table/show.hbs
+++ b/app/components/rdf-form-fields/engagement-table/show.hbs
@@ -1,0 +1,73 @@
+<AuLabel>
+  Welke was, ruw geschat, de gemiddelde maandelijkse personeelsinzet (VTE)
+</AuLabel>
+<AuLabel for={{this.inputFor}}>
+  {{@field.label}}
+  {{#if this.isRequired}}
+    <AuPill>Verplicht</AuPill>
+  {{/if}}
+</AuLabel>
+<table
+  class="data-table data-table--zebra data-table--tight au-u-margin-top-small"
+>
+  <thead>
+    <tr>
+      <th>
+        Bestaand personeelskader
+      </th>
+      <th>
+        (Tijdelijk) extra aangeworven betaald personeel
+      </th>
+      <th>
+        Vrijwilligers
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    {{#each this.entries as |entry index|}}
+      <tr>
+        <td>
+          <AuLabel for="existing-staff-{{index}}" class="au-u-hidden-visually">
+            Bestaand personeelskader
+          </AuLabel>
+          <AuInput
+            id="existing-staff-{{index}}"
+            @width="block"
+            @value={{entry.existingStaff.value}}
+            @disabled={{true}}
+            @type="number"
+          />
+        </td>
+        <td>
+          <AuLabel
+            for="additional-staff-{{index}}"
+            class="au-u-hidden-visually"
+          >
+            (Tijdelijk) extra aangeworven betaald personeel
+          </AuLabel>
+          <AuInput
+            @width="block"
+            @value={{entry.additionalStaff.value}}
+            @disabled={{true}}
+            @type="number"
+            id="additional-staff-{{index}}"
+          />
+        </td>
+        <td>
+          <AuLabel for="volunteers-{{index}}" class="au-u-hidden-visually">
+            Vrijwilligers
+          </AuLabel>
+          <AuInput
+            @width="block"
+            @value={{entry.volunteers.value}}
+            @disabled={{true}}
+            @type="number"
+            id="volunteers-{{index}}"
+          />
+        </td>
+      </tr>
+    {{/each}}
+  </tbody>
+</table>
+
+{{yield}}

--- a/app/components/rdf-form-fields/engagement-table/show.js
+++ b/app/components/rdf-form-fields/engagement-table/show.js
@@ -1,0 +1,136 @@
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+import { tracked } from '@glimmer/tracking';
+import { triplesForPath } from '@lblod/submission-form-helpers';
+import rdflib from 'browser-rdflib';
+import { next } from '@ember/runloop';
+
+const extBaseUri = 'http://mu.semte.ch/vocabularies/ext/';
+const engagementEntryPredicate = new rdflib.NamedNode(
+  `${extBaseUri}engagementEntry`
+);
+const existingStaffPredicate = new rdflib.NamedNode(
+  'http://mu.semte.ch/vocabularies/ext/existingStaff'
+);
+const additionalStaffPredicate = new rdflib.NamedNode(
+  'http://mu.semte.ch/vocabularies/ext/additionalStaff'
+);
+const volunteersPredicate = new rdflib.NamedNode(
+  'http://mu.semte.ch/vocabularies/ext/volunteers'
+);
+
+class EntryProperties {
+  @tracked value;
+
+  constructor(value, predicate) {
+    this.value = value;
+    this.predicate = predicate;
+  }
+}
+
+class EngagementEntry {
+  @tracked engagementEntrySubject;
+
+  constructor({
+    engagementEntrySubject,
+    existingStaff,
+    additionalStaff,
+    volunteers,
+  }) {
+    this.engagementEntrySubject = engagementEntrySubject;
+    this.existingStaff = new EntryProperties(
+      existingStaff,
+      existingStaffPredicate
+    );
+    this.additionalStaff = new EntryProperties(
+      additionalStaff,
+      additionalStaffPredicate
+    );
+    this.volunteers = new EntryProperties(volunteers, volunteersPredicate);
+  }
+}
+
+export default class RdfFormFieldsEngagementTableShowComponent extends InputFieldComponent {
+  @tracked engagementTableSubject = null;
+  @tracked entries = [];
+
+  constructor() {
+    super(...arguments);
+    next(this, () => {
+      this.loadProvidedValue();
+    });
+  }
+
+  loadProvidedValue() {
+    const matches = triplesForPath(this.storeOptions);
+    const triples = matches.triples;
+
+    if (triples.length) {
+      this.engagementTableSubject = triples[0].object; // assuming only one per form
+
+      const entriesMatches = triplesForPath({
+        store: this.storeOptions.store,
+        path: engagementEntryPredicate,
+        formGraph: this.storeOptions.formGraph,
+        sourceNode: this.engagementTableSubject,
+        sourceGraph: this.storeOptions.sourceGraph,
+      });
+      const entriesTriples = entriesMatches.triples;
+
+      if (entriesTriples.length > 0) {
+        for (let entry of entriesTriples) {
+          const entryProperties = this.storeOptions.store.match(
+            entry.object,
+            undefined,
+            undefined,
+            this.storeOptions.sourceGraph
+          );
+
+          const parsedEntry = this.parseEntryProperties(entryProperties);
+
+          this.entries.pushObject(
+            new EngagementEntry({
+              engagementEntrySubject: entry.object,
+              existingStaff: parsedEntry.existingStaff,
+              additionalStaff: parsedEntry.additionalStaff,
+              volunteers: parsedEntry.volunteers,
+            })
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * Parse entry properties from triples to a simple object with the triple values
+   */
+  parseEntryProperties(entryProperties) {
+    let entry = {};
+
+    if (
+      entryProperties.find(
+        (entry) => entry.predicate.value == existingStaffPredicate.value
+      )
+    )
+      entry.existingStaff = entryProperties.find(
+        (entry) => entry.predicate.value == existingStaffPredicate.value
+      ).object.value;
+    if (
+      entryProperties.find(
+        (entry) => entry.predicate.value == additionalStaffPredicate.value
+      )
+    )
+      entry.additionalStaff = entryProperties.find(
+        (entry) => entry.predicate.value == additionalStaffPredicate.value
+      ).object.value;
+    if (
+      entryProperties.find(
+        (entry) => entry.predicate.value == volunteersPredicate.value
+      )
+    )
+      entry.volunteers = entryProperties.find(
+        (entry) => entry.predicate.value == volunteersPredicate.value
+      ).object.value;
+
+    return entry;
+  }
+}

--- a/app/components/rdf-form-fields/estimated-cost-table/base-table.js
+++ b/app/components/rdf-form-fields/estimated-cost-table/base-table.js
@@ -1,0 +1,154 @@
+import { tracked } from '@glimmer/tracking';
+
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+import { triplesForPath } from '@lblod/submission-form-helpers';
+import rdflib from 'browser-rdflib';
+
+export const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+
+export const estimatedCostTableBaseUri =
+  'http://lblod.data.gift/id/subsidie/bicycle-infrastructure/table';
+export const bicycleInfrastructureUri =
+  'http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#';
+export const extBaseUri = 'http://mu.semte.ch/vocabularies/ext/';
+export const subsidyRulesUri = 'http://data.lblod.info/id/subsidies/rules/';
+
+export const EstimatedCostTableType = new rdflib.NamedNode(
+  `${bicycleInfrastructureUri}EstimatedCostTable`
+);
+export const EstimatedCostEntryType = new rdflib.NamedNode(
+  `${bicycleInfrastructureUri}EstimatedCostEntry`
+);
+export const estimatedCostTablePredicate = new rdflib.NamedNode(
+  `${bicycleInfrastructureUri}estimatedCostTable`
+);
+export const estimatedCostEntryPredicate = new rdflib.NamedNode(
+  `${bicycleInfrastructureUri}estimatedCostEntry`
+);
+
+export const descriptionPredicate = new rdflib.NamedNode(
+  `${bicycleInfrastructureUri}costEstimationType`
+);
+export const costPredicate = new rdflib.NamedNode(
+  `${bicycleInfrastructureUri}cost`
+);
+export const sharePredicate = new rdflib.NamedNode(
+  `${bicycleInfrastructureUri}share`
+);
+export const indexPredicate = new rdflib.NamedNode(`${extBaseUri}index`);
+export const validEstimatedCostTable = new rdflib.NamedNode(
+  `${bicycleInfrastructureUri}validEstimatedCostTable`
+);
+export const optionsPredicate = new rdflib.NamedNode(
+  'http://lblod.data.gift/vocabularies/forms/options'
+);
+
+export class EntryProperties {
+  @tracked value;
+  @tracked errors = [];
+
+  constructor(value, predicate) {
+    this.value = value;
+    this.predicate = predicate;
+    this.errors = [];
+  }
+}
+
+export class EstimatedCostEntry {
+  @tracked estimatedCostEntrySubject;
+
+  constructor({ estimatedCostEntrySubject, description, cost, share, index }) {
+    this.estimatedCostEntrySubject = estimatedCostEntrySubject;
+    this.description = new EntryProperties(description, descriptionPredicate);
+    this.cost = new EntryProperties(cost, costPredicate);
+    this.share = new EntryProperties(share, sharePredicate);
+    this.index = new EntryProperties(index, indexPredicate);
+  }
+}
+
+export default class RdfFormFieldsEstimatedCostTableBaseTableComponent extends InputFieldComponent {
+  @tracked estimatedCostTableSubject = null;
+  @tracked entries = [];
+
+  loadEstimatedCostEntries() {
+    const estimatedCostEntries = [];
+    const matches = triplesForPath(this.storeOptions);
+    const triples = matches.triples;
+
+    if (triples.length) {
+      this.estimatedCostTableSubject = triples[0].object; // assuming only one per form
+
+      const entriesMatches = triplesForPath({
+        store: this.storeOptions.store,
+        path: estimatedCostEntryPredicate,
+        formGraph: this.storeOptions.formGraph,
+        sourceNode: this.estimatedCostTableSubject,
+        sourceGraph: this.storeOptions.sourceGraph,
+      });
+      const entriesTriples = entriesMatches.triples;
+
+      if (entriesTriples.length > 0) {
+        for (let entry of entriesTriples) {
+          const entryProperties = this.storeOptions.store.match(
+            entry.object,
+            undefined,
+            undefined,
+            this.storeOptions.sourceGraph
+          );
+
+          const parsedEntry = this.parseEntryProperties(entryProperties);
+
+          estimatedCostEntries.push(
+            new EstimatedCostEntry({
+              estimatedCostEntrySubject: entry.object,
+              description: parsedEntry.description,
+              cost: parsedEntry.cost,
+              share: parsedEntry.share,
+              index: parsedEntry.index,
+            })
+          );
+
+          estimatedCostEntries.sort((a, b) => a.index.value - b.index.value);
+        }
+      }
+    }
+    return estimatedCostEntries;
+  }
+
+  parseEntryProperties(entryProperties) {
+    let entry = {};
+    if (
+      entryProperties.find(
+        (entry) => entry.predicate.value == descriptionPredicate.value
+      )
+    )
+      entry.description = entryProperties.find(
+        (entry) => entry.predicate.value == descriptionPredicate.value
+      ).object.value;
+    if (
+      entryProperties.find(
+        (entry) => entry.predicate.value == costPredicate.value
+      )
+    )
+      entry.cost = entryProperties.find(
+        (entry) => entry.predicate.value == costPredicate.value
+      ).object.value;
+    if (
+      entryProperties.find(
+        (entry) => entry.predicate.value == sharePredicate.value
+      )
+    )
+      entry.share = entryProperties.find(
+        (entry) => entry.predicate.value == sharePredicate.value
+      ).object.value;
+    if (
+      entryProperties.find(
+        (entry) => entry.predicate.value == indexPredicate.value
+      )
+    )
+      entry.index = entryProperties.find(
+        (entry) => entry.predicate.value == indexPredicate.value
+      ).object.value;
+    return entry;
+  }
+}

--- a/app/components/rdf-form-fields/estimated-cost-table/edit.hbs
+++ b/app/components/rdf-form-fields/estimated-cost-table/edit.hbs
@@ -1,0 +1,75 @@
+<AuLabel
+  @error={{this.hasErrors}}
+  @required={{this.isRequired}}
+  for={{this.inputFor}}
+>
+  {{@field.label}}
+</AuLabel>
+
+{{#each this.errors as |error|}}
+  <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+{{/each}}
+
+<table
+  class="data-table data-table--zebra data-table--tight au-u-margin-top-small"
+>
+  <caption class="au-u-hidden-visually">Vul de raming van de totale kostprijs
+    voor de fietsinfrastructuur in</caption>
+  <thead>
+    <tr>
+      <td>
+      </td>
+      <th scope="col">
+        Kosten (Excl. BTW)
+      </th>
+      <th scope="col">
+        Het gemeentelijk aandeel (%) in kosten
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    {{#each this.entries as |entry index|}}
+      <tr>
+        <th scope="row">
+          {{entry.description.value}}
+        </th>
+        <td>
+          <AuLabel for="costs-{{index}}" class="au-u-hidden-visually">
+            Kosten (Excl. BTW)
+          </AuLabel>
+          <AuInput
+            @width="block"
+            @value={{entry.cost.value}}
+            @type="number"
+            id="costs-{{index}}"
+            step="any"
+            class={{if entry.cost.errors "au-c-input--error"}}
+            {{on "blur" (fn this.updateCost entry)}}
+          />
+          {{#each entry.cost.errors as |error|}}
+            <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+          {{/each}}
+        </td>
+        <td>
+          <AuLabel for="share-{{index}}" class="au-u-hidden-visually">
+            Het gemeentelijk aandeel (%) in kosten
+          </AuLabel>
+          <AuInput
+            @width="block"
+            @value={{entry.share.value}}
+            @type="number"
+            id="share-{{index}}"
+            step="any"
+            class={{if entry.share.errors "au-c-input--error"}}
+            {{on "blur" (fn this.updateShare entry)}}
+          />
+          {{#each entry.share.errors as |error|}}
+            <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+          {{/each}}
+        </td>
+      </tr>
+    {{/each}}
+  </tbody>
+</table>
+
+{{yield}}

--- a/app/components/rdf-form-fields/estimated-cost-table/edit.js
+++ b/app/components/rdf-form-fields/estimated-cost-table/edit.js
@@ -1,0 +1,397 @@
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+import rdflib from 'browser-rdflib';
+import { v4 as uuidv4 } from 'uuid';
+import { RDF } from '@lblod/submission-form-helpers';
+import { next } from '@ember/runloop';
+
+import BaseTable from './base-table';
+import { EstimatedCostEntry } from './base-table';
+import {
+  MU,
+  estimatedCostTableBaseUri,
+  EstimatedCostTableType,
+  estimatedCostTablePredicate,
+  subsidyRulesUri,
+  EstimatedCostEntryType,
+  estimatedCostEntryPredicate,
+  costPredicate,
+  validEstimatedCostTable,
+} from './base-table';
+
+const defaultRows = [
+  {
+    uuid: 'bda9c645-9520-44ff-bac4-8b77647a93e0',
+    description:
+      'Totale raming van de kostprijs excl. BTW (enkel subsidieerbare kosten) en excl. onteigeningsvergoedingen',
+    cost: 0,
+    share: 100,
+    index: 0,
+  },
+  {
+    uuid: '38f24b3d-e4dd-408e-a530-c8d3a8fca0ff',
+    description: 'Totale raming van de onteigeningsvergoedingen',
+    cost: 0,
+    share: 100,
+    index: 1,
+  },
+];
+
+const aanvraagRows = [
+  {
+    uuid: 'b22a9324-874a-42d1-b815-f20f96b31a53',
+    description:
+      'Kostprijs excl. BTW (enkel subsidieerbare kosten) en excl. onteigeningsvergoedingen',
+    cost: 0,
+    share: 100,
+    index: 0,
+  },
+  {
+    uuid: '92a25430-ab31-46dc-a0d8-3f4cf1dc1b04',
+    description: 'Onteigeningsvergoedingen',
+    cost: 0,
+    share: 100,
+    index: 1,
+  },
+];
+
+export default class RdfFormFieldsEstimatedCostTableEditComponent extends BaseTable {
+  @tracked errors = [];
+
+  constructor() {
+    super(...arguments);
+
+    // There is a lot of stuff that get's updated in the same runloop, we'll need to revise this a bit
+    // Now the workaround is to schedule it.
+    next(this, () => {
+      this.entries = this.loadEstimatedCostEntries();
+      this.initializeTable();
+      this.validate();
+    });
+  }
+
+  get hasEstimatedCostTable() {
+    if (!this.estimatedCostTableSubject) return false;
+    else
+      return (
+        this.storeOptions.store.match(
+          this.sourceNode,
+          estimatedCostTablePredicate,
+          this.estimatedCostTableSubject,
+          this.storeOptions.sourceGraph
+        ).length > 0
+      );
+  }
+
+  get isAanvraagStep() {
+    return Boolean(this.args.field?.options?.isAanvraagStep);
+  }
+
+  initializeTable() {
+    if (!this.hasEstimatedCostTable) {
+      this.createEstimatedCostTable();
+      this.entries = this.createEntries();
+    }
+  }
+
+  createEstimatedCostTable() {
+    const uuid = uuidv4();
+    this.estimatedCostTableSubject = new rdflib.NamedNode(
+      `${estimatedCostTableBaseUri}/${uuid}`
+    );
+    const triples = [
+      {
+        subject: this.estimatedCostTableSubject,
+        predicate: RDF('type'),
+        object: EstimatedCostTableType,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: this.estimatedCostTableSubject,
+        predicate: MU('uuid'),
+        object: uuid,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: this.storeOptions.sourceNode,
+        predicate: estimatedCostTablePredicate,
+        object: this.estimatedCostTableSubject,
+        graph: this.storeOptions.sourceGraph,
+      },
+    ];
+    this.storeOptions.store.addAll(triples);
+  }
+
+  createEntries() {
+    let entries = [];
+    const estimatedCostEntriesDetails = this.createEstimatedCostEntries();
+    estimatedCostEntriesDetails.forEach((detail) => {
+      const newEntry = new EstimatedCostEntry({
+        estimatedCostEntrySubject: detail.subject,
+        description: detail.description,
+        cost: detail.cost,
+        share: detail.share,
+        index: detail.index,
+      });
+      entries.pushObject(newEntry);
+    });
+
+    this.initializeEntriesFields(entries);
+    return entries;
+  }
+
+  createEstimatedCostEntries() {
+    let triples = [];
+    let estimatedCostEntriesDetails = [];
+    let rows = [];
+
+    if (this.isAanvraagStep) {
+      rows = aanvraagRows;
+    } else {
+      rows = defaultRows;
+    }
+
+    rows.forEach((target) => {
+      const uuid = uuidv4();
+      const estimatedCostEntrySubject = new rdflib.NamedNode(
+        `${subsidyRulesUri}/${uuid}`
+      );
+
+      estimatedCostEntriesDetails.push({
+        subject: estimatedCostEntrySubject,
+        description: target.description,
+        cost: target.cost,
+        share: target.share,
+        index: target.index,
+      });
+
+      triples.push(
+        {
+          subject: estimatedCostEntrySubject,
+          predicate: RDF('type'),
+          object: EstimatedCostEntryType,
+          graph: this.storeOptions.sourceGraph,
+        },
+        {
+          subject: estimatedCostEntrySubject,
+          predicate: MU('uuid'),
+          object: target.uuid,
+          graph: this.storeOptions.sourceGraph,
+        },
+        {
+          subject: this.estimatedCostTableSubject,
+          predicate: estimatedCostEntryPredicate,
+          object: estimatedCostEntrySubject,
+          graph: this.storeOptions.sourceGraph,
+        }
+      );
+    });
+    this.storeOptions.store.addAll(triples);
+    return estimatedCostEntriesDetails;
+  }
+
+  initializeEntriesFields(entries) {
+    let triples = [];
+    entries.forEach((entry) => {
+      triples.push(
+        {
+          subject: entry.estimatedCostEntrySubject,
+          predicate: entry['description'].predicate,
+          object: entry['description'].value,
+          graph: this.storeOptions.sourceGraph,
+        },
+        {
+          subject: entry.estimatedCostEntrySubject,
+          predicate: entry['cost'].predicate,
+          object: entry['cost'].value,
+          graph: this.storeOptions.sourceGraph,
+        },
+        {
+          subject: entry.estimatedCostEntrySubject,
+          predicate: entry['share'].predicate,
+          object: entry['share'].value,
+          graph: this.storeOptions.sourceGraph,
+        },
+        {
+          subject: entry.estimatedCostEntrySubject,
+          predicate: entry['index'].predicate,
+          object: entry['index'].value,
+          graph: this.storeOptions.sourceGraph,
+        }
+      );
+    });
+    this.storeOptions.store.addAll(triples);
+  }
+
+  updateTripleObject(subject, predicate, newObject = null) {
+    const triples = this.storeOptions.store.match(
+      subject,
+      predicate,
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+
+    this.storeOptions.store.removeStatements([...triples]);
+
+    if (newObject) {
+      this.storeOptions.store.addAll([
+        {
+          subject: subject,
+          predicate: predicate,
+          object: newObject,
+          graph: this.storeOptions.sourceGraph,
+        },
+      ]);
+    }
+  }
+
+  validate() {
+    this.errors = [];
+    const entries = this.storeOptions.store.match(
+      undefined,
+      costPredicate,
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+
+    const invalidCosts = entries.filter((entry) =>
+      isNaN(parseInt(entry.object.value))
+    );
+    if (invalidCosts.length) {
+      this.errors.pushObject({
+        message: 'Eén van de velden werd niet correct ingevuld.',
+      });
+      this.updateTripleObject(
+        this.estimatedCostTableSubject,
+        validEstimatedCostTable,
+        null
+      );
+    }
+
+    const positiveCosts = entries.filter(
+      (entry) => parseInt(entry.object.value) > 0
+    );
+    if (!positiveCosts.length) {
+      this.errors.pushObject({
+        message:
+          'Minstens één kosten veld moet een waarde groter dan 0 bevatten.',
+      });
+      this.updateTripleObject(
+        this.estimatedCostTableSubject,
+        validEstimatedCostTable,
+        null
+      );
+    }
+
+    if (positiveCosts.length && !invalidCosts.length) {
+      this.updateTripleObject(
+        this.estimatedCostTableSubject,
+        validEstimatedCostTable,
+        true
+      );
+    }
+  }
+
+  @action
+  updateCost(entry) {
+    entry.cost.errors = [];
+
+    if (!this.isPositiveInteger(entry.cost.value)) {
+      entry.cost.errors.pushObject({
+        message: 'Kosten moet groter of gelijk aan 0 zijn',
+      });
+      this.updateTripleObject(
+        this.estimatedCostTableSubject,
+        validEstimatedCostTable,
+        null
+      );
+    } else {
+      this.updateTripleObject(
+        this.estimatedCostTableSubject,
+        validEstimatedCostTable,
+        true
+      );
+    }
+
+    if (isNaN(parseInt(entry.cost.value))) {
+      this.updateTripleObject(
+        entry.estimatedCostEntrySubject,
+        entry['cost'].predicate,
+        'Field is empty'
+      );
+    } else {
+      this.updateTripleObject(
+        entry.estimatedCostEntrySubject,
+        entry['cost'].predicate,
+        entry['cost'].value
+      );
+    }
+
+    this.validate();
+  }
+
+  @action
+  updateShare(entry) {
+    entry.share.errors = [];
+
+    if (this.isEmpty(entry.share.value)) {
+      entry.share.errors.pushObject({
+        message: 'Gemeentelijk aandeel in kosten is verplicht.',
+      });
+      this.updateTripleObject(
+        this.estimatedCostTableSubject,
+        validEstimatedCostTable,
+        null
+      );
+    } else if (!this.isPositiveInteger(Number(entry.share.value))) {
+      entry.share.errors.pushObject({
+        message:
+          'Het gemeentelijke aandeel in kosten moet groter of gelijk aan 0 zijn',
+      });
+      this.updateTripleObject(
+        this.estimatedCostTableSubject,
+        validEstimatedCostTable,
+        null
+      );
+    } else if (!this.isSmallerThan(Number(entry.share.value), 100)) {
+      entry.share.errors.pushObject({
+        message:
+          'Het gemeentelijke aandeel in kosten mag niet hoger liggen dan 100%',
+      });
+      this.updateTripleObject(
+        this.estimatedCostTableSubject,
+        validEstimatedCostTable,
+        null
+      );
+    } else {
+      this.updateTripleObject(
+        this.estimatedCostTableSubject,
+        validEstimatedCostTable,
+        true
+      );
+    }
+
+    this.updateTripleObject(
+      entry.estimatedCostEntrySubject,
+      entry['share'].predicate,
+      entry['share'].value
+    );
+  }
+
+  isPositiveInteger(value) {
+    return parseInt(value) >= 0;
+  }
+
+  isEmpty(value) {
+    return value.toString().length == 0;
+  }
+
+  isValidInteger(value) {
+    return parseFloat(value) % 1 === 0;
+  }
+
+  isSmallerThan(value, max) {
+    return value <= max;
+  }
+}

--- a/app/components/rdf-form-fields/estimated-cost-table/show.hbs
+++ b/app/components/rdf-form-fields/estimated-cost-table/show.hbs
@@ -1,0 +1,59 @@
+<AuLabel for={{this.inputFor}}>
+  {{@field.label}}
+  {{#if this.isRequired}}
+    <AuPill>Verplicht</AuPill>
+  {{/if}}
+</AuLabel>
+<table
+  class="data-table data-table--zebra data-table--tight au-u-margin-top-small"
+>
+  <caption class="au-u-hidden-visually">
+    Vul de raming van de totale kostprijs voor de fietsinfrastructuur in
+  </caption>
+  <thead>
+    <tr>
+      <td></td>
+      <th scope="col">
+        Kosten (Excl. BTW)
+      </th>
+      <th scope="col">
+        Het gemeentelijk aandeel (%) in kosten
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    {{#each this.entries as |entry index|}}
+      <tr>
+        <th scope="row">
+          {{entry.description.value}}
+        </th>
+        <td>
+          <AuLabel for="costs-{{index}}" class="au-u-hidden-visually">
+            Kosten (Excl. BTW)
+          </AuLabel>
+          <AuInput
+            @width="block"
+            @value={{entry.cost.value}}
+            @disabled={{true}}
+            @type="number"
+            id="costs-{{index}}"
+            step="any"
+          />
+        </td>
+        <td>
+          <AuLabel for="share-{{index}}" class="au-u-hidden-visually">
+            Het gemeentelijk aandeel (%) in kosten
+          </AuLabel>
+          <AuInput
+            @width="block"
+            @value={{entry.share.value}}
+            @disabled={{true}}
+            @type="number"
+            id="share-{{index}}"
+            step="any"
+          />
+        </td>
+      </tr>
+    {{/each}}
+  </tbody>
+</table>

--- a/app/components/rdf-form-fields/estimated-cost-table/show.js
+++ b/app/components/rdf-form-fields/estimated-cost-table/show.js
@@ -1,0 +1,8 @@
+import BaseTable from './base-table';
+
+export default class RdfFormFieldsEstimatedCostTableShowComponent extends BaseTable {
+  constructor() {
+    super(...arguments);
+    this.entries = this.loadEstimatedCostEntries();
+  }
+}

--- a/app/components/rdf-form-fields/objective-table/edit.hbs
+++ b/app/components/rdf-form-fields/objective-table/edit.hbs
@@ -1,0 +1,193 @@
+<AuLabel @error={{this.hasErrors}} @required={{this.isRequired}} for={{this.inputFor}}>
+  {{@field.label}}
+</AuLabel>
+{{#each this.errors as |error|}}
+    <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+{{/each}}
+
+<table class="au-c-table au-c-table--zebra">
+  <caption class="au-u-hidden-visually">Vul de doestelling in kilometer in</caption>
+  <thead>
+    <tr>
+      <td rowspan="2" style="border-right:0.2rem solid #CCD1D9;" id="th-name" {{!template-lint-disable no-inline-styles}}></td>
+      <th colspan="2" id="een-kant">
+        Aan- en vrijliggend fietspad langs 1 kant van de weg
+      </th>
+      <th colspan="2" id="beide-kanten">
+        Aan- en vrijliggend fietspad langs beide kanten van de weg
+      </th>
+      <th colspan="2" id="fietsweg">
+        Fietsweg
+      </th>
+      <th colspan="2" id="sugestiestroken">
+        Fietssugestiestroken
+      </th>
+      <th id="fietszone">Fietszone</th>
+    </tr>
+    <tr class="au-c-table__row-indent">
+      <th id="een-enkel">Enkelrichting</th>
+      <th id="een-dubbel">Dubbelrichting</th>
+      <th id="twee-enkel">Enkelrichting</th>
+      <th id="twee-dubbel">Dubbelrichting</th>
+      <th id="fietsweg-enkel">Enkelrichting</th>
+      <th id="fietsweg-dubbel">Dubbelrichting</th>
+      <th id="sugestiestroken-enkel">Enkelrichting</th>
+      <th id="sugestiestroken-dubbel">Dubbelrichting</th>
+      <td></td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row" id="verbeteren">
+        Verbeteren
+      </th>
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="een-kant een-enkel verbeteren"
+        @approachType="verbeteren"
+        @bikeLaneType="vrijliggendAanEenKantVanDeWeg"
+        @directionType="enkelrichting"
+        @storeOptions={{this.storeOptions}}
+        @onUpdateCell={{this.validate}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="een-kant een-dubbel verbeteren"
+        @approachType="verbeteren"
+        @bikeLaneType="vrijliggendAanEenKantVanDeWeg"
+        @directionType="dubbelrichting"
+        @storeOptions={{this.storeOptions}}
+        @onUpdateCell={{this.validate}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="beide-kanten twee-enkel verbeteren"
+        @approachType="verbeteren"
+        @bikeLaneType="vrijliggendBeideKantenVanDeWeg"
+        @directionType="enkelrichting"
+        @storeOptions={{this.storeOptions}}
+        @onUpdateCell={{this.validate}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="beide-kanten twee-dubbel verbeteren"
+        @approachType="verbeteren"
+        @bikeLaneType="vrijliggendBeideKantenVanDeWeg"
+        @directionType="dubbelrichting"
+        @storeOptions={{this.storeOptions}}
+        @onUpdateCell={{this.validate}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="fietsweg fietsweg-enkel verbeteren"
+        @approachType="verbeteren"
+        @bikeLaneType="fietsweg"
+        @directionType="enkelrichting"
+        @storeOptions={{this.storeOptions}}
+        @onUpdateCell={{this.validate}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="fietsweg fietsweg-dubbel verbeteren"
+        @approachType="verbeteren"
+        @bikeLaneType="fietsweg"
+        @directionType="dubbelrichting"
+        @storeOptions={{this.storeOptions}}
+        @onUpdateCell={{this.validate}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="sugestiestroken sugestiestroken-enkel verbeteren"
+        @approachType="verbeteren"
+        @bikeLaneType="fietssugestiestroken"
+        @directionType="enkelrichting"
+        @storeOptions={{this.storeOptions}}
+        @onUpdateCell={{this.validate}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="sugestiestroken sugestiestroken-dubbel verbeteren"
+        @approachType="verbeteren"
+        @bikeLaneType="fietssugestiestroken"
+        @directionType="dubbelrichting"
+        @storeOptions={{this.storeOptions}}
+        @onUpdateCell={{this.validate}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="fietszone verbeteren"
+        @approachType="verbeteren"
+        @bikeLaneType="fietszone"
+        @storeOptions={{this.storeOptions}}
+        @onUpdateCell={{this.validate}}
+      />
+    </tr>
+    <tr>
+      <th scope="row" id="vernieuwen">
+          Vernieuwen
+      </th>
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="een-kant een-enkel vernieuwen"
+        @approachType="vernieuwing"
+        @bikeLaneType="vrijliggendAanEenKantVanDeWeg"
+        @directionType="enkelrichting"
+        @storeOptions={{this.storeOptions}}
+        @onUpdateCell={{this.validate}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="een-kant een-dubbel vernieuwen"
+        @approachType="vernieuwing"
+        @bikeLaneType="vrijliggendAanEenKantVanDeWeg"
+        @directionType="dubbelrichting"
+        @storeOptions={{this.storeOptions}}
+        @onUpdateCell={{this.validate}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="beide-kanten twee-enkel vernieuwen"
+        @approachType="vernieuwing"
+        @bikeLaneType="vrijliggendBeideKantenVanDeWeg"
+        @directionType="enkelrichting"
+        @storeOptions={{this.storeOptions}}
+        @onUpdateCell={{this.validate}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="beide-kanten twee-dubbel vernieuwen"
+        @approachType="vernieuwing"
+        @bikeLaneType="vrijliggendBeideKantenVanDeWeg"
+        @directionType="dubbelrichting"
+        @storeOptions={{this.storeOptions}}
+        @onUpdateCell={{this.validate}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="fietsweg fietsweg-enkel vernieuwen"
+        @approachType="vernieuwing"
+        @bikeLaneType="fietsweg"
+        @directionType="enkelrichting"
+        @storeOptions={{this.storeOptions}}
+        @onUpdateCell={{this.validate}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="fietsweg fietsweg-dubbel vernieuwen"
+        @approachType="vernieuwing"
+        @bikeLaneType="fietsweg"
+        @directionType="dubbelrichting"
+        @storeOptions={{this.storeOptions}}
+        @onUpdateCell={{this.validate}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="sugestiestroken sugestiestroken-enkel vernieuwen"
+        @approachType="vernieuwing"
+        @bikeLaneType="fietssugestiestroken"
+        @directionType="enkelrichting"
+        @storeOptions={{this.storeOptions}}
+        @onUpdateCell={{this.validate}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="sugestiestroken sugestiestroken-dubbel vernieuwen"
+        @approachType="vernieuwing"
+        @bikeLaneType="fietssugestiestroken"
+        @directionType="dubbelrichting"
+        @storeOptions={{this.storeOptions}}
+        @onUpdateCell={{this.validate}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="fietszone vernieuwen"
+        @approachType="vernieuwing"
+        @bikeLaneType="fietszone"
+        @storeOptions={{this.storeOptions}}
+        @onUpdateCell={{this.validate}}
+      />
+    </tr>
+  </tbody>
+</table>

--- a/app/components/rdf-form-fields/objective-table/edit.js
+++ b/app/components/rdf-form-fields/objective-table/edit.js
@@ -1,0 +1,170 @@
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { triplesForPath } from '@lblod/submission-form-helpers';
+import rdflib from 'browser-rdflib';
+import { v4 as uuidv4 } from 'uuid';
+import { RDF } from '@lblod/submission-form-helpers';
+import { scheduleOnce } from '@ember/runloop';
+
+const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+
+const bicycleInfrastructureUri =
+  'http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#';
+const resourceInstanceBaseUri =
+  'http://lblod.data.gift/id/subsidie/bicycle-infrastructure';
+const ObjectiveTableType = new rdflib.NamedNode(
+  `${bicycleInfrastructureUri}ObjectiveTable`
+);
+const objectiveTablePredicate = new rdflib.NamedNode(
+  `${bicycleInfrastructureUri}objectiveTable`
+);
+const kilometersPredicate = new rdflib.NamedNode(
+  `${bicycleInfrastructureUri}kilometers`
+);
+
+const hasInvalidCellPredicate = new rdflib.NamedNode(
+  `${bicycleInfrastructureUri}/hasInvalidObjectiveTableEntry`
+);
+const validObjectiveTable = new rdflib.NamedNode(
+  `${bicycleInfrastructureUri}validObjectiveTable`
+);
+
+export default class RdfFormFieldsObjectiveTableEditComponent extends InputFieldComponent {
+  @tracked objectiveTableSubject = null;
+  @tracked errors = [];
+
+  get hasObjectiveTable() {
+    return (
+      this.storeOptions.store.match(
+        this.sourceNode,
+        objectiveTablePredicate,
+        this.objectiveTableSubject,
+        this.storeOptions.sourceGraph
+      ).length > 0
+    );
+  }
+
+  constructor() {
+    super(...arguments);
+    scheduleOnce('actions', this, this.initTable);
+  }
+
+  initTable() {
+    // Create table and entries in the store if not already existing
+    if (this.hasObjectiveTable) {
+      this.loadProvidedValue();
+      this.validate();
+    } else {
+      this.createObjectiveTable();
+    }
+  }
+
+  loadProvidedValue() {
+    const matches = triplesForPath(this.storeOptions);
+    const triples = matches.triples;
+
+    if (triples.length) {
+      this.objectiveTableSubject = triples[0].object; // assuming only one per form
+    }
+  }
+
+  createObjectiveTable() {
+    const uuid = uuidv4();
+    this.objectiveTableSubject = new rdflib.NamedNode(
+      `${resourceInstanceBaseUri}/${uuid}`
+    );
+    const triples = [
+      {
+        subject: this.objectiveTableSubject,
+        predicate: RDF('type'),
+        object: ObjectiveTableType,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: this.objectiveTableSubject,
+        predicate: MU('uuid'),
+        object: uuid,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: this.storeOptions.sourceNode,
+        predicate: objectiveTablePredicate,
+        object: this.objectiveTableSubject,
+        graph: this.storeOptions.sourceGraph,
+      },
+    ];
+    this.storeOptions.store.addAll(triples);
+  }
+
+  updateTripleObject(subject, predicate, newObject = null) {
+    const triples = this.storeOptions.store.match(
+      subject,
+      predicate,
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+
+    this.storeOptions.store.removeStatements([...triples]);
+
+    if (newObject) {
+      this.storeOptions.store.addAll([
+        {
+          subject: subject,
+          predicate: predicate,
+          object: newObject,
+          graph: this.storeOptions.sourceGraph,
+        },
+      ]);
+    }
+  }
+
+  cellHasValue() {
+    const cells = this.storeOptions.store.match(
+      null,
+      kilometersPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    );
+    const cellsWithValue = cells.filter((item) => item.object.value > 0);
+    return cellsWithValue.length > 0;
+  }
+
+  @action
+  validate() {
+    this.errors = [];
+
+    const invalidRow = this.storeOptions.store.any(
+      this.objectiveTableSubject,
+      hasInvalidCellPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    );
+
+    if (!this.cellHasValue()) {
+      this.errors.pushObject({
+        message: 'Minstens één veld moet een waarde groter dan 0 bevatten.',
+      });
+      this.updateTripleObject(
+        this.objectiveTableSubject,
+        validObjectiveTable,
+        null
+      );
+    } else if (invalidRow) {
+      this.errors.pushObject({
+        message: 'Een van de rijen is niet correct ingevuld',
+      });
+      this.updateTripleObject(
+        this.objectiveTableSubject,
+        validObjectiveTable,
+        null
+      );
+    } else {
+      this.updateTripleObject(
+        this.objectiveTableSubject,
+        validObjectiveTable,
+        true
+      );
+    }
+  }
+}

--- a/app/components/rdf-form-fields/objective-table/show.hbs
+++ b/app/components/rdf-form-fields/objective-table/show.hbs
@@ -1,0 +1,193 @@
+<AuLabel for={{this.inputFor}}>
+  {{@field.label}}
+  {{#if this.isRequired}}
+    <AuPill>Verplicht</AuPill>
+  {{/if}}
+</AuLabel>
+
+<table class="au-c-table au-c-table--zebra">
+  <caption class="au-u-hidden-visually">Vul de doestelling in kilometer in</caption>
+  <thead>
+    <tr>
+      <td rowspan="2" style="border-right:0.2rem solid #CCD1D9;" {{!template-lint-disable no-inline-styles}}></td>
+      <th colspan="2" id="een-kant">
+        Aan- en vrijliggend fietspad langs 1 kant van de weg
+      </th>
+      <th colspan="2" id="beide-kanten">
+        Aan- en vrijliggend fietspad langs beide kanten van de weg
+      </th>
+      <th colspan="2" id="fietsweg">
+        Fietsweg
+      </th>
+      <th colspan="2" id="sugestiestroken">
+        Fietssugestiestroken
+      </th>
+      <th id="fietszone">Fietszone</th>
+    </tr>
+    <tr class="au-c-table__row-indent">
+      <th id="een-enkel">Enkelrichting</th>
+      <th id="een-dubbel">Dubbelrichting</th>
+      <th id="twee-enkel">Enkelrichting</th>
+      <th id="twee-dubbel">Dubbelrichting</th>
+      <th id="fietsweg-enkel">Enkelrichting</th>
+      <th id="fietsweg-dubbel">Dubbelrichting</th>
+      <th id="sugestiestroken-enkel">Enkelrichting</th>
+      <th id="sugestiestroken-dubbel">Dubbelrichting</th>
+      <td></td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row" id="verbeteren">
+        Verbeteren
+      </th>
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="een-kant een-enkel verbeteren"
+        @approachType="verbeteren"
+        @bikeLaneType="vrijliggendAanEenKantVanDeWeg"
+        @directionType="enkelrichting"
+        @storeOptions={{this.storeOptions}}
+        @disabled={{true}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="een-kant een-dubbel verbeteren"
+        @approachType="verbeteren"
+        @bikeLaneType="vrijliggendAanEenKantVanDeWeg"
+        @directionType="dubbelrichting"
+        @storeOptions={{this.storeOptions}}
+        @disabled={{true}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="beide-kanten twee-enkel verbeteren"
+        @approachType="verbeteren"
+        @bikeLaneType="vrijliggendBeideKantenVanDeWeg"
+        @directionType="enkelrichting"
+        @storeOptions={{this.storeOptions}}
+        @disabled={{true}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="beide-kanten twee-dubbel verbeteren"
+        @approachType="verbeteren"
+        @bikeLaneType="vrijliggendBeideKantenVanDeWeg"
+        @directionType="dubbelrichting"
+        @storeOptions={{this.storeOptions}}
+        @disabled={{true}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="fietsweg fietsweg-enkel verbeteren"
+        @approachType="verbeteren"
+        @bikeLaneType="fietsweg"
+        @directionType="enkelrichting"
+        @storeOptions={{this.storeOptions}}
+        @disabled={{true}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="fietsweg fietsweg-dubbel verbeteren"
+        @approachType="verbeteren"
+        @bikeLaneType="fietsweg"
+        @directionType="dubbelrichting"
+        @storeOptions={{this.storeOptions}}
+        @disabled={{true}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="sugestiestroken sugestiestroken-enkel verbeteren"
+        @approachType="verbeteren"
+        @bikeLaneType="fietssugestiestroken"
+        @directionType="enkelrichting"
+        @storeOptions={{this.storeOptions}}
+        @disabled={{true}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="sugestiestroken sugestiestroken-dubbel verbeteren"
+        @approachType="verbeteren"
+        @bikeLaneType="fietssugestiestroken"
+        @directionType="dubbelrichting"
+        @storeOptions={{this.storeOptions}}
+        @disabled={{true}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="fietszone verbeteren"
+        @approachType="verbeteren"
+        @bikeLaneType="fietszone"
+        @storeOptions={{this.storeOptions}}
+        @disabled={{true}}
+      />
+    </tr>
+    <tr>
+      <th scope="row" id="vernieuwen">
+        Vernieuwen
+      </th>
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="een-kant een-enkel vernieuwen"
+        @approachType="vernieuwing"
+        @bikeLaneType="vrijliggendAanEenKantVanDeWeg"
+        @directionType="enkelrichting"
+        @storeOptions={{this.storeOptions}}
+        @disabled={{true}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="een-kant een-dubbel vernieuwen"
+        @approachType="vernieuwing"
+        @bikeLaneType="vrijliggendAanEenKantVanDeWeg"
+        @directionType="dubbelrichting"
+        @storeOptions={{this.storeOptions}}
+        @disabled={{true}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="beide-kanten twee-enkel vernieuwen"
+        @approachType="vernieuwing"
+        @bikeLaneType="vrijliggendBeideKantenVanDeWeg"
+        @directionType="enkelrichting"
+        @storeOptions={{this.storeOptions}}
+        @disabled={{true}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="beide-kanten twee-dubbel vernieuwen"
+        @approachType="vernieuwing"
+        @bikeLaneType="vrijliggendBeideKantenVanDeWeg"
+        @directionType="dubbelrichting"
+        @storeOptions={{this.storeOptions}}
+        @disabled={{true}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="fietsweg fietsweg-enkel vernieuwen"
+        @approachType="vernieuwing"
+        @bikeLaneType="fietsweg"
+        @directionType="enkelrichting"
+        @storeOptions={{this.storeOptions}}
+        @disabled={{true}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="fietsweg fietsweg-dubbel vernieuwen"
+        @approachType="vernieuwing"
+        @bikeLaneType="fietsweg"
+        @directionType="dubbelrichting"
+        @storeOptions={{this.storeOptions}}
+        @disabled={{true}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="sugestiestroken sugestiestroken-enkel vernieuwen"
+        @approachType="vernieuwing"
+        @bikeLaneType="fietssugestiestroken"
+        @directionType="enkelrichting"
+        @storeOptions={{this.storeOptions}}
+        @disabled={{true}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="sugestiestroken sugestiestroken-dubbel vernieuwen"
+        @approachType="vernieuwing"
+        @bikeLaneType="fietssugestiestroken"
+        @directionType="dubbelrichting"
+        @storeOptions={{this.storeOptions}}
+        @disabled={{true}}
+      />
+      <RdfFormFields::ObjectiveTable::TableCell
+        @tableHeaders="fietszone vernieuwen"
+        @approachType="vernieuwing"
+        @bikeLaneType="fietszone"
+        @storeOptions={{this.storeOptions}}
+        @disabled={{true}}
+      />
+    </tr>
+  </tbody>
+</table>

--- a/app/components/rdf-form-fields/objective-table/show.js
+++ b/app/components/rdf-form-fields/objective-table/show.js
@@ -1,0 +1,3 @@
+import RdfFormFieldsObjectiveTableEditComponent from './edit';
+
+export default class RdfFormFieldsObjectiveTableShowComponent extends RdfFormFieldsObjectiveTableEditComponent {}

--- a/app/components/rdf-form-fields/objective-table/table-cell.hbs
+++ b/app/components/rdf-form-fields/objective-table/table-cell.hbs
@@ -1,0 +1,15 @@
+<td headers={{@tableHeaders}}>
+  <AuInput
+    @disabled={{@disabled}}
+    @type="number"
+    @width="block"
+    @value={{this.kilometers}}
+    @error={{this.errors}}
+    lang="nl-BE"
+    step="any"
+    {{on "blur" this.update}}
+  />
+  {{#each this.errors as |error|}}
+    <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+  {{/each}}
+</td>

--- a/app/components/rdf-form-fields/objective-table/table-cell.js
+++ b/app/components/rdf-form-fields/objective-table/table-cell.js
@@ -1,0 +1,287 @@
+import Component from '@glimmer/component';
+import { schedule } from '@ember/runloop';
+import rdflib from 'browser-rdflib';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { v4 as uuidv4 } from 'uuid';
+import { RDF } from '@lblod/submission-form-helpers';
+
+const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+
+const bicycleInfrastructureUri =
+  'http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#';
+const resourceInstanceBaseUri =
+  'http://lblod.data.gift/id/subsidie/bicycle-infrastructure';
+const objectiveEntryPredicate = new rdflib.NamedNode(
+  `${bicycleInfrastructureUri}objectiveEntry`
+);
+const ObjectiveEntryType = new rdflib.NamedNode(
+  `${bicycleInfrastructureUri}ObjectiveEntry`
+);
+
+const objectiveTablePredicate = new rdflib.NamedNode(
+  `${bicycleInfrastructureUri}objectiveTable`
+);
+const approachTypePredicate = new rdflib.NamedNode(
+  `${bicycleInfrastructureUri}approachType`
+);
+const directionTypePredicate = new rdflib.NamedNode(
+  `${bicycleInfrastructureUri}directionType`
+);
+const bikeLaneTypePredicate = new rdflib.NamedNode(
+  `${bicycleInfrastructureUri}bikeLaneType`
+);
+const kilometersPredicate = new rdflib.NamedNode(
+  `${bicycleInfrastructureUri}kilometers`
+);
+
+const hasInvalidCellPredicate = new rdflib.NamedNode(
+  `${bicycleInfrastructureUri}/hasInvalidObjectiveTableEntry`
+);
+
+export default class RdfFormFieldsObjectiveTableTableCellComponent extends Component {
+  @tracked tableEntryUri = null;
+  @tracked errors = [];
+  @tracked kilometers = null;
+
+  get storeOptions() {
+    return this.args.storeOptions;
+  }
+
+  get objectiveTableSubject() {
+    const triple = this.storeOptions.store.match(
+      this.storeOptions.sourceNode,
+      objectiveTablePredicate,
+      null,
+      this.storeOptions.sourceGraph
+    );
+    return new rdflib.NamedNode(triple[0].object.value);
+  }
+
+  get bikeLaneType() {
+    return `${bicycleInfrastructureUri}${this.args.bikeLaneType}`;
+  }
+
+  get approachType() {
+    return `${bicycleInfrastructureUri}${this.args.approachType}`;
+  }
+
+  get directionType() {
+    return `${bicycleInfrastructureUri}${this.args.directionType}`;
+  }
+
+  //...
+  get onUpdateCell() {
+    return this.args.onUpdateCell;
+  }
+
+  constructor() {
+    super(...arguments);
+    schedule('actions', this, this.initTableCell);
+  }
+
+  initTableCell() {
+    if (this.hasValues()) {
+      this.loadProvidedValue();
+    } else {
+      this.initializeDefault();
+    }
+
+    if (!this.args.disabled) {
+      this.onUpdateCell();
+    }
+  }
+
+  hasValues() {
+    const entries = this.storeOptions.store.match(
+      this.objectiveTableSubject,
+      objectiveEntryPredicate,
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+    const entriesWithDetails = [];
+
+    // Get all properties for each entry
+    entries.forEach((element) => {
+      const result = this.storeOptions.store.match(
+        element.object,
+        undefined,
+        undefined,
+        this.storeOptions.sourceGraph
+      );
+      if (result.length > 0) {
+        entriesWithDetails.push(result);
+      }
+    });
+
+    // See if one of the entries matches requirements of this table cell
+    const results = entriesWithDetails.filter((item) => {
+      let hasBikeLaneType = false;
+      let hasApproachType = false;
+      let hasDirectionType = false;
+
+      item.forEach((triple) => {
+        if (triple.object.value == this.bikeLaneType) {
+          hasBikeLaneType = true;
+        }
+        if (triple.object.value == this.approachType) {
+          hasApproachType = true;
+        }
+        if (triple.object.value == this.directionType) {
+          hasDirectionType = true;
+        }
+      });
+
+      return hasBikeLaneType && hasApproachType && hasDirectionType;
+    });
+
+    // There is a possibility this can happen in the future so early warning sign for that
+    if (results.length > 1) {
+      throw 'A table-cell should only have one matching triple';
+    }
+
+    //TODO: refactor later -> but in general we don't exepect side effects in checking functions
+    if (results.length == 1) {
+      this.tableEntryUri = results[0][0].subject;
+    }
+
+    return results.length;
+  }
+
+  loadProvidedValue() {
+    const kilometersTriple = this.storeOptions.store.match(
+      this.tableEntryUri,
+      kilometersPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    );
+    this.kilometers = kilometersTriple[0].object.value;
+  }
+
+  initializeDefault() {
+    const uuid = uuidv4();
+    const tableEntryUri = new rdflib.NamedNode(
+      `${resourceInstanceBaseUri}/${uuid}`
+    );
+
+    let triples = [
+      {
+        subject: tableEntryUri,
+        predicate: RDF('type'),
+        object: ObjectiveEntryType,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: tableEntryUri,
+        predicate: MU('uuid'),
+        object: uuid,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: this.objectiveTableSubject,
+        predicate: objectiveEntryPredicate,
+        object: tableEntryUri,
+        graph: this.storeOptions.sourceGraph,
+      },
+    ];
+
+    triples.push({
+      subject: tableEntryUri,
+      predicate: bikeLaneTypePredicate,
+      object: this.bikeLaneType,
+      graph: this.storeOptions.sourceGraph,
+    });
+
+    triples.push({
+      subject: tableEntryUri,
+      predicate: directionTypePredicate,
+      object: this.directionType,
+      graph: this.storeOptions.sourceGraph,
+    });
+
+    triples.push({
+      subject: tableEntryUri,
+      predicate: approachTypePredicate,
+      object: this.approachType,
+      graph: this.storeOptions.sourceGraph,
+    });
+
+    triples.push({
+      subject: tableEntryUri,
+      predicate: kilometersPredicate,
+      object: 0,
+      graph: this.storeOptions.sourceGraph,
+    });
+
+    this.storeOptions.store.addAll(triples);
+    this.setComponentValues(tableEntryUri);
+  }
+
+  setComponentValues(subject) {
+    this.tableEntryUri = subject;
+    this.kilometers = this.storeOptions.store.match(
+      this.tableEntryUri,
+      kilometersPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    )[0].object.value;
+  }
+
+  updateTripleObject(subject, predicate, newObject = null) {
+    const triples = this.storeOptions.store.match(
+      subject,
+      predicate,
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+
+    this.storeOptions.store.removeStatements([...triples]);
+
+    if (newObject) {
+      this.storeOptions.store.addAll([
+        {
+          subject: subject,
+          predicate: predicate,
+          object: newObject,
+          graph: this.storeOptions.sourceGraph,
+        },
+      ]);
+    }
+  }
+
+  @action
+  update(e) {
+    this.errors = [];
+    if (e && typeof e.preventDefault === 'function') e.preventDefault();
+
+    if (!this.isPositiveInteger(this.kilometers)) {
+      this.errors.pushObject({
+        message: 'Het aantal kilometers mag niet onder 0 liggen',
+      });
+      this.updateTripleObject(
+        this.objectiveTableSubject,
+        hasInvalidCellPredicate,
+        true
+      );
+    } else {
+      this.updateTripleObject(
+        this.objectiveTableSubject,
+        hasInvalidCellPredicate,
+        null
+      );
+    }
+
+    const parsedAmount = Number(this.kilometers);
+
+    this.updateTripleObject(
+      this.tableEntryUri,
+      kilometersPredicate,
+      rdflib.literal(parsedAmount)
+    );
+    return this.onUpdateCell();
+  }
+
+  isPositiveInteger(value) {
+    return parseInt(value) >= 0;
+  }
+}

--- a/app/components/rdf-form-fields/plan-living-together-table/edit.hbs
+++ b/app/components/rdf-form-fields/plan-living-together-table/edit.hbs
@@ -1,0 +1,467 @@
+<div class="au-u-margin-bottom">
+  <AuHeading @level="3" @skin="6">Hieronder vind je alle acties die gesubsidieerd worden door het Plan Samenleven.</AuHeading>
+  <AuHelpText class="au-c-content">
+    <ul>
+      <li>Geef in de tweede kolom aan wat het huidige bereik is voor deze actie (zonder middelen van het Plan Samenleven). Dit moet enkel ingevuld worden als jullie zich voor deze actie engageren.</li>
+      <li>Geef in de derde kolom aan welke bijkomende doelstellingen jullie bestuur wenst te realiseren voor het Plan Samenleven. Enkel deze bijkomende acties komen in aanmerking voor subsidiëring door de Vlaamse overheid.</li>
+      <li>In de vierde kolom ziet u het bedrag dat in aanmerking komt voor subsidiëring door de Vlaamse overheid. Er wordt verwacht dat het bestuur voor deze acties evenveel investeert.</li>
+      <li>Geef in de vierde kolom aan de hand van cijfers aan wat de prioriteit is per actie waarop het bestuur bijkomend inzet. Wanneer er niet voldoende middelen zijn, zal de Vlaamse overheid aan de hand van deze prioritering bepalen naar welke acties de subsidies gaan. Wanneer jullie bestuur intekent voor bv. 5 acties, dan moeten de nummers 1 t.e.m. 5 verdeeld worden over deze acties.</li>
+    </ul>
+  </AuHelpText>
+</div>
+
+<AuLabel @error={{this.hasErrors}} for={{this.inputFor}}>
+  {{@field.label}}
+</AuLabel>
+{{#each this.errors as |error|}}
+    <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+{{/each}}
+
+<table class="data-table data-table--zebra data-table--tight au-u-margin-top-small">
+  <caption class="au-u-hidden-visually">Algemene beleidsdoelstellingen</caption>
+  <thead>
+    <tr>
+      <th scope="col">
+        Vlaamse doelstellingen Plan Samenleven
+      </th>
+      <th scope="col">
+        Jullie huidige gemeentelijk bereik <br>
+        <span class="au-u-regular">(enkel invullen als jullie bijkomende acties doen)</span>
+      </th>
+      <th scope="col">
+        Jullie gepland bereik in kader van het Plan Samenleven
+      </th>
+      <th scope="col">
+        Bijdrage Vlaanderen
+        <span class="au-u-regular">(er wordt verwacht dat het bestuur hetzelfde bedrag bijdraagt)</span>
+      </th>
+      <th scope="col">
+        Prioritering
+        <span class="au-u-regular">(iedere doelstelling moet een aparte prioriteit hebben: 1, 2, 3 ...)</span>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/7f7f1d20-942d-48ac-85a0-748db7f3d835"
+      @rangeLabel="lokaal actieplan"
+      @maxRange={{1}}
+      @multiplier={{12500}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Veiligheid en leefbaarheid:
+        </AuHeading>
+        <p>
+          Ontwikkelen van een lokaal actieplan voor de aanpak van polarisatie en zetten in op de uitrol ervan.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/f8be95d1-b262-4a7c-8bfb-e77c115d42c6"
+      @rangeLabel="volwassen anderstaligen"
+      @maxRange={{2250}}
+      @multiplier={{60}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Nederlands
+        </AuHeading>
+        <p>
+          Volwassen anderstaligen nemen deel aan een oefenkans.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/ba162648-8286-4c36-bce3-03b816069b28"
+      @rangeLabel="begeleide personen"
+      @maxRange={{23}}
+      @multiplier={{600}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Competenties
+        </AuHeading>
+        <p>
+          Begeleiden van personen met een diploma van buiten de EU naar verkorte opleidingstrajecten.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/15217ddf-e56a-4529-9352-f0c82d433546"
+      @rangeLabel="kwetsbare kinderen"
+      @maxRange={{150}}
+      @multiplier={{650}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Competenties
+        </AuHeading>
+        <p>
+          Begeleiden van kwetsbare kinderen naar hogere studies.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/55a23203-794a-4680-8223-cae33b01ad8e"
+      @rangeLabel="ongekwalificeerde uitstromers"
+      @maxRange={{150}}
+      @multiplier={{650}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Competenties
+        </AuHeading>
+        <p>
+          Begeleiden van ongekwalificeerde uitstromers naar een kwalificerend traject.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/bd57a052-8744-402b-bdcb-19d0c386ff54"
+      @rangeLabel="begeleide nieuwkomers"
+      @maxRange={{150}}
+      @multiplier={{650}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Werk
+        </AuHeading>
+        <p>
+          Begeleiden van nieuwkomers, mensen met een handicap en 55plussers naar de arbeidsmarkt.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/a7643e23-3eee-477c-baf4-bd1eb93d9aa5"
+      @rangeLabel="begeleide personen met een handicap"
+      @maxRange={{38}}
+      @multiplier={{650}}
+      @onUpdateRow={{this.validate}}
+    />
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/88388d78-f277-43ee-963e-6e111fc28d46"
+      @rangeLabel="begeleide 55-plussers"
+      @maxRange={{75}}
+      @multiplier={{650}}
+      @onUpdateRow={{this.validate}}
+    />
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/6b8a5a4e-c1f8-40c7-9a23-7b589aede212"
+      @rangeLabel="begeleide nieuwkomers"
+      @maxRange={{75}}
+      @multiplier={{650}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Werk
+        </AuHeading>
+        <p>
+          Begeleiden van nieuwkomers, vrouwen en personen met een handicap naar ondernemerschap
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/8bae2cec-4b7c-4e16-acc2-e747d9e3b853"
+      @rangeLabel="begeleide vrouwen"
+      @maxRange={{30}}
+      @multiplier={{650}}
+      @onUpdateRow={{this.validate}}
+    />
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/619edfa8-0004-45d3-af51-7faf71d477d5"
+      @rangeLabel="begeleide personen met een handicap"
+      @maxRange={{15}}
+      @multiplier={{650}}
+      @onUpdateRow={{this.validate}}
+    />
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/ec887ea5-83ee-4782-866c-1ddedd6d7ed0"
+      @rangeLabel="begeleide personen van buitenlandse herkomst"
+      @maxRange={{300}}
+      @multiplier={{320}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Werk
+        </AuHeading>
+        <p>
+          Inzet van mentoren die jonge personen van buitenlandse herkomst begeleiden naar werk.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/80dd881d-9706-40be-8f0b-fe97d69fa00d"
+      @rangeLabel="jongeren van buitenlandse herkomst"
+      @maxRange={{150}}
+      @multiplier={{210}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Netwerk
+        </AuHeading>
+        <p>
+          Jongeren van buitenlandse herkomst en jongeren met een handicap in contact brengen met sport.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/c5719bb2-e567-433c-ae6b-f99ff5c98897"
+      @rangeLabel="personen met een handicap"
+      @maxRange={{30}}
+      @multiplier={{210}}
+      @onUpdateRow={{this.validate}}
+    />
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/5faefdda-75aa-45cd-acd4-1ee051e806fd"
+      @rangeLabel="jongeren met grotere afstand tot de arbeidsmarkt"
+      @maxRange={{180}}
+      @multiplier={{210}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Netwerk
+        </AuHeading>
+        <p>
+          Jongeren met een grotere afstand tot de arbeidsmarkt in contact brengen met opleidingen, stages, jobs en ondernemerschap
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/2b415839-747b-4514-a3f2-d02ca4303be4"
+      @rangeLabel="kwetsbare gezinnen"
+      @maxRange={{300}}
+      @multiplier={{320}}
+      @onUpdateRow={{this.validate}}
+
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Netwerk
+        </AuHeading>
+        <p>
+          Inzetten van brugfiguren die de brug maken tussen kwetsbare gezinnen en onderwijs.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/7fbac258-3c1c-44a1-8db0-ffcdcb6a3113"
+      @rangeLabel="lokaal actieplan"
+      @maxRange={{1}}
+      @multiplier={{25000}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Non-discriminatie
+        </AuHeading>
+        <p>
+          Ontwikkelen van lokale actieplannen voor de aanpak van straatintimidatie en de uitrol ervan.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/0b0d5a3a-0c10-4acf-9a94-fd4e881444bc"
+      @rangeLabel="gevormde professionals"
+      @maxRange={{150}}
+      @multiplier={{90}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Non-discriminatie
+        </AuHeading>
+        <p>
+          Vormen van professionals en burgers volgens het omstaanders-principe
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/f7c0a231-e418-4f38-8f73-3815a22f518b"
+      @rangeLabel="gevormde burgers"
+      @maxRange={{150}}
+      @multiplier={{90}}
+      @onUpdateRow={{this.validate}}
+    />
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/a419be41-704b-488d-b7c1-86d50a8a46ce"
+      @rangeLabel="lokaal actieplan"
+      @maxRange={{1}}
+      @multiplier={{25000}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Non-discriminatie
+        </AuHeading>
+        <p>
+          Ontwikkelen van lokale actieplannen voor de toegankelijkheid van publieke gebouwen en de uitrol ervan.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/fea603c6-dc87-4c09-bb85-3520cc1c495d"
+      @rangeLabel="bestuur dat correspondentietesten inzet"
+      @maxRange={{1}}
+      @multiplier={{25000}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Non-discriminatie
+        </AuHeading>
+        <p>
+          Inzetten van correspondentietesten om discriminatie te meten
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/f732ab43-ea22-4590-b3a4-6617cff64777"
+      @rangeLabel="begeleide gezinnen"
+      @maxRange={{300}}
+      @multiplier={{170}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          1 gemeenschap
+        </AuHeading>
+        <p>
+          Begeleiden van gezinnen om de sociale mix in scholen te bevorderen
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/5fcf7a3a-04b7-46e7-9449-2088656c555b"
+      @rangeLabel="jongeren van buitenlandse herkomst"
+      @maxRange={{15}}
+      @multiplier={{650}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          1 gemeenschap
+        </AuHeading>
+        <p>
+          Begeleiden van jongeren van buitenlandse herkomst en personen met een handicap tot een lerarenopleiding.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/2f7db13f-b710-4b94-92c8-efcf8eac1ead"
+      @rangeLabel="jongeren met een handicap"
+      @maxRange={{8}}
+      @multiplier={{650}}
+      @onUpdateRow={{this.validate}}
+    />
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/fd1882a8-996c-42a8-8774-0a7a453f5c70"
+      @rangeLabel="pleinmakers"
+      @maxRange={{4}}
+      @multiplier={{5800}}
+      @onUpdateRow={{this.validate}}
+
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          1 gemeenschap
+        </AuHeading>
+        <p>
+          Inzetten van pleinmakers in sociale woonwijken om het sociaal weefsel te versterken.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/e4effa35-4453-426a-95af-17767e23ed64"
+      @rangeLabel="jongeren van buitenlandse herkomst "
+      @maxRange={{150}}
+      @multiplier={{210}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          1 gemeenschap
+        </AuHeading>
+        <p>
+          Jongeren van buitenlandse herkomst en jongeren met een handicap in contact brengen met cultuur.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/56e523bd-ad3c-4648-94b0-df6d9e72c7b0"
+      @rangeLabel="jongeren met een handicap"
+      @maxRange={{30}}
+      @multiplier={{210}}
+      @onUpdateRow={{this.validate}}
+    />
+  </tbody>
+</table>
+
+<div class="au-u-margin-top">
+  <div>Totale bijdrage lokaal bestuur = <span class="au-u-medium">{{convert-to-currency this.totalContribution}}</span></div>
+  <div>Totale bijdrage Vlaamse overheid indien voldoende middelen beschikbaar = <span class="au-u-medium">{{convert-to-currency this.totalContribution}}</span></div>
+</div>

--- a/app/components/rdf-form-fields/plan-living-together-table/edit.js
+++ b/app/components/rdf-form-fields/plan-living-together-table/edit.js
@@ -1,0 +1,187 @@
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+import { tracked } from '@glimmer/tracking';
+import { A } from '@ember/array';
+import { action } from '@ember/object';
+import { triplesForPath } from '@lblod/submission-form-helpers';
+import { scheduleOnce } from '@ember/runloop';
+import rdflib from 'browser-rdflib';
+import { v4 as uuidv4 } from 'uuid';
+import { RDF } from '@lblod/submission-form-helpers';
+
+const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+
+const planBaseUri =
+  'http://lblod.data.gift/vocabularies/subsidie/plan-samenleven/';
+const planTableBaseUri = 'http://data.lblod.info/plan-living-together-tables';
+
+const lblodSubsidieBaseUri = 'http://lblod.data.gift/vocabularies/subsidie/';
+const planTableType = new rdflib.NamedNode(
+  `${lblodSubsidieBaseUri}PlanLivingTogetherTable`
+);
+const planTablePredicate = new rdflib.NamedNode(
+  `${lblodSubsidieBaseUri}planLivingTogetherTable`
+);
+const plannedRangePredicate = new rdflib.NamedNode(
+  `${planBaseUri}plannedRange`
+);
+const contributionPredicate = new rdflib.NamedNode(
+  `${planBaseUri}contribution`
+);
+const totalContributionPredicate = new rdflib.NamedNode(
+  `${planBaseUri}totalContribution`
+);
+const hasInvalidRowPredicate = new rdflib.NamedNode(
+  `${planTableBaseUri}hasInvalidPlanLivingTogetherTableEntry`
+);
+const validPlanTable = new rdflib.NamedNode(
+  `${lblodSubsidieBaseUri}validPlanLivingTogetherTable`
+);
+
+export default class RdfFormFieldsPlanLivingTogetherTableEditComponent extends InputFieldComponent {
+  @tracked planTableSubject = null;
+  @tracked errors = A();
+  @tracked entries = [];
+  @tracked totalContribution = 0;
+
+  get hasPlanTable() {
+    if (!this.planTableSubject) return false;
+    else
+      return (
+        this.storeOptions.store.match(
+          this.sourceNode,
+          planTablePredicate,
+          this.planTableSubject,
+          this.storeOptions.sourceGraph
+        ).length > 0
+      );
+  }
+
+  constructor() {
+    super(...arguments);
+    scheduleOnce('actions', this, this.initializeTable);
+  }
+
+  loadProvidedValue() {
+    const matches = triplesForPath(this.storeOptions);
+    const triples = matches.triples;
+    if (triples.length) {
+      this.planTableSubject = triples[0].object; // assuming only one per form
+    }
+  }
+
+  initializeTable() {
+    this.loadProvidedValue();
+
+    if (!this.hasPlanTable) {
+      this.createPlanTable();
+    }
+
+    this.validate();
+  }
+
+  createPlanTable() {
+    const uuid = uuidv4();
+    this.planTableSubject = new rdflib.NamedNode(`${planTableBaseUri}/${uuid}`);
+
+    const triples = [
+      {
+        subject: this.planTableSubject,
+        predicate: RDF('type'),
+        object: planTableType,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: this.planTableSubject,
+        predicate: MU('uuid'),
+        object: uuid,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: this.storeOptions.sourceNode,
+        predicate: planTablePredicate,
+        object: this.planTableSubject,
+        graph: this.storeOptions.sourceGraph,
+      },
+    ];
+    this.storeOptions.store.addAll(triples);
+  }
+
+  //TODO: move to some common code
+  updateTripleObject(subject, predicate, newObject = null) {
+    const triples = this.storeOptions.store.match(
+      subject,
+      predicate,
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+
+    this.storeOptions.store.removeStatements([...triples]);
+
+    if (newObject) {
+      this.storeOptions.store.addAll([
+        {
+          subject: subject,
+          predicate: predicate,
+          object: newObject,
+          graph: this.storeOptions.sourceGraph,
+        },
+      ]);
+    }
+  }
+
+  @action
+  validate() {
+    this.errors = A();
+
+    // Calculate total contribution (column D)
+    const contributionEntries = this.storeOptions.store.match(
+      undefined,
+      contributionPredicate,
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+
+    this.totalContribution = contributionEntries.reduce(
+      (prev, curr) => prev + Number(curr.object.value),
+      0
+    );
+
+    // check that at least 1 value set in column C
+    const rangeEntries = this.storeOptions.store.match(
+      undefined,
+      plannedRangePredicate,
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+
+    const invalidRow = this.storeOptions.store.any(
+      this.planTableSubject,
+      hasInvalidRowPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    );
+    const hasPlannedRange = rangeEntries.filter(
+      (entry) => parseInt(entry.object.value) > 0
+    );
+
+    if (invalidRow) {
+      this.errors.pushObject({
+        message: 'Een van de rijen is niet correct ingevuld',
+      });
+      this.updateTripleObject(this.planTableSubject, validPlanTable, null);
+    } else if (!hasPlannedRange.length) {
+      this.errors.pushObject({
+        message:
+          'Minstens één gepland bereik veld moet een waarde groter dan 0 bevatten.',
+      });
+      this.updateTripleObject(this.planTableSubject, validPlanTable, null);
+    } else {
+      this.updateTripleObject(
+        this.planTableSubject,
+        totalContributionPredicate,
+        this.totalContribution
+      );
+      this.updateTripleObject(this.planTableSubject, validPlanTable, true);
+    }
+  }
+}

--- a/app/components/rdf-form-fields/plan-living-together-table/show.hbs
+++ b/app/components/rdf-form-fields/plan-living-together-table/show.hbs
@@ -1,0 +1,490 @@
+<div class="au-u-margin-bottom">
+  <AuHeading @level="3" @skin="6">Hieronder vind je alle acties die gesubsidieerd worden door het Plan Samenleven.</AuHeading>
+  <AuHelpText class="au-c-content">
+    <ul>
+      <li>Geef in de tweede kolom aan wat het huidige bereik is voor deze actie (zonder middelen van het Plan Samenleven). Dit moet enkel ingevuld worden als jullie zich voor deze actie engageren.</li>
+      <li>Geef in de derde kolom aan welke bijkomende doelstellingen jullie bestuur wenst te realiseren voor het Plan Samenleven. Enkel deze bijkomende acties komen in aanmerking voor subsidiëring door de Vlaamse overheid.</li>
+      <li>In de vierde kolom ziet u het bedrag dat in aanmerking komt voor subsidiëring door de Vlaamse overheid. Er wordt verwacht dat het bestuur voor deze acties evenveel investeert.</li>
+      <li>Geef in de vierde kolom aan de hand van cijfers aan wat de prioriteit is per actie waarop het bestuur bijkomend inzet. Wanneer er niet voldoende middelen zijn, zal de Vlaamse overheid aan de hand van deze prioritering bepalen naar welke acties de subsidies gaan. Wanneer jullie bestuur intekent voor bv. 5 acties, dan moeten de nummers 1 t.e.m. 5 verdeeld worden over deze acties.</li>
+    </ul>
+  </AuHelpText>
+</div>
+
+<AuLabel for={{this.inputFor}}>
+  {{@field.label}}
+</AuLabel>
+
+<table class="data-table data-table--zebra data-table--tight au-u-margin-top-small">
+  <caption class="au-u-hidden-visually">Algemene beleidsdoelstellingen</caption>
+  <thead>
+    <tr>
+      <th scope="col">
+        Vlaamse doelstellingen Plan Samenleven
+      </th>
+      <th scope="col">
+        Jullie huidige gemeentelijk bereik <br>
+        <span class="au-u-regular">(enkel invullen als jullie bijkomende acties doen)</span>
+      </th>
+      <th scope="col">
+        Jullie gepland bereik in kader van het Plan Samenleven
+      </th>
+      <th scope="col">
+        Bijdrage Vlaanderen
+        <span class="au-u-regular">(er wordt verwacht dat het bestuur hetzelfde bedrag bijdraagt)</span>
+      </th>
+      <th scope="col">
+        Prioritering
+        <span class="au-u-regular">(iedere doelstelling moet een aparte prioriteit hebben: 1, 2, 3 ...)</span>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/7f7f1d20-942d-48ac-85a0-748db7f3d835"
+      @rangeLabel="lokaal actieplan"
+      @maxRange={{1}}
+      @multiplier={{12500}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Veiligheid en leefbaarheid:
+        </AuHeading>
+        <p>
+          Ontwikkelen van een lokaal actieplan voor de aanpak van polarisatie en zetten in op de uitrol ervan.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/f8be95d1-b262-4a7c-8bfb-e77c115d42c6"
+      @rangeLabel="volwassen anderstaligen"
+      @maxRange={{2250}}
+      @multiplier={{60}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Nederlands
+        </AuHeading>
+        <p>
+          Volwassen anderstaligen nemen deel aan een oefenkans.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/ba162648-8286-4c36-bce3-03b816069b28"
+      @rangeLabel="begeleide personen"
+      @maxRange={{23}}
+      @multiplier={{600}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Competenties
+        </AuHeading>
+        <p>
+          Begeleiden van personen met een diploma van buiten de EU naar verkorte opleidingstrajecten.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/15217ddf-e56a-4529-9352-f0c82d433546"
+      @rangeLabel="kwetsbare kinderen"
+      @maxRange={{150}}
+      @multiplier={{650}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Competenties
+        </AuHeading>
+        <p>
+          Begeleiden van kwetsbare kinderen naar hogere studies.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/55a23203-794a-4680-8223-cae33b01ad8e"
+      @rangeLabel="ongekwalificeerde uitstromers"
+      @maxRange={{150}}
+      @multiplier={{650}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Competenties
+        </AuHeading>
+        <p>
+          Begeleiden van ongekwalificeerde uitstromers naar een kwalificerend traject.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/bd57a052-8744-402b-bdcb-19d0c386ff54"
+      @rangeLabel="begeleide nieuwkomers"
+      @maxRange={{150}}
+      @multiplier={{650}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Werk
+        </AuHeading>
+        <p>
+          Begeleiden van nieuwkomers, mensen met een handicap en 55plussers naar de arbeidsmarkt.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/a7643e23-3eee-477c-baf4-bd1eb93d9aa5"
+      @rangeLabel="begeleide personen met een handicap"
+      @maxRange={{38}}
+      @multiplier={{650}}
+      @onUpdateRow={{this.validate}}
+    />
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/88388d78-f277-43ee-963e-6e111fc28d46"
+      @rangeLabel="begeleide 55-plussers"
+      @maxRange={{75}}
+      @multiplier={{650}}
+      @onUpdateRow={{this.validate}}
+    />
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/6b8a5a4e-c1f8-40c7-9a23-7b589aede212"
+      @rangeLabel="begeleide nieuwkomers"
+      @maxRange={{75}}
+      @multiplier={{650}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Werk
+        </AuHeading>
+        <p>
+          Begeleiden van nieuwkomers, vrouwen en personen met een handicap naar ondernemerschap
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/8bae2cec-4b7c-4e16-acc2-e747d9e3b853"
+      @rangeLabel="begeleide vrouwen"
+      @maxRange={{30}}
+      @multiplier={{650}}
+      @onUpdateRow={{this.validate}}
+    />
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/619edfa8-0004-45d3-af51-7faf71d477d5"
+      @rangeLabel="begeleide personen met een handicap"
+      @maxRange={{15}}
+      @multiplier={{650}}
+      @onUpdateRow={{this.validate}}
+    />
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/ec887ea5-83ee-4782-866c-1ddedd6d7ed0"
+      @rangeLabel="begeleide personen van buitenlandse herkomst"
+      @maxRange={{300}}
+      @multiplier={{320}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Werk
+        </AuHeading>
+        <p>
+          Inzet van mentoren die jonge personen van buitenlandse herkomst begeleiden naar werk.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/80dd881d-9706-40be-8f0b-fe97d69fa00d"
+      @rangeLabel="jongeren van buitenlandse herkomst"
+      @maxRange={{150}}
+      @multiplier={{210}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Netwerk
+        </AuHeading>
+        <p>
+          Jongeren van buitenlandse herkomst en jongeren met een handicap in contact brengen met sport.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/c5719bb2-e567-433c-ae6b-f99ff5c98897"
+      @rangeLabel="personen met een handicap"
+      @maxRange={{30}}
+      @multiplier={{210}}
+      @onUpdateRow={{this.validate}}
+    />
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/5faefdda-75aa-45cd-acd4-1ee051e806fd"
+      @rangeLabel="jongeren met grotere afstand tot de arbeidsmarkt"
+      @maxRange={{180}}
+      @multiplier={{210}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Netwerk
+        </AuHeading>
+        <p>
+          Jongeren met een grotere afstand tot de arbeidsmarkt in contact brengen met opleidingen, stages, jobs en ondernemerschap
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/2b415839-747b-4514-a3f2-d02ca4303be4"
+      @rangeLabel="kwetsbare gezinnen"
+      @maxRange={{300}}
+      @multiplier={{320}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Netwerk
+        </AuHeading>
+        <p>
+          Inzetten van brugfiguren die de brug maken tussen kwetsbare gezinnen en onderwijs.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/7fbac258-3c1c-44a1-8db0-ffcdcb6a3113"
+      @rangeLabel="lokaal actieplan"
+      @maxRange={{1}}
+      @multiplier={{25000}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Non-discriminatie
+        </AuHeading>
+        <p>
+          Ontwikkelen van lokale actieplannen voor de aanpak van straatintimidatie en de uitrol ervan.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/0b0d5a3a-0c10-4acf-9a94-fd4e881444bc"
+      @rangeLabel="gevormde professionals"
+      @maxRange={{150}}
+      @multiplier={{90}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Non-discriminatie
+        </AuHeading>
+        <p>
+          Vormen van professionals en burgers volgens het omstaanders-principe
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/f7c0a231-e418-4f38-8f73-3815a22f518b"
+      @rangeLabel="gevormde burgers"
+      @maxRange={{150}}
+      @multiplier={{90}}
+      @onUpdateRow={{this.validate}}
+    />
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/a419be41-704b-488d-b7c1-86d50a8a46ce"
+      @rangeLabel="lokaal actieplan"
+      @maxRange={{1}}
+      @multiplier={{25000}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Non-discriminatie
+        </AuHeading>
+        <p>
+          Ontwikkelen van lokale actieplannen voor de toegankelijkheid van publieke gebouwen en de uitrol ervan.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/fea603c6-dc87-4c09-bb85-3520cc1c495d"
+      @rangeLabel="bestuur dat correspondentietesten inzet"
+      @maxRange={{1}}
+      @multiplier={{25000}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          Non-discriminatie
+        </AuHeading>
+        <p>
+          Inzetten van correspondentietesten om discriminatie te meten
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/f732ab43-ea22-4590-b3a4-6617cff64777"
+      @rangeLabel="begeleide gezinnen"
+      @maxRange={{300}}
+      @multiplier={{170}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          1 gemeenschap
+        </AuHeading>
+        <p>
+          Begeleiden van gezinnen om de sociale mix in scholen te bevorderen
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/5fcf7a3a-04b7-46e7-9449-2088656c555b"
+      @rangeLabel="jongeren van buitenlandse herkomst"
+      @maxRange={{15}}
+      @multiplier={{650}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          1 gemeenschap
+        </AuHeading>
+        <p>
+          Begeleiden van jongeren van buitenlandse herkomst en personen met een handicap tot een lerarenopleiding.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/2f7db13f-b710-4b94-92c8-efcf8eac1ead"
+      @rangeLabel="jongeren met een handicap"
+      @maxRange={{8}}
+      @multiplier={{650}}
+      @onUpdateRow={{this.validate}}
+    />
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/fd1882a8-996c-42a8-8774-0a7a453f5c70"
+      @rangeLabel="pleinmakers"
+      @maxRange={{4}}
+      @multiplier={{5800}}
+      @onUpdateRow={{this.validate}}
+
+      >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          1 gemeenschap
+        </AuHeading>
+        <p>
+          Inzetten van pleinmakers in sociale woonwijken om het sociaal weefsel te versterken.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/e4effa35-4453-426a-95af-17767e23ed64"
+      @rangeLabel="jongeren van buitenlandse herkomst "
+      @maxRange={{150}}
+      @multiplier={{210}}
+      @onUpdateRow={{this.validate}}
+    >
+      <:description>
+        <AuHeading  @level="4" @skin="6">
+          1 gemeenschap
+        </AuHeading>
+        <p>
+          Jongeren van buitenlandse herkomst en jongeren met een handicap in contact brengen met cultuur.
+        </p>
+      </:description>
+    </RdfFormFields::PlanLivingTogetherTable::TableRow>
+    <RdfFormFields::PlanLivingTogetherTable::TableRow
+      @disabled={{true}}
+      @storeOptions={{this.storeOptions}}
+      @planTableSubject={{this.planTableSubject}}
+      @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/56e523bd-ad3c-4648-94b0-df6d9e72c7b0"
+      @rangeLabel="jongeren met een handicap"
+      @maxRange={{30}}
+      @multiplier={{210}}
+      @onUpdateRow={{this.validate}}
+    />
+  </tbody>
+</table>
+
+<div class="au-u-margin-top">
+  <div>Totale bijdrage lokaal bestuur = <span class="au-u-medium">{{convert-to-currency this.totalContribution}}</span></div>
+  <div>Totale bijdrage Vlaamse overheid indien voldoende middelen beschikbaar = <span class="au-u-medium">{{convert-to-currency this.totalContribution}}</span></div>
+</div>

--- a/app/components/rdf-form-fields/plan-living-together-table/show.js
+++ b/app/components/rdf-form-fields/plan-living-together-table/show.js
@@ -1,0 +1,3 @@
+import RdfFormFieldsPlanLivingTogetherTableEditComponent from './edit';
+
+export default class RdfFormFieldsPlanLivingTogetherTableShowComponent extends RdfFormFieldsPlanLivingTogetherTableEditComponent {}

--- a/app/components/rdf-form-fields/plan-living-together-table/table-row.hbs
+++ b/app/components/rdf-form-fields/plan-living-together-table/table-row.hbs
@@ -1,0 +1,55 @@
+<tr>
+  <th scope="row" class="au-u-regular">
+    {{yield to="description"}}
+  </th>
+  <td>
+    <AuInput
+      @disabled={{@disabled}}
+      @width="block"
+      @value={{this.currentRange}}
+      @error={{if this.currentRangeErrors true false}}
+      @type="number"
+      lang="nl-BE"
+      {{on "blur" this.update}}
+    />
+    <div class="au-u-margin-top-tiny">{{@rangeLabel}}</div>
+
+    {{#each this.currentRangeErrors as |error|}}
+      <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+    {{/each}}
+  </td>
+  <td>
+    <AuInput
+      @disabled={{@disabled}}
+      @width="block"
+      @value={{this.plannedRange}}
+      @error={{if this.plannedRangeErrors true false}}
+      @type="number"
+      lang="nl-BE"
+      {{on "blur" this.update}}
+    />
+    <div class="au-u-margin-top-tiny">{{@rangeLabel}} (max. {{@maxRange}})</div>
+
+    {{#each this.plannedRangeErrors as |error|}}
+      <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+    {{/each}}
+  </td>
+  <td>
+    {{convert-to-currency this.contribution}}
+  </td>
+  <td>
+    <AuInput
+      @disabled={{@disabled}}
+      @width="block"
+      @value={{this.priority}}
+      @error={{if this.priorityErrors true false}}
+      @type="number"
+      lang="nl-BE"
+      {{on "blur" this.update}}
+    />
+
+    {{#each this.priorityErrors as |error|}}
+      <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+    {{/each}}
+  </td>
+</tr>

--- a/app/components/rdf-form-fields/plan-living-together-table/table-row.js
+++ b/app/components/rdf-form-fields/plan-living-together-table/table-row.js
@@ -1,0 +1,387 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { A } from '@ember/array';
+import { action } from '@ember/object';
+import rdflib from 'browser-rdflib';
+import { scheduleOnce } from '@ember/runloop';
+import { v4 as uuidv4 } from 'uuid';
+import { RDF, XSD } from '@lblod/submission-form-helpers';
+
+const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+
+const planBaseUri =
+  'http://lblod.data.gift/vocabularies/subsidie/plan-samenleven/';
+const planTableBaseUri = 'http://data.lblod.info/plan-living-together-tables';
+
+const tableEntryBaseUri =
+  'http://data.lblod.info/id/plan-living-together-table/row-entry';
+const PlanEntryType = new rdflib.NamedNode(
+  `${planBaseUri}PlanLivingTogetherEntry`
+);
+const planEntryPredicate = new rdflib.NamedNode(
+  `${planBaseUri}planLivingTogetherEntry`
+);
+const descriptionPredicate = new rdflib.NamedNode(`${planBaseUri}description`);
+const currentRangePredicate = new rdflib.NamedNode(
+  `${planBaseUri}currentRange`
+);
+const plannedRangePredicate = new rdflib.NamedNode(
+  `${planBaseUri}plannedRange`
+);
+const contributionPredicate = new rdflib.NamedNode(
+  `${planBaseUri}contribution`
+);
+const priorityPredicate = new rdflib.NamedNode(`${planBaseUri}priority`);
+const hasInvalidRowPredicate = new rdflib.NamedNode(
+  `${planTableBaseUri}hasInvalidPlanLivingTogetherTableEntry`
+);
+
+export default class RdfFormFieldsPlanLivingTogetherTableTableRowComponent extends Component {
+  @tracked tableEntryUri = null;
+  @tracked currentRange = null;
+  @tracked plannedRange = null;
+  @tracked priority = null;
+
+  @tracked currentRangeErrors = A();
+  @tracked plannedRangeErrors = A();
+  @tracked priorityErrors = A();
+
+  get storeOptions() {
+    return this.args.storeOptions;
+  }
+
+  get planTableSubject() {
+    return this.args.planTableSubject;
+  }
+
+  get businessRuleUri() {
+    return new rdflib.NamedNode(this.args.businessRuleUriStr);
+  }
+
+  get onUpdateRow() {
+    return this.args.onUpdateRow;
+  }
+
+  get multiplier() {
+    return this.args.multiplier;
+  }
+
+  get maxRange() {
+    return this.args.maxRange;
+  }
+
+  get contribution() {
+    return this.plannedRange * this.multiplier;
+  }
+
+  constructor() {
+    super(...arguments);
+    scheduleOnce('actions', this, this.initializeTableRow);
+  }
+
+  initializeTableRow() {
+    if (this.hasValues()) {
+      this.loadProvidedValue();
+      this.onUpdateRow();
+    } else {
+      this.initializeDefault();
+    }
+  }
+
+  hasValues() {
+    const values = this.storeOptions.store.match(
+      null,
+      descriptionPredicate,
+      this.businessRuleUri,
+      this.storeOptions.sourceGraph
+    );
+    return values.length;
+  }
+
+  loadProvidedValue() {
+    const values = this.storeOptions.store.match(
+      null,
+      descriptionPredicate,
+      this.businessRuleUri,
+      this.storeOptions.sourceGraph
+    );
+    if (values.length > 1) {
+      throw `Expected single value for ${this.businessRuleUri}`;
+    } else {
+      this.setComponentValues(values[0].subject);
+    }
+  }
+
+  setComponentValues(subject) {
+    this.tableEntryUri = subject;
+
+    this.currentRange = this.storeOptions.store.match(
+      this.tableEntryUri,
+      currentRangePredicate,
+      null,
+      this.storeOptions.sourceGraph
+    )[0].object.value;
+    this.plannedRange = this.storeOptions.store.match(
+      this.tableEntryUri,
+      plannedRangePredicate,
+      null,
+      this.storeOptions.sourceGraph
+    )[0].object.value;
+    this.priority = this.storeOptions.store.match(
+      this.tableEntryUri,
+      priorityPredicate,
+      null,
+      this.storeOptions.sourceGraph
+    )[0].object.value;
+
+    this.convertInputValuesToNumbers();
+  }
+
+  initializeDefault() {
+    const uuid = uuidv4();
+    const tableEntryUri = new rdflib.NamedNode(`${tableEntryBaseUri}/${uuid}`);
+
+    let triples = [
+      {
+        subject: tableEntryUri,
+        predicate: RDF('type'),
+        object: PlanEntryType,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: tableEntryUri,
+        predicate: MU('uuid'),
+        object: uuid,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: this.planTableSubject,
+        predicate: planEntryPredicate,
+        object: tableEntryUri,
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: tableEntryUri,
+        predicate: descriptionPredicate,
+        object: this.businessRuleUri,
+        graph: this.storeOptions.sourceGraph,
+      },
+    ];
+
+    triples.push({
+      subject: tableEntryUri,
+      predicate: currentRangePredicate,
+      object: 0,
+      graph: this.storeOptions.sourceGraph,
+    });
+
+    triples.push({
+      subject: tableEntryUri,
+      predicate: plannedRangePredicate,
+      object: 0,
+      graph: this.storeOptions.sourceGraph,
+    });
+
+    triples.push({
+      subject: tableEntryUri,
+      predicate: priorityPredicate,
+      object: 0,
+      graph: this.storeOptions.sourceGraph,
+    });
+
+    this.storeOptions.store.addAll(triples);
+    this.setComponentValues(tableEntryUri);
+  }
+
+  updateTripleObject(subject, predicate, newObject = null) {
+    const triples = this.storeOptions.store.match(
+      subject,
+      predicate,
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+
+    this.storeOptions.store.removeStatements([...triples]);
+
+    if (newObject) {
+      this.storeOptions.store.addAll([
+        {
+          subject: subject,
+          predicate: predicate,
+          object: newObject,
+          graph: this.storeOptions.sourceGraph,
+        },
+      ]);
+    }
+  }
+
+  validateCurrentRange(currentRange) {
+    this.currentRangeErrors = A();
+
+    if (!this.isPositiveInteger(currentRange)) {
+      this.currentRangeErrors.pushObject({
+        message: 'De waarde moet groter of gelijk aan 0 zijn.',
+      });
+      this.updateTripleObject(
+        this.planTableSubject,
+        hasInvalidRowPredicate,
+        this.tableEntryUri
+      );
+      return false;
+    } else if (!this.isValidInteger(currentRange)) {
+      this.currentRangeErrors.pushObject({
+        message: 'De waarde moet een geheel getal vormen.',
+      });
+      this.updateTripleObject(
+        this.planTableSubject,
+        hasInvalidRowPredicate,
+        this.tableEntryUri
+      );
+      return false;
+    }
+  }
+
+  validatePlannedRange(plannedRange) {
+    this.plannedRangeErrors = A();
+
+    if (!this.isPositiveInteger(plannedRange)) {
+      this.plannedRangeErrors.pushObject({
+        message: 'De waarde moet groter of gelijk aan 0 zijn.',
+      });
+      this.updateTripleObject(
+        this.planTableSubject,
+        hasInvalidRowPredicate,
+        this.tableEntryUri
+      );
+      return false;
+    } else if (!this.isValidInteger(plannedRange)) {
+      this.plannedRangeErrors.pushObject({
+        message: 'De waarde moet een geheel getal vormen.',
+      });
+      this.updateTripleObject(
+        this.planTableSubject,
+        hasInvalidRowPredicate,
+        this.tableEntryUri
+      );
+      return false;
+    } else if (plannedRange > this.maxRange) {
+      this.plannedRangeErrors.pushObject({
+        message: `De waarde mag niet hoger liggen dan ${this.maxRange}.`,
+      });
+      this.updateTripleObject(
+        this.planTableSubject,
+        hasInvalidRowPredicate,
+        this.tableEntryUri
+      );
+      return false;
+    }
+  }
+
+  validatePriority(priority) {
+    this.priorityErrors = A();
+
+    if (this.plannedRange > 0 && this.priority == 0) {
+      this.priorityErrors.pushObject({
+        message: 'Gelieve een waarde groter dan 0 in te geven.',
+      });
+      this.updateTripleObject(
+        this.planTableSubject,
+        hasInvalidRowPredicate,
+        this.tableEntryUri
+      );
+      return false;
+    } else if (!this.isPositiveInteger(priority)) {
+      this.priorityErrors.pushObject({
+        message: 'De waarde moet groter of gelijk aan 0 zijn.',
+      });
+      this.updateTripleObject(
+        this.planTableSubject,
+        hasInvalidRowPredicate,
+        this.tableEntryUri
+      );
+      return false;
+    } else if (!this.isValidInteger(priority)) {
+      this.priorityErrors.pushObject({
+        message: 'De waarde moet een geheel getal vormen.',
+      });
+      this.updateTripleObject(
+        this.planTableSubject,
+        hasInvalidRowPredicate,
+        this.tableEntryUri
+      );
+      return false;
+    }
+  }
+
+  @action
+  update(e) {
+    if (e && typeof e.preventDefault === 'function') e.preventDefault();
+
+    this.updateTripleObject(
+      this.planTableSubject,
+      hasInvalidRowPredicate,
+      null
+    );
+
+    this.convertInputValuesToNumbers();
+
+    /** start validation **/
+    this.validateCurrentRange(this.currentRange);
+    this.validatePlannedRange(this.plannedRange);
+    this.validatePriority(this.priority);
+
+    if (this.currentRangeErrors.length) return this.onUpdateRow();
+    if (this.plannedRangeErrors.length) return this.onUpdateRow();
+    if (this.priorityErrors.length) return this.onUpdateRow();
+    /** end validation **/
+
+    this.updateTripleObject(
+      this.tableEntryUri,
+      currentRangePredicate,
+      rdflib.literal(this.currentRange, XSD('integer'))
+    );
+    this.updateTripleObject(
+      this.tableEntryUri,
+      plannedRangePredicate,
+      rdflib.literal(this.plannedRange, XSD('integer'))
+    );
+    this.updateTripleObject(
+      this.tableEntryUri,
+      contributionPredicate,
+      rdflib.literal(this.contribution, XSD('float'))
+    );
+    this.updateTripleObject(
+      this.tableEntryUri,
+      priorityPredicate,
+      rdflib.literal(this.priority, XSD('integer'))
+    );
+    this.setComponentValues(this.tableEntryUri);
+
+    return this.onUpdateRow();
+  }
+
+  /**
+   * Both rdflib and <Input>'s 2-way-binding return strings, so we convert everything to numbers
+   */
+  convertInputValuesToNumbers() {
+    this.currentRange = !isNaN(parseFloat(this.currentRange))
+      ? parseFloat(this.currentRange)
+      : 0;
+
+    this.plannedRange = !isNaN(parseFloat(this.plannedRange))
+      ? parseFloat(this.plannedRange)
+      : 0;
+
+    this.priority = !isNaN(parseFloat(this.priority))
+      ? parseFloat(this.priority)
+      : 0;
+  }
+
+  isPositiveInteger(value) {
+    return value >= 0;
+  }
+
+  isValidInteger(value) {
+    return value % 1 === 0;
+  }
+}

--- a/app/routes/subsidy/applications/edit.js
+++ b/app/routes/subsidy/applications/edit.js
@@ -1,9 +1,27 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { registerFormFields } from '@lblod/ember-submission-form-fields';
+import ApplicationFormTableEditComponent from 'frontend-loket/components/rdf-form-fields/application-form-table/edit';
+import ApplicationFormTableShowComponent from 'frontend-loket/components/rdf-form-fields/application-form-table/show';
+import ClimateSubsidyCostsTableComponent from 'frontend-loket/components/rdf-form-fields/climate-subsidy-costs-table';
+import EngagementTableEditComponent from 'frontend-loket/components/rdf-form-fields/engagement-table/edit';
+import EngagementTableShowComponent from 'frontend-loket/components/rdf-form-fields/engagement-table/show';
+import EstimatedCostEditComponent from 'frontend-loket/components/rdf-form-fields/estimated-cost-table/edit';
+import EstimatedCostShowComponent from 'frontend-loket/components/rdf-form-fields/estimated-cost-table/show';
+import ObjectiveTableEditComponent from 'frontend-loket/components/rdf-form-fields/objective-table/edit';
+import ObjectiveTableShowComponent from 'frontend-loket/components/rdf-form-fields/objective-table/show';
+import PlanLivingTogetherTableEditComponent from 'frontend-loket/components/rdf-form-fields/plan-living-together-table/edit';
+import PlanLivingTogetherTableShowComponent from 'frontend-loket/components/rdf-form-fields/plan-living-together-table/show';
 
 export default class SubsidyApplicationsEditRoute extends Route {
   @service store;
   @service currentSession;
+
+  constructor() {
+    super(...arguments);
+
+    this.registerTableFields();
+  }
 
   async model({ id: consumptionID }) {
     const consumption = await this.store.findRecord(
@@ -27,5 +45,42 @@ export default class SubsidyApplicationsEditRoute extends Route {
       consumption,
       organization: this.currentSession.group,
     };
+  }
+
+  registerTableFields() {
+    registerFormFields([
+      {
+        displayType:
+          'http://lblod.data.gift/display-types/applicationFormTable',
+        edit: ApplicationFormTableEditComponent,
+        show: ApplicationFormTableShowComponent,
+      },
+      {
+        displayType:
+          'http://lblod.data.gift/display-types/climateSubsidyCostTable',
+        edit: ClimateSubsidyCostsTableComponent,
+      },
+      {
+        displayType: 'http://lblod.data.gift/display-types/engagementTable',
+        edit: EngagementTableEditComponent,
+        show: EngagementTableShowComponent,
+      },
+      {
+        displayType: 'http://lblod.data.gift/display-types/estimatedCostTable',
+        edit: EstimatedCostEditComponent,
+        show: EstimatedCostShowComponent,
+      },
+      {
+        displayType: 'http://lblod.data.gift/display-types/objectiveTable',
+        edit: ObjectiveTableEditComponent,
+        show: ObjectiveTableShowComponent,
+      },
+      {
+        displayType:
+          'http://lblod.data.gift/display-types/planLivingTogetherTable',
+        edit: PlanLivingTogetherTableEditComponent,
+        show: PlanLivingTogetherTableShowComponent,
+      },
+    ]);
   }
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -11,6 +11,10 @@ module.exports = function (defaults) {
     'ember-simple-auth': {
       useSessionSetupMethod: true,
     },
+    '@lblod/ember-submission-form-fields': {
+      includeTableComponents: false,
+      includeSearchComponents: false,
+    },
   };
 
   if (process.env.EMBER_TEST_SELECTORS_STRIP == 'false') {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@glimmer/tracking": "^1.0.4",
     "@lblod/ember-acmidm-login": "^1.4.0",
     "@lblod/ember-mock-login": "^0.7.0",
-    "@lblod/ember-submission-form-fields": "^1.6.0",
+    "@lblod/ember-submission-form-fields": "^1.7.0",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "moment": "^2.29.1"
   },
   "devDependencies": {
-    "@appuniversum/ember-appuniversum": "^1.0.0",
+    "@appuniversum/ember-appuniversum": "^1.0.6",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.6.0",
     "@glimmer/component": "^1.0.4",


### PR DESCRIPTION
This moves over the custom table form fields from the `@lblod/ember-submission-form-fields` addon and registers them with the addon. This allows us to remove the components from the addon in the future.

Most of the file are simply copy pasted from the addon (with some minor renaming to make it work). The new code that needs to be reviewed is this file: [app/routes/subsidy/applications/edit.js](https://github.com/lblod/frontend-loket/pull/88/files#diff-cbaae15bb1529778752b4b7374f463d71e1e487fd5d62a4e44f134007c9bbf6c)

~~Draft since it requires a new release of the `@lblod/ember-submission-form-fields` addon with [this PR](https://github.com/lblod/ember-submission-form-fields/pull/70).~~ 1.7.0 has been released