### PR TITLE
Install the default helper manager polyfill

### DIFF
--- a/app/helpers/mandatenbeheer/display-rrn.js
+++ b/app/helpers/mandatenbeheer/display-rrn.js
@@ -1,10 +1,6 @@
-import { helper } from '@ember/component/helper';
+export default function mandatenbeheerDisplayRrn(rrn) {
+  if (rrn?.length !== 11) return '';
 
-export function mandatenbeheerDisplayRrn(params/*, hash*/) {
-  params = params[0];
-  if(!params || params.length !== 11)
-    return '';
-  return `${params.slice(0,2)}.${params.slice(2,4)}.${params.slice(4,6)}-${params.slice(6,9)}.${params.slice(9,11)}`;
+  // prettier-ignore
+  return `${rrn.slice(0,2)}.${rrn.slice(2,4)}.${rrn.slice(4,6)}-${rrn.slice(6,9)}.${rrn.slice(9,11)}`;
 }
-
-export default helper(mandatenbeheerDisplayRrn);

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "ember-concurrency": "^2.2.0",
     "ember-data": "~3.27.0",
     "ember-fetch": "^8.1.1",
+    "ember-functions-as-helper-polyfill": "^2.0.1",
     "ember-load-initializers": "^2.1.2",
     "ember-moment": "^9.0.0",
     "ember-mu-transform-helpers": "^2.1.2",


### PR DESCRIPTION
`ember-functions-as-helper-polyfill` is a polyfill for the "Default helper manager" feature that will soon be part of Ember. It allows us to use plain JavaScript functions as a helper which is a nice simplification.

I refactored 1 of the existing helpers to the new API. The others are either going to be replaced when the parent component is refactored, or no longer used.