### PR TITLE
Fix the `Route#transitionTo` deprecations

### DIFF
--- a/app/routes/bbcdr.js
+++ b/app/routes/bbcdr.js
@@ -3,11 +3,12 @@ import { inject as service } from '@ember/service';
 
 export default class BbcdrRoute extends Route {
   @service session;
-  @service() currentSession;
+  @service currentSession;
+  @service router;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
 
-    if (!this.currentSession.canAccessBbcdr) this.transitionTo('index');
+    if (!this.currentSession.canAccessBbcdr) this.router.transitionTo('index');
   }
 }

--- a/app/routes/berichtencentrum.js
+++ b/app/routes/berichtencentrum.js
@@ -2,12 +2,14 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class BerichtencentrumRoute extends Route {
-  @service() session;
-  @service() currentSession;
+  @service session;
+  @service currentSession;
+  @service router;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
 
-    if (!this.currentSession.canAccessBerichten) this.transitionTo('index');
+    if (!this.currentSession.canAccessBerichten)
+      this.router.transitionTo('index');
   }
 }

--- a/app/routes/leidinggevendenbeheer.js
+++ b/app/routes/leidinggevendenbeheer.js
@@ -4,12 +4,13 @@ import { inject as service } from '@ember/service';
 export default class LeidinggevendenbeheerRoute extends Route {
   @service session;
   @service currentSession;
+  @service router;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
 
     if (!this.currentSession.canAccessLeidinggevenden)
-      this.transitionTo('index');
+      this.router.transitionTo('index');
   }
 
   model() {

--- a/app/routes/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie.js
+++ b/app/routes/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie.js
@@ -2,7 +2,8 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class LeidinggevendenbeheerBestuursfunctiesBestuursfunctieRoute extends Route {
-  @service('current-session') currentSession;
+  @service currentSession;
+  @service router;
 
   async afterModel() {
     const bestuurseenheidClassificatie =
@@ -11,7 +12,7 @@ export default class LeidinggevendenbeheerBestuursfunctiesBestuursfunctieRoute e
       bestuurseenheidClassificatie.uri ===
       'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002'
     ) {
-      this.transitionTo('leidinggevendenbeheer.bestuursfuncties.index');
+      this.router.transitionTo('leidinggevendenbeheer.bestuursfuncties.index');
     }
   }
 

--- a/app/routes/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/functionarissen/index.js
+++ b/app/routes/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/functionarissen/index.js
@@ -6,7 +6,8 @@ export default class LeidinggevendenbeheerBestuursfunctiesBestuursfunctieFunctio
   DataTableRouteMixin
 ) {
   modelName = 'functionaris';
-  @service('current-session') currentSession;
+  @service currentSession;
+  @service router;
 
   async beforeModel() {
     const bestuurseenheidClassificatie =
@@ -15,7 +16,7 @@ export default class LeidinggevendenbeheerBestuursfunctiesBestuursfunctieFunctio
       bestuurseenheidClassificatie.uri ===
       'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002'
     ) {
-      this.transitionTo('leidinggevendenbeheer.bestuursfuncties.index');
+      this.router.transitionTo('leidinggevendenbeheer.bestuursfuncties.index');
     }
   }
 

--- a/app/routes/mandatenbeheer.js
+++ b/app/routes/mandatenbeheer.js
@@ -2,19 +2,19 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
 
-export default Route.extend({
-  currentSession: service(),
-  session: service(),
+export default class MandatenbeheerRoute extends Route {
+  @service currentSession;
+  @service session;
 
-  queryParams: {
+  queryParams = {
     startDate: { refreshModel: true },
-  },
+  };
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
 
     if (!this.currentSession.canAccessMandaat) this.transitionTo('index');
-  },
+  }
 
   async model(params) {
     this.startDate = params.startDate;
@@ -28,13 +28,13 @@ export default Route.extend({
       bestuursperioden: this.getBestuursperioden(bestuurseenheid.get('id')),
       startDate: this.startDate,
     });
-  },
+  }
 
   /*
    * Returns bestuursorgaan in tijd starting on the given start date
    * for all bestuursorganen of the given bestuurseenheid.
    */
-  getBestuursorganenInTijdByStartDate: async function (bestuurseenheidId) {
+  async getBestuursorganenInTijdByStartDate(bestuurseenheidId) {
     const bestuursorganen = await this.store.query('bestuursorgaan', {
       'filter[bestuurseenheid][id]': bestuurseenheidId,
       'filter[heeft-tijdsspecialisaties][:has:bevat]': true, // only organs with a political mandate
@@ -48,12 +48,9 @@ export default Route.extend({
       })
     );
     return organenStartingOnStartDate.filter((orgaan) => orgaan); // filter null values
-  },
+  }
 
-  getBestuursorgaanInTijdByStartDate: async function (
-    bestuursorgaanId,
-    startDate
-  ) {
+  async getBestuursorgaanInTijdByStartDate(bestuursorgaanId, startDate) {
     const queryParams = {
       page: { size: 1 },
       sort: '-binding-start',
@@ -64,17 +61,17 @@ export default Route.extend({
 
     const organen = await this.store.query('bestuursorgaan', queryParams);
     return organen.firstObject;
-  },
+  }
 
   /*
    * Get all the bestuursorganen in tijd of a bestuursorgaan with at least 1 political mandate.
    * @return Array of bestuursorganen in tijd ressembling the bestuursperiodes
    */
-  getBestuursperioden: async function (bestuurseenheidId) {
+  async getBestuursperioden(bestuurseenheidId) {
     return await this.store.query('bestuursorgaan', {
       'filter[is-tijdsspecialisatie-van][bestuurseenheid][id]':
         bestuurseenheidId,
       'filter[:has:bevat]': true, // only organs with a political mandate
     });
-  },
-});
+  }
+}

--- a/app/routes/mandatenbeheer.js
+++ b/app/routes/mandatenbeheer.js
@@ -5,6 +5,7 @@ import RSVP from 'rsvp';
 export default class MandatenbeheerRoute extends Route {
   @service currentSession;
   @service session;
+  @service router;
 
   queryParams = {
     startDate: { refreshModel: true },
@@ -13,7 +14,8 @@ export default class MandatenbeheerRoute extends Route {
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
 
-    if (!this.currentSession.canAccessMandaat) this.transitionTo('index');
+    if (!this.currentSession.canAccessMandaat)
+      this.router.transitionTo('index');
   }
 
   async model(params) {

--- a/app/routes/personeelsbeheer.js
+++ b/app/routes/personeelsbeheer.js
@@ -1,18 +1,18 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
-export default Route.extend({
-  currentSession: service(),
-  session: service(),
+export default class PersoneelsbeheerRoute extends Route {
+  @service currentSession;
+  @service session;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
 
     if (!this.currentSession.canAccessPersoneelsbeheer)
       this.transitionTo('index');
-  },
+  }
 
   model() {
     return this.currentSession.group; // bestuurseenheid
-  },
-});
+  }
+}

--- a/app/routes/personeelsbeheer.js
+++ b/app/routes/personeelsbeheer.js
@@ -4,12 +4,13 @@ import { inject as service } from '@ember/service';
 export default class PersoneelsbeheerRoute extends Route {
   @service currentSession;
   @service session;
+  @service router;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
 
     if (!this.currentSession.canAccessPersoneelsbeheer)
-      this.transitionTo('index');
+      this.router.transitionTo('index');
   }
 
   model() {

--- a/app/routes/personeelsbeheer/index.js
+++ b/app/routes/personeelsbeheer/index.js
@@ -1,7 +1,10 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class PersoneelsbeheerIndexRoute extends Route {
+  @service router;
+
   beforeModel() {
-    this.transitionTo('personeelsbeheer.personeelsaantallen.index');
+    this.router.transitionTo('personeelsbeheer.personeelsaantallen.index');
   }
 }

--- a/app/routes/personeelsbeheer/personeelsaantallen/latest.js
+++ b/app/routes/personeelsbeheer/personeelsaantallen/latest.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class PersoneelsbeheerPersoneelsaantallenLatestRoute extends Route {
+  @service router;
+
   async model(params) {
     this.set('datasetId', params.dataset_id);
     const periods = await this.store.query('employee-period-slice', {
@@ -12,7 +15,7 @@ export default class PersoneelsbeheerPersoneelsaantallenLatestRoute extends Rout
   }
 
   afterModel(model) {
-    this.transitionTo(
+    this.router.transitionTo(
       'personeelsbeheer.personeelsaantallen.periodes.edit',
       this.datasetId,
       model.id

--- a/app/routes/subsidy.js
+++ b/app/routes/subsidy.js
@@ -4,10 +4,12 @@ import { inject as service } from '@ember/service';
 export default class SubsidyRoute extends Route {
   @service session;
   @service currentSession;
+  @service router;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
 
-    if (!this.currentSession.canAccessSubsidies) this.transitionTo('index');
+    if (!this.currentSession.canAccessSubsidies)
+      this.router.transitionTo('index');
   }
 }

--- a/app/routes/supervision.js
+++ b/app/routes/supervision.js
@@ -4,9 +4,11 @@ import { inject as service } from '@ember/service';
 export default class SupervisionRoute extends Route {
   @service session;
   @service currentSession;
+  @service router;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentSession.canAccessToezicht) this.transitionTo('index');
+    if (!this.currentSession.canAccessToezicht)
+      this.router.transitionTo('index');
   }
 }

--- a/app/routes/supervision/submissions/edit.js
+++ b/app/routes/supervision/submissions/edit.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { warn } from '@ember/debug';
+import { inject as service } from '@ember/service';
 import rdflib from 'browser-rdflib';
 import fetch from 'fetch';
 import { ForkingStore } from '@lblod/ember-submission-form-fields';
@@ -9,6 +10,8 @@ const RDF = new rdflib.Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#');
 const FORM = new rdflib.Namespace('http://lblod.data.gift/vocabularies/forms/');
 
 export default class SupervisionSubmissionsEditRoute extends Route {
+  @service router;
+
   async model(params) {
     // Fetch data from backend
 
@@ -20,7 +23,7 @@ export default class SupervisionSubmissionsEditRoute extends Route {
       warn('No submission document, Transitioning to index.', {
         id: 'no-submission-document',
       });
-      this.transitionTo('supervision.submissions');
+      this.router.transitionTo('supervision.submissions');
     }
 
     const response = await fetch(`/submission-forms/${submissionDocument.id}`);

--- a/app/routes/supervision/submissions/new.js
+++ b/app/routes/supervision/submissions/new.js
@@ -4,6 +4,7 @@ import { CONCEPT_STATUS } from '../../../models/submission-document-status';
 
 export default class SupervisionSubmissionsNewRoute extends Route {
   @service currentSession;
+  @service router;
 
   async beforeModel() {
     const conceptStatuses = await this.store.query(
@@ -41,6 +42,6 @@ export default class SupervisionSubmissionsNewRoute extends Route {
   }
 
   afterModel(model) {
-    this.transitionTo('supervision.submissions.edit', model.id);
+    this.router.transitionTo('supervision.submissions.edit', model.id);
   }
 }


### PR DESCRIPTION
Route#transitionTo was deprecated in Ember 3.26.

More information: https://deprecations.emberjs.com/v3.x#toc_routing-transition-methods