### PR TITLE
Fix a problem where the table cell error state was always displayed

### DIFF
--- a/app/components/rdf-form-fields/objective-table/table-cell.hbs
+++ b/app/components/rdf-form-fields/objective-table/table-cell.hbs
@@ -4,7 +4,7 @@
     @type="number"
     @width="block"
     @value={{this.kilometers}}
-    @error={{this.errors}}
+    @error={{if this.errors true false}}
     lang="nl-BE"
     step="any"
     {{on "blur" this.update}}


### PR DESCRIPTION
HBS's thruthy works different from the JS thruthy system. Empty arrays are considered truthy in JS, but falsy in HBS. We depend on this to explicitly return true or false when needed.