### PR TITLE
Resolve `AuAlert` deprecation warnings

### DIFF
--- a/.lint-todo
+++ b/.lint-todo
@@ -98,7 +98,7 @@ add|ember-template-lint|no-html-comments|156|8|156|8|56dc5dee5280d5ba2ca9db1e1ad
 add|ember-template-lint|no-html-comments|166|8|166|8|f8c3ee9e8499efd34cab711f2da99c1c2fc28b1b|1649980800000|||app/templates/subsidy/applications/edit/step/edit.hbs
 add|ember-template-lint|no-html-comments|176|8|176|8|08f6fb89e624ced332e22803d2f27ec8fd3bb394|1649980800000|||app/templates/subsidy/applications/edit/step/edit.hbs
 add|ember-template-lint|no-html-comments|186|8|186|8|b22a97a8e2d6a0b2c0b6630b09f0b9cae9d86a89|1649980800000|||app/templates/subsidy/applications/edit/step/edit.hbs
-add|ember-template-lint|no-negated-condition|35|6|35|6|b3bae55ef640fcf0f48029ae328b0c3b1bacfe61|1649980800000|||app/templates/subsidy/applications/edit/step/edit.hbs
 add|ember-template-lint|simple-unless|46|6|46|6|02b279bc993a1ee6632c7e6edf341a2aabc519cb|1649980800000|||app/templates/subsidy/applications/edit/step/edit.hbs
 add|ember-template-lint|simple-unless|134|8|134|8|02b279bc993a1ee6632c7e6edf341a2aabc519cb|1649980800000|||app/templates/subsidy/applications/edit/step/edit.hbs
+add|ember-template-lint|no-negated-condition|35|6|35|6|2f3f9a1f9d0f83a049f115cd21d2e111e8e79b55|1650931200000|||app/templates/subsidy/applications/edit/step/edit.hbs
 add|ember-template-lint|no-action|11|24|11|24|ddedce34a8333bd81cbc747afcadd4a6a78eac1d|1650931200000|||app/components/personeelsbeheer/employee-observation-table-cell.hbs

--- a/app/components/bbcdr/report-edit.hbs
+++ b/app/components/bbcdr/report-edit.hbs
@@ -34,9 +34,9 @@
       {{/if}}
 
       {{#if this.showError}}
-      <AuAlert @alertIcon="alert-triangle"
-        @alertTitle="Er is een fout opgetreden tijdens het opslaan, gelieve opnieuw te proberen of de systeembeheerder te contacteren."
-        @alertskin="error" class="au-u-margin-top-tiny" />
+      <AuAlert @icon="alert-triangle"
+        @title="Er is een fout opgetreden tijdens het opslaan, gelieve opnieuw te proberen of de systeembeheerder te contacteren."
+        @skin="error" class="au-u-margin-top-tiny" />
       {{/if}}
     </div>
 
@@ -55,7 +55,7 @@
       </AuButtonGroup>
       {{else}}
       {{#unless @report.status.isConcept}}
-      <AuAlert @alertIcon="check" @alertTitle="Rapport verstuurd" @alertsize="small" @alertskin="success" data-test-loket="bbcdr-already-submitted-message" />
+      <AuAlert @icon="check" @title="Rapport verstuurd" @size="small" @skin="success" data-test-loket="bbcdr-already-submitted-message" />
       {{/unless}}
       <AuButtonGroup>
         {{#if @report.status.isConcept}}

--- a/app/components/login-button.hbs
+++ b/app/components/login-button.hbs
@@ -12,10 +12,10 @@
 
   {{#if acmidm.errorMessage}}
     <AuAlert
-      @alertIcon="alert-triangle"
-      @alertSize="small"
-      @alertTitle={{acmidm.errorMessage}}
-      @alertSkin="error"
+      @icon="alert-triangle"
+      @size="small"
+      @title={{acmidm.errorMessage}}
+      @skin="error"
       class={{unless @isCompact "au-u-margin-top-small"}}
     />
   {{/if}}

--- a/app/components/mandatenbeheer/mandataris-edit.hbs
+++ b/app/components/mandatenbeheer/mandataris-edit.hbs
@@ -97,10 +97,10 @@
 
       <div class="au-u-margin-top">
         {{#if this.requiredFieldError}}
-          <AuAlert @alertIcon="alert-triangle" @alertTitle={{this.requiredFieldError}} @alertskin="error" @alertsize="small" />
+          <AuAlert @icon="alert-triangle" @title={{this.requiredFieldError}} @skin="error" @size="small" />
         {{/if}}
         {{#if this.saveError}}
-          <AuAlert @alertIcon="alert-triangle" @alertTitle="Er is een fout opgetreden tijdens het opslaan, gelieve opnieuw te proberen of de systeembeheerder te contacteren." @alertskin="error" @alertsize="small" />
+          <AuAlert @icon="alert-triangle" @title="Er is een fout opgetreden tijdens het opslaan, gelieve opnieuw te proberen of de systeembeheerder te contacteren." @skin="error" @size="small" />
         {{/if}}
         {{#if this.save.isRunning}}
           <AuLoader @padding="small" />
@@ -160,10 +160,10 @@
       </div>
       <div class="au-u-margin-top">
         {{#if this.requiredFieldError}}
-          <AuAlert @alertIcon="alert-triangle" @alertTitle={{this.requiredFieldError}} @alertskin="error" @alertsize="small" />
+          <AuAlert @icon="alert-triangle" @title={{this.requiredFieldError}} @skin="error" @size="small" />
         {{/if}}
         {{#if this.saveError}}
-          <AuAlert @alertIcon="alert-triangle" @alertTitle="Er is een fout opgetreden tijdens het opslaan, gelieve opnieuw te proberen of de systeembeheerder te contacteren." @alertskin="error" @alertsize="small" />
+          <AuAlert @icon="alert-triangle" @title="Er is een fout opgetreden tijdens het opslaan, gelieve opnieuw te proberen of de systeembeheerder te contacteren." @skin="error" @size="small" />
         {{/if}}
         {{#if this.save.isRunning}}
           <AuLoader @padding="small" />
@@ -264,10 +264,10 @@
 
       <div class="au-u-margin-top">
         {{#if this.requiredFieldError}}
-          <AuAlert @alertIcon="alert-triangle" @alertTitle={{this.requiredFieldError}} @alertskin="error" @alertsize="small" />
+          <AuAlert @icon="alert-triangle" @title={{this.requiredFieldError}} @skin="error" @size="small" />
         {{/if}}
         {{#if this.saveError}}
-          <AuAlert @alertIcon="alert-triangle" @alertTitle="Er is een fout opgetreden tijdens het opslaan, gelieve opnieuw te proberen of de systeembeheerder te contacteren." @alertskin="error" @alertsize="small" />
+          <AuAlert @icon="alert-triangle" @title="Er is een fout opgetreden tijdens het opslaan, gelieve opnieuw te proberen of de systeembeheerder te contacteren." @skin="error" @size="small" />
         {{/if}}
         {{#if this.save.isRunning}}
           <AuLoader @padding="small" />

--- a/app/components/shared/persoon/create-persoon.hbs
+++ b/app/components/shared/persoon/create-persoon.hbs
@@ -127,10 +127,10 @@
       </div>
       {{#if this.errors.save}}
         <AuAlert
-          @alertIcon="alert-triangle"
-          @alertTitle="Fout bij opslaan"
-          @alertSkin="error"
-          @alertSize="small"
+          @icon="alert-triangle"
+          @title="Fout bij opslaan"
+          @skin="error"
+          @size="small"
         >
           <p>{{this.errors.save}}</p>
         </AuAlert>

--- a/app/components/shared/persoon/persoon-search-form.hbs
+++ b/app/components/shared/persoon/persoon-search-form.hbs
@@ -54,7 +54,7 @@
 <div class="au-c-body-container au-c-body-container--scroll">
   <div class="au-o-box">
     {{#if this.error}}
-      <AuAlert @alertIcon="alert-triangle" @alertTitle="Fout bij het zoeken, gelieve opnieuw te proberen" @alertskin="warning">
+      <AuAlert @icon="alert-triangle" @title="Fout bij het zoeken, gelieve opnieuw te proberen" @skin="warning">
         <p class="au-u-margin-top-small">
           <AuButton {{on 'click' this.toggleError}}>OK</AuButton>
         </p>
@@ -89,7 +89,7 @@
             {{/each}}
           </ul>
 
-          <AuAlert @alertTitle="Komt het zoekresultaat niet overeen met wat u zocht?" @alertskin="info" @alertsize="tiny" class="au-u-margin-top-small">
+          <AuAlert @title="Komt het zoekresultaat niet overeen met wat u zocht?" @skin="info" @size="tiny" class="au-u-margin-top-small">
             <p>
               Kijk uw zoekopdracht na of
               <AuButton @skin="tertiary" {{on 'click' @onCreateNewPerson}} class="au-c-link">
@@ -99,7 +99,7 @@
             </p>
           </AuAlert>
         {{else}}
-          <AuAlert @alertTitle='"{{this.searchTerms}}" bestaat mogelijk nog niet.' @alertskin="info" @alertsize="tiny">
+          <AuAlert @title='"{{this.searchTerms}}" bestaat mogelijk nog niet.' @skin="info" @size="tiny">
             <p>
               Kijk uw zoekopdracht na of
               <AuButton @skin="tertiary" {{on 'click' @onCreateNewPerson}} class="au-c-link">

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -25,7 +25,7 @@
                 <AuButton {{on 'click' this.goToToezicht}}>Ga naar toezicht</AuButton>
               </p>
             {{else}}
-              <AuAlert @alertTitle="Geen toegang." @alertskin="info" @alertsize="tiny">
+              <AuAlert @title="Geen toegang." @skin="info" @size="tiny">
                 Neem contact op met uw interne beheerder om toegang te verkrijgen.
               </AuAlert>
             {{/if}}
@@ -59,7 +59,7 @@
                 <AuButton {{on 'click' this.goToBerichtencentrum}}>Ga naar berichtencentrum</AuButton>
               </p>
             {{else}}
-              <AuAlert @alertTitle="Geen toegang." @alertskin="info" @alertsize="tiny">
+              <AuAlert @title="Geen toegang." @skin="info" @size="tiny">
                 Neem contact op met uw interne beheerder om toegang te verkrijgen.
               </AuAlert>
             {{/if}}
@@ -93,7 +93,7 @@
                 <AuButton {{on 'click' this.goToBbcdr}}>Ga naar BBC DR</AuButton>
               </p>
             {{else}}
-              <AuAlert @alertTitle="Geen toegang." @alertskin="info" @alertsize="tiny">
+              <AuAlert @title="Geen toegang." @skin="info" @size="tiny">
                 Neem contact op met uw interne beheerder om toegang te verkrijgen.
               </AuAlert>
             {{/if}}
@@ -127,7 +127,7 @@
                 <AuButton {{on 'click' this.goToMandatenbeheer}}>Ga naar mandatenbeheer</AuButton>
               </p>
             {{else}}
-              <AuAlert @alertTitle="Geen toegang." @alertskin="info" @alertsize="tiny">
+              <AuAlert @title="Geen toegang." @skin="info" @size="tiny">
                 Neem contact op met uw interne beheerder om toegang te verkrijgen.
               </AuAlert>
             {{/if}}
@@ -161,7 +161,7 @@
                 <AuButton {{on 'click' this.goToLeidinggevendenbeheer}}>Ga naar leidinggevendenbeheer</AuButton>
               </p>
             {{else}}
-              <AuAlert @alertTitle="Geen toegang." @alertskin="info" @alertsize="tiny">
+              <AuAlert @title="Geen toegang." @skin="info" @size="tiny">
                 Neem contact op met uw interne beheerder om toegang te verkrijgen.
               </AuAlert>
             {{/if}}
@@ -195,7 +195,7 @@
                 <AuButton {{on 'click' this.goToPersoneelsbeheer}}>Ga naar personeelsbeheer</AuButton>
               </p>
             {{else}}
-              <AuAlert @alertTitle="Geen toegang." @alertskin="info" @alertsize="tiny">
+              <AuAlert @title="Geen toegang." @skin="info" @size="tiny">
                 Neem contact op met uw interne beheerder om toegang te verkrijgen.
               </AuAlert>
             {{/if}}
@@ -224,7 +224,7 @@
                 <AuButton {{on 'click' this.goToSubsidiebeheer}}>Ga naar subsidiebeheer</AuButton>
               </p>
             {{else}}
-              <AuAlert @alertTitle="Geen toegang." @alertskin="info" @alertsize="tiny">
+              <AuAlert @title="Geen toegang." @skin="info" @size="tiny">
                 Neem contact op met uw interne beheerder om toegang te verkrijgen.
               </AuAlert>
             {{/if}}

--- a/app/templates/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/functionarissen/edit.hbs
+++ b/app/templates/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/functionarissen/edit.hbs
@@ -6,7 +6,7 @@
 
 <Leidinggevendenbeheer::FunctionarisForm @model={{this.model}} as |isValid| >
   <div class="au-o-box">
-    <AuAlert @alertIcon="info-circle">
+    <AuAlert @icon="info-circle">
       <AuContent @skin="small">
         <p>Hou de <strong>historiek</strong> van afgelopen aanstellingsperiodes bij.</p>
         <ul>

--- a/app/templates/leidinggevendenbeheer/bestuursfuncties/index.hbs
+++ b/app/templates/leidinggevendenbeheer/bestuursfuncties/index.hbs
@@ -9,7 +9,7 @@
 <div class="au-c-body-container au-c-body-container--scroll">
   {{#if (or (not this.allowed) (eq this.model.length 0))}}
     <div class="au-o-box">
-      <AuAlert @alertIcon="info-circle" @alertsize="small">
+      <AuAlert @icon="info-circle" @size="small">
         <p>Voor de bestuurseenheid {{this.bestuurseenheid.classificatie.label}} {{this.bestuurseenheid.naam}} moeten er geen leidinggevende functies bijgehouden worden.</p>
       </AuAlert>
     </div>

--- a/app/templates/mock-login.hbs
+++ b/app/templates/mock-login.hbs
@@ -16,7 +16,7 @@
               <AuLoader @padding="small" />
             {{else}}
               {{#if login.errorMessage}}
-                <AuAlert @alertIcon="alert-triangle" @alertTitle={{login.errorMessage}} @alertskin="warning" />
+                <AuAlert @icon="alert-triangle" @title={{login.errorMessage}} @skin="warning" />
               {{/if}}
               <login.each-account @accounts={{this.model}} as |account|>
                 <div class="au-o-box au-o-box--small au-c-card au-u-margin-bottom-small">

--- a/app/templates/personeelsbeheer/personeelsaantallen/index.hbs
+++ b/app/templates/personeelsbeheer/personeelsaantallen/index.hbs
@@ -3,7 +3,7 @@
     <AuHeading @skin="2">Personeelsbeheer &mdash; Overzicht aantallen</AuHeading>
   </AuToolbarGroup>
 
-  {{!-- TODO     <AuAlert @alertIcon="info-circle" @alertTitle="Actie vereist" @alertskin={{"warning"}} class="au-u-margin-bottom-none">
+  {{!-- TODO     <AuAlert @icon="info-circle" @title="Actie vereist" @skin={{"warning"}} class="au-u-margin-bottom-none">
       <p>Gelieve de aantallen die niet actueel zijn voor dit jaar aan te passen.</p>
     </AuAlert> --}}
 </AuToolbar>

--- a/app/templates/personeelsbeheer/personeelsaantallen/periodes/edit.hbs
+++ b/app/templates/personeelsbeheer/personeelsaantallen/periodes/edit.hbs
@@ -9,7 +9,7 @@
     </AuToolbarGroup>
     <AuToolbarGroup>
       {{#if this.save.last.isError}}
-        <AuAlert @alertIcon="info-circle" @alertTitle="Wijzigingen niet opgeslagen, probeer later opnieuw." @alertskin={{"error"}} @alertsize={{"small"}}>
+        <AuAlert @icon="info-circle" @title="Wijzigingen niet opgeslagen, probeer later opnieuw." @skin={{"error"}} @size={{"small"}}>
         </AuAlert>
       {{/if}}
       {{#unless this.dataset.modified}}
@@ -32,7 +32,7 @@
 
   <div class="au-c-body-container au-c-body-container--scroll">
     <div class="au-o-box">
-      <AuAlert @alertskin={{"info"}} @alertsize={{"tiny"}} class="au-u-2-3@medium">
+      <AuAlert @skin={{"info"}} @size={{"tiny"}} class="au-u-2-3@medium">
         {{#if this.isFTEDataset}}
           <p><strong>Iedere tewerkstelling moet uitgedrukt worden in een percentage (kommagetal) van een voltijds tewerkgesteld personeelslid.</strong> Eén VTE is een voltijds equivalent of tewerkgesteld volgens een regime van 38/38sten.  Wie minder dan voltijds tewerkgesteld is wordt pro rato meegerekend wat de VTE betreft.</p>
           <br>

--- a/app/templates/subsidy/applications/edit/step/edit.hbs
+++ b/app/templates/subsidy/applications/edit/step/edit.hbs
@@ -16,16 +16,16 @@
   <AuToolbar @size="large">
     {{#if (and this.forceShowErrors (not this.isValidForm))}}
       <AuToolbarGroup class="au-c-toolbar__group--row">
-        <AuAlert @alertIcon="alert-triangle" @alertTitle="Kan dossier niet versturen" @alertskin="error"
-                 @alertsize="small" @closable="true" class="au-u-margin-bottom-none">
+        <AuAlert @icon="alert-triangle" @title="Kan dossier niet versturen" @skin="error"
+                 @size="small" @closable="true" class="au-u-margin-bottom-none">
           <p>Kan formulier niet versturen door ontbrekende of foutief ingevulde velden.</p>
         </AuAlert>
       </AuToolbarGroup>
     {{/if}}
     {{#if this.error}}
       <AuToolbarGroup class="au-c-toolbar__group--row">
-        <AuAlert @alertIcon="alert-triangle" @alertTitle="Oeps! Dit is een beetje gênant ..." @alertskin="error"
-                 @alertsize="small" @closable="true" class="au-u-margin-bottom-none">
+        <AuAlert @icon="alert-triangle" @title="Oeps! Dit is een beetje gênant ..." @skin="error"
+                 @size="small" @closable="true" class="au-u-margin-bottom-none">
           <p>Het lijkt er op dat er iets onverwacht is fout gelopen bij het {{this.error.action}} van het formulier.</p>
         </AuAlert>
       </AuToolbarGroup>
@@ -51,10 +51,10 @@
 
               <div>
                 <AuAlert class="au-u-margin-bottom-small"
-                         @alertIcon="info-circle"
-                         @alertskin="info"
-                         @alertsize="small"
-                         @alertTitle="Deze stap kan u nog niet indienen.">
+                         @icon="info-circle"
+                         @skin="info"
+                         @size="small"
+                         @title="Deze stap kan u nog niet indienen.">
                   <AuContent>
                     <p>U kan pas vanaf een later moment indienen.</p>
 
@@ -89,9 +89,9 @@
               </div>
             {{else if this.submittablePeriodExpired}}
               <div>
-                <AuAlert @alertIcon="info-circle" @alertTitle="De deadline voor deze stap is verstreken."
-                         @alertskin="warning"
-                  @alertsize="small" class="au-u-margin-bottom-small">
+                <AuAlert @icon="info-circle" @title="De deadline voor deze stap is verstreken."
+                         @skin="warning"
+                  @size="small" class="au-u-margin-bottom-small">
                   <p> Deze stap was beschikbaar tot en met
                     {{moment-format this.step.subsidyProceduralStep.period.end 'DD-MM-YYYY'}}.
                   </p>
@@ -103,9 +103,9 @@
               </div>
             {{else}} <!-- GENERAL ISSUES (data is broken) -->
               <div>
-                <AuAlert @alertIcon="info-circle" @alertTitle="Algemene fout"
-                         @alertskin="error"
-                         @alertsize="small" class="au-u-margin-bottom-small">
+                <AuAlert @icon="info-circle" @title="Algemene fout"
+                         @skin="error"
+                         @size="small" class="au-u-margin-bottom-small">
                   <p>Indien dit blijft gebeuren, neem contact op met
                     <a href="mailto:LoketLokaalBestuur@vlaanderen.be" class="au-c-link">
                       LoketLokaalBestuur@vlaanderen.be
@@ -116,9 +116,9 @@
             {{/if}}
           {{else}} <!-- PREVIOUS STEP NEEDS TO BE COMPLETED FIRST -->
             <div>
-              <AuAlert @alertIcon="info-circle" @alertTitle="Deze subsidieaanvraag stap is nog niet beschikbaar."
-                       @alertskin="info"
-                       @alertsize="small" class="au-u-margin-bottom-small">
+              <AuAlert @icon="info-circle" @title="Deze subsidieaanvraag stap is nog niet beschikbaar."
+                       @skin="info"
+                       @size="small" class="au-u-margin-bottom-small">
                 <p>Gelieve eerst de nog in te dienen stappen aan te vullen.</p>
                 <p>Indien u een fout heeft ontdekt, of een vraag heeft, neem contact op met <a
                         href="mailto:LoketLokaalBestuur@vlaanderen.be"
@@ -133,8 +133,8 @@
           {{/if}}
         {{else}}
           <div>
-            <AuAlert @alertIcon="info-circle" @alertTitle="De subsidiestap werd verstuurd." @alertskin="success"
-                     @alertsize="small">
+            <AuAlert @icon="info-circle" @title="De subsidiestap werd verstuurd." @skin="success"
+                     @size="small">
               <p>We nemen contact op met de opgegeven contactpersoon over het verdere verloop. <a
                       href="https://lokaalbestuur.vlaanderen.be/loket-lokaal-bestuur-module-subsidies" target="_blank"
                       rel="noreferrer noopener">Vind hier meer informatie over de inhoud en het verloop van de
@@ -157,40 +157,40 @@
         {{#if this.saveConcept.isRunning}}
           <li class="au-o-grid__item">
             <AuAlert class="au-u-margin-none"
-                     @alertIcon="info-circle"
-                     @alertTitle="Aan het opslaan..."
-                     @alertskin="info"
-                     @alertsize="small"></AuAlert>
+                     @icon="info-circle"
+                     @title="Aan het opslaan..."
+                     @skin="info"
+                     @size="small"></AuAlert>
           </li>
         {{/if}}
         <!-- MOVING -->
         {{#if this.next.isRunning }}
           <li class="au-o-grid__item">
             <AuAlert class="au-u-margin-none"
-                     @alertIcon="info-circle"
-                     @alertTitle="Volgende stap voorbereiden..."
-                     @alertskin="info"
-                     @alertsize="small"></AuAlert>
+                     @icon="info-circle"
+                     @title="Volgende stap voorbereiden..."
+                     @skin="info"
+                     @size="small"></AuAlert>
           </li>
         {{/if}}
         <!-- SENDING -->
         {{#if (and this.submit.isRunning (not this.saveConcept.isRunning) (not this.next.isRunning))}}
           <li class="au-o-grid__item">
             <AuAlert class="au-u-margin-none"
-                     @alertIcon="info-circle"
-                     @alertTitle="Aan het versturen..."
-                     @alertskin="info"
-                     @alertsize="small"></AuAlert>
+                     @icon="info-circle"
+                     @title="Aan het versturen..."
+                     @skin="info"
+                     @size="small"></AuAlert>
           </li>
         {{/if}}
         <!-- RECENTLY SAVED -->
         {{#if (and this.recentlySaved (not this.saveConcept.isRunning) (not this.submit.isRunning) (not this.next.isRunning))}}
           <li class="au-o-grid__item">
             <AuAlert class="au-u-margin-none"
-                     @alertIcon="info-circle"
-                     @alertTitle="Opgeslagen."
-                     @alertskin="success"
-                     @alertsize="small"></AuAlert>
+                     @icon="info-circle"
+                     @title="Opgeslagen."
+                     @skin="success"
+                     @size="small"></AuAlert>
           </li>
         {{/if}}
       </ul>

--- a/app/templates/supervision/submissions/edit.hbs
+++ b/app/templates/supervision/submissions/edit.hbs
@@ -22,22 +22,22 @@
       </li>
       {{#if this.save.isRunning}}
         <li class="au-o-grid__item au-u-1-2 au-u-2-6@medium">
-          <AuAlert @alertIcon="info-circle" @alertTitle="Aan het opslaan..."  @alertskin="info" @alertsize="small"></AuAlert>
+          <AuAlert @icon="info-circle" @title="Aan het opslaan..."  @skin="info" @size="small"></AuAlert>
         </li>
       {{/if}}
       {{#if this.submit.isRunning}}
         <li class="au-o-grid__item au-u-1-2 au-u-2-6@medium">
-          <AuAlert @alertIcon="info-circle" @alertTitle="Aan het versturen..."  @alertskin="info" @alertsize="small"></AuAlert>
+          <AuAlert @icon="info-circle" @title="Aan het versturen..."  @skin="info" @size="small"></AuAlert>
         </li>
       {{/if}}
       {{#if this.delete.isRunning}}
         <li class="au-o-grid__item au-u-1-2 au-u-2-6@medium">
-          <AuAlert @alertIcon="info-circle" @alertTitle="Aan het verwijderen..."  @alertskin="info" @alertsize="small"></AuAlert>
+          <AuAlert @icon="info-circle" @title="Aan het verwijderen..."  @skin="info" @size="small"></AuAlert>
         </li>
       {{/if}}
       {{#if this.recentlySaved}}
         <li class="au-o-grid__item au-u-1-2 au-u-1-6@medium">
-          <AuAlert @alertIcon="info-circle" @alertTitle="Opgeslagen."  @alertskin="success" @alertsize="small"></AuAlert>
+          <AuAlert @icon="info-circle" @title="Opgeslagen."  @skin="success" @size="small"></AuAlert>
         </li>
       {{/if}}
     </ul>
@@ -63,14 +63,14 @@
 <AuToolbar @border="top" @size="large">
   {{#if this.model.submitted}}
   <AuToolbarGroup class="au-c-toolbar__group--row">
-    <AuAlert @alertIcon="check" @alertTitle="Dossier verstuurd" @alertskin="success" @alertsize="small" class="au-u-margin-bottom-none">
+    <AuAlert @icon="check" @title="Dossier verstuurd" @skin="success" @size="small" class="au-u-margin-bottom-none">
       <p>Dit dossier werd verstuurd op {{moment-format this.model.submission.sentDate 'DD-MM-YYYY'}}</p>
     </AuAlert>
   </AuToolbarGroup>
   {{/if}}
   {{#if (and this.forceShowErrors (not this.isValidForm))}}
   <AuToolbarGroup class="au-c-toolbar__group--row">
-    <AuAlert @alertIcon="alert-triangle" @alertTitle="Kan dossier niet versturen"  @alertskin="error" @alertsize="small" class="au-u-margin-bottom-none">
+    <AuAlert @icon="alert-triangle" @title="Kan dossier niet versturen"  @skin="error" @size="small" class="au-u-margin-bottom-none">
       <p>Kan formulier niet versturen door ontbrekende of foutief ingevulde velden.</p>
     </AuAlert>
   </AuToolbarGroup>

--- a/app/templates/switch-login.hbs
+++ b/app/templates/switch-login.hbs
@@ -18,7 +18,7 @@
             <div class="au-o-grid__item au-u-1-2@medium au-u-text-right@medium">
               <AcmidmLogin/>
               {{#if this.model}}
-                <AuAlert @alertIcon="alert-triangle" @alertTitle={{this.model}}  @alertskin="error" class="au-u-text-left" />
+                <AuAlert @icon="alert-triangle" @title={{this.model}}  @skin="error" class="au-u-text-left" />
               {{/if}}
             </div>
           </div>

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "moment": "^2.29.1"
   },
   "devDependencies": {
-    "@appuniversum/ember-appuniversum": "^1.0.6",
+    "@appuniversum/ember-appuniversum": "^1.0.9",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.6.0",
     "@glimmer/component": "^1.0.4",


### PR DESCRIPTION
The `alert*` prefixed argument names were deprecated in [v1.0.8](https://github.com/appuniversum/ember-appuniversum/blob/master/CHANGELOG.md#v108-2022-04-25).