### PR TITLE
Implement the "public services" overview page

### DIFF
--- a/app/components/public-services/publication-status.hbs
+++ b/app/components/public-services/publication-status.hbs
@@ -1,0 +1,3 @@
+<AuPill @skin={{this.statusSkin}}>
+  {{yield}}
+</AuPill>

--- a/app/components/public-services/publication-status.js
+++ b/app/components/public-services/publication-status.js
@@ -1,0 +1,13 @@
+import Component from '@glimmer/component';
+
+// TODO: replace this with the real URIs or UUIDs
+const PUBLICATION_STATUS_SKIN = {
+  1: 'info',
+  2: 'success',
+};
+
+export default class PublicationStatus extends Component {
+  get statusSkin() {
+    return PUBLICATION_STATUS_SKIN[this.args.id];
+  }
+}

--- a/app/components/public-services/sector-select.hbs
+++ b/app/components/public-services/sector-select.hbs
@@ -1,0 +1,13 @@
+<div ...attributes>
+  <PowerSelect
+    @allowClear={{@allowClear}}
+    @options={{this.sectors}}
+    @onChange={{@onChange}}
+    @placeholder="Sector"
+    @matchTriggerWidth={{false}}
+    @selected={{@selected}}
+    as |sector|
+  >
+    {{sector.name}}
+  </PowerSelect>
+</div>

--- a/app/components/public-services/sector-select.js
+++ b/app/components/public-services/sector-select.js
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+
+export const mockSectors = [
+  { id: '1', name: 'Detailhandel en diensten' },
+  {
+    id: '2',
+    name: 'Horeca',
+  },
+  {
+    id: '3',
+    name: 'Ambulante activiteiten',
+  },
+];
+
+export default class SectorSelect extends Component {
+  // TODO: Retrieve the correct data from the backend
+  sectors = mockSectors;
+}

--- a/app/components/public-services/translation-status.hbs
+++ b/app/components/public-services/translation-status.hbs
@@ -1,0 +1,3 @@
+<StatusLabel @skin={{if this.isFullyTranslated "success" "warning"}}>
+  {{yield}}
+</StatusLabel>

--- a/app/components/public-services/translation-status.js
+++ b/app/components/public-services/translation-status.js
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+
+export default class TranslationStatus extends Component {
+  get isFullyTranslated() {
+    // TODO: Replace this with the correct id
+    return this.args.id === '2';
+  }
+}

--- a/app/components/shared/bread-crumb.js
+++ b/app/components/shared/bread-crumb.js
@@ -201,7 +201,7 @@ export default class SharedBreadCrumbComponent extends Component {
       ],
     },
     {
-      route: 'public-services',
+      route: 'public-services.index',
       crumbs: [{ label: 'Producten- en dienstencatalogus' }],
     },
   ];

--- a/app/components/status-label.hbs
+++ b/app/components/status-label.hbs
@@ -1,0 +1,6 @@
+<div class="status-label au-u-medium au-u-para-small">
+  <div
+    class="status-label__status-color {{this.statusColor}}"
+  ></div>
+  {{yield}}
+</div>

--- a/app/components/status-label.js
+++ b/app/components/status-label.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+
+const STATUS_COLORS = {
+  action: 'status-label__status-color--action',
+  info: 'status-label__status-color--info',
+  success: 'status-label__status-color--success',
+  warning: 'status-label__status-color--warning',
+};
+
+export default class StatusLabel extends Component {
+  get statusColor() {
+    return STATUS_COLORS[this.args.skin];
+  }
+}

--- a/app/controllers/public-services/index.js
+++ b/app/controllers/public-services/index.js
@@ -1,0 +1,62 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { restartableTask, timeout } from 'ember-concurrency';
+
+export default class PublicServicesIndexController extends Controller {
+  queryParams = ['search', 'sector', 'sort', 'page'];
+  @tracked search = '';
+  @tracked sector = '';
+  @tracked sort = 'name';
+  @tracked page = 0;
+
+  get publicServices() {
+    if (this.model.loadPublicServices.isFinished) {
+      return this.model.loadPublicServices.value;
+    }
+
+    return this.model.loadedPublicServices || [];
+  }
+
+  get isFiltering() {
+    return Boolean(this.search) || Boolean(this.sector);
+  }
+
+  get isLoading() {
+    return this.model.loadPublicServices.isRunning;
+  }
+
+  get hasPreviousData() {
+    return this.model.loadedPublicServices?.length > 0;
+  }
+
+  get showTableLoader() {
+    // TODO: Add a different loading state when the table already contains data
+    // At the moment the table is cleared and the loading animation is shown.
+    // It would be better to keep showing the already loaded data with a spinner overlay.
+    // return this.isLoading && !this.hasPreviousData;
+
+    return this.isLoading;
+  }
+
+  get hasResults() {
+    return this.publicServices.length > 0;
+  }
+
+  get hasErrored() {
+    return this.model.loadPublicServices.isError;
+  }
+
+  @restartableTask
+  *searchTask(searchValue) {
+    yield timeout(500);
+
+    this.search = searchValue;
+    this.page = 0;
+  }
+
+  @action
+  handleSectorSelection(sector) {
+    this.sector = sector?.id || '';
+  }
+}

--- a/app/router.js
+++ b/app/router.js
@@ -99,7 +99,11 @@ Router.map(function () {
     });
   });
 
-  this.route('public-services', { path: '/producten-en-dienstencatalogus' });
+  this.route(
+    'public-services',
+    { path: '/producten-en-dienstencatalogus' },
+    function () {}
+  );
 
   this.route('route-not-found', {
     path: '/*wildcard',

--- a/app/routes/public-services/index.js
+++ b/app/routes/public-services/index.js
@@ -1,0 +1,91 @@
+import Route from '@ember/routing/route';
+import { restartableTask, timeout } from 'ember-concurrency';
+import { mockSectors } from 'frontend-loket/components/public-services/sector-select';
+
+const TRANSLATION_STATUS = {
+  PARTIALLY_TRANSLATED: { id: '1', label: 'Niet vertaalde velden' },
+  TRANSLATED: { id: '2', label: 'Vertaald' },
+};
+
+const PUBLICATION_STATUS = {
+  DRAFT: { id: '1', label: 'Ontwerp' },
+  PUBLISHED: { id: '2', label: 'Gepubliceerd' },
+};
+
+// TODO: Retrieve the actual records from the backend
+let mockPublicServices = [
+  {
+    id: '1',
+    pid: '1923',
+    name: 'Vestigingsvergunning nachtwinkels - phoneshops',
+    sector: mockSectors[0],
+    dateModified: new Date(2022, 1, 22, 15, 17),
+    translationStatus: TRANSLATION_STATUS.PARTIALLY_TRANSLATED,
+    publicationStatus: PUBLICATION_STATUS.DRAFT,
+  },
+  {
+    id: '2',
+    pid: '1932',
+    name: 'Terrasvergunning - inname openbaar domein',
+    sector: mockSectors[1],
+    dateModified: new Date(2022, 1, 11, 11, 37),
+    translationStatus: TRANSLATION_STATUS.TRANSLATED,
+    publicationStatus: PUBLICATION_STATUS.PUBLISHED,
+  },
+];
+
+export default class PublicServicesIndexRoute extends Route {
+  queryParams = {
+    search: {
+      refreshModel: true,
+      replace: true,
+    },
+    sector: {
+      refreshModel: true,
+      replace: true,
+    },
+    page: {
+      refreshModel: true,
+    },
+    sort: {
+      refreshModel: true,
+    },
+  };
+
+  model(params) {
+    let sector;
+    if (params.sector) {
+      sector = mockSectors.find((sector) => sector.id === params.sector);
+    }
+
+    return {
+      loadPublicServices: this.loadPublicServicesTask.perform(params),
+      loadedPublicServices: this.loadPublicServicesTask.lastSuccessful?.value,
+      sector,
+    };
+  }
+
+  @restartableTask
+  *loadPublicServicesTask({ search, sector }) {
+    yield timeout(1000);
+
+    let publicServices = mockPublicServices;
+
+    if (search) {
+      publicServices = publicServices.filter((service) => {
+        return (
+          service.name.toLowerCase().includes(search.toLowerCase().trim()) ||
+          service.pid.includes(search)
+        );
+      });
+    }
+
+    if (sector) {
+      publicServices = publicServices.filter(
+        (service) => service.sector.id === sector
+      );
+    }
+
+    return publicServices;
+  }
+}

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -315,3 +315,12 @@
     flex-grow: 1;
   }
 }
+
+.u-table-cell-shrink-content {
+  width: 1px !important;
+}
+
+// Fix a whitespace issue when the clear button is shown: https://github.com/appuniversum/ember-appuniversum/issues/248
+.ember-power-select-trigger {
+  padding: 0 5.6rem 0 0.6rem !important;
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -20,6 +20,7 @@
 // COMPONENTS
 @import "ember-appuniversum/a-components";
 @import "project/c-document-status-pills";
+@import "project/c-status-label";
 
 // PLUGINS
 @import "ember-appuniversum/a-plugins";

--- a/app/styles/project/_c-status-label.scss
+++ b/app/styles/project/_c-status-label.scss
@@ -1,0 +1,28 @@
+.status-label {
+  display: flex;
+  align-items: center;
+  color: var(--au-gray-700);
+}
+
+.status-label__status-color {
+  width: $au-unit-small;
+  height: $au-unit-small;
+  border-radius: var(--au-radius);
+  margin-right: $au-unit-tiny;
+}
+
+.status-label__status-color--info {
+  background-color: var(--au-gray-300);
+}
+
+.status-label__status-color--warning {
+  background-color: var(--au-orange-500);
+}
+
+.status-label__status-color--success {
+  background-color: var(--au-green-500);
+}
+
+.status-label__status-color--action {
+  background-color: var(--au-green-500);
+}

--- a/app/templates/public-services/index.hbs
+++ b/app/templates/public-services/index.hbs
@@ -1,0 +1,153 @@
+<AuToolbar @border="bottom" @size="large" @nowrap={{true}}>
+  <AuToolbarGroup>
+    <AuHeading @skin="2" data-test-loket="public-services-page-title">
+      Producten- en dienstencatalogus
+    </AuHeading>
+  </AuToolbarGroup>
+  <AuToolbarGroup class="au-u-flex au-u-flex--vertical-center">
+    <label for="search" class="au-u-hidden-visually">Vul uw zoekterm in</label>
+
+    {{! TODO: Replace this with `AuInput` once we get rid of 2-way-binding }}
+    <span class="au-c-input-wrapper au-c-input-wrapper--left">
+      <AuIcon @icon="search" />
+      <input
+        value={{this.search}}
+        id="search"
+        class="au-c-input"
+        placeholder="Vul uw zoekterm in"
+        {{on "input" (perform this.searchTask value="target.value")}}
+      />
+    </span>
+    <PublicServices::SectorSelect
+      @selected={{@model.sector}}
+      @onChange={{this.handleSectorSelection}}
+      @allowClear={{true}}
+    />
+    <AuLink
+      {{! TODO: Add the correct route }}
+      @route="public-services"
+      @icon="add"
+      @iconAlignment="left"
+      @skin="button"
+    >
+      Product toevoegen
+    </AuLink>
+  </AuToolbarGroup>
+</AuToolbar>
+
+<AuDataTable
+  @content={{this.publicServices}}
+  @sort={{this.sort}}
+  @page={{this.page}}
+  @size={{20}}
+  as |Table|
+>
+  <Table.content class="hehe" as |Content|>
+    <Content.header>
+      <AuDataTableThSortable
+        @field="name"
+        @currentSorting={{this.sort}}
+        @label="Productnaam"
+      />
+      <AuDataTableThSortable
+        @field=""
+        @currentSorting={{this.sort}}
+        @label="PID"
+      />
+      <AuDataTableThSortable
+        @field=""
+        @currentSorting={{this.sort}}
+        @label="Sector"
+      />
+      <AuDataTableThSortable
+        @field=""
+        @currentSorting={{this.sort}}
+        @label="Laatst bewerkt"
+      />
+      <AuDataTableThSortable
+        @field=""
+        @currentSorting={{this.sort}}
+        @label="Vertalingen"
+      />
+      <AuDataTableThSortable
+        @field=""
+        @currentSorting={{this.sort}}
+        @label="Status"
+      />
+      <th class="u-table-cell-shrink-content">
+        <span class="au-u-hidden-visually">Product of dienst bewerken</span>
+      </th>
+    </Content.header>
+
+    {{#if this.showTableLoader}}
+      <tbody>
+        <tr>
+          <td colspan="100%" class="au-c-data-table__message">
+            <AuLoader @size="small" />
+          </td>
+        </tr>
+      </tbody>
+    {{else if this.hasErrored}}
+      <tr>
+        <td colspan="100%" class="au-c-data-table__message">
+          <AuAlert
+            @title="Er ging iets fout bij het opvragen van de producten en diensten."
+            @icon="info-circle"
+            @skin="error"
+            @size="small"
+            class="au-u-margin-bottom-none"
+          />
+        </td>
+      </tr>
+    {{else if this.hasResults}}
+      <Content.body as |publicService|>
+        <td>{{publicService.name}}</td>
+        <td>{{publicService.pid}}</td>
+        <td>{{publicService.sector.name}}</td>
+        <td>
+          {{moment-format publicService.dateModified "DD-MM-YYYY - HH:mm"}}
+        </td>
+        <td>
+          <PublicServices::TranslationStatus
+            @id={{publicService.translationStatus.id}}
+          >
+            {{publicService.translationStatus.label}}
+          </PublicServices::TranslationStatus>
+        </td>
+        <td>
+          <PublicServices::PublicationStatus
+            @id={{publicService.publicationStatus.id}}
+          >
+            {{publicService.publicationStatus.label}}
+          </PublicServices::PublicationStatus>
+        </td>
+        <td class="u-table-cell-fit-content">
+          <AuPill
+            @icon="chevron-right"
+            @hideText={{true}}
+            {{! TODO: Add the correct route }}
+            @route="public-services"
+          >
+            Bewerk
+          </AuPill>
+        </td>
+      </Content.body>
+    {{else}}
+      <tr>
+        <td colspan="100%" class="au-c-data-table__message">
+          <AuAlert
+            @title={{if
+              this.isFiltering
+              "Er werden geen producten of diensten gevonden"
+              "Er werden nog geen producten of diensten toegevoegd"
+            }}
+            @icon="info-circle"
+            @skin="info"
+            @size="small"
+            class="au-u-margin-bottom-none"
+          />
+        </td>
+      </tr>
+    {{/if}}
+  </Table.content>
+</AuDataTable>

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "moment": "^2.29.1"
   },
   "devDependencies": {
-    "@appuniversum/ember-appuniversum": "^1.0.9",
+    "@appuniversum/ember-appuniversum": "^1.0.11",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.6.0",
     "@glimmer/component": "^1.0.4",
@@ -81,6 +81,7 @@
     "ember-template-lint": "^4.0.0",
     "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.0.0",
+    "ember-unique-id-helper-polyfill": "^1.2.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-ember": "^10.5.8",


### PR DESCRIPTION
This adds the public services overview page with some mock data.

The filters are mocked as well, pagination and sorting doesn't work since that was harder to mock and I didn't want to spend more time on it.

A lot of TODO comments will be resolvable once the mu-cl-resources config is added.