### PR TITLE
Fix/fietssubsidies fault table data

### DIFF
--- a/app/components/rdf-form-fields/estimated-cost-table/base-table.js
+++ b/app/components/rdf-form-fields/estimated-cost-table/base-table.js
@@ -102,8 +102,10 @@ export default class RdfFormFieldsEstimatedCostTableBaseTableComponent extends I
             new EstimatedCostEntry({
               estimatedCostEntrySubject: entry.object,
               description: parsedEntry.description,
-              cost: isNaN(parseInt(parsedEntry.cost)) ?  0 : parsedEntry.cost,
-              share: isNaN(parseInt(parsedEntry.share)) ? 100 : parsedEntry.share ,
+              cost: isNaN(parseInt(parsedEntry.cost)) ? 0 : parsedEntry.cost,
+              share: isNaN(parseInt(parsedEntry.share))
+                ? 100
+                : parsedEntry.share,
               index: parsedEntry.index,
             })
           );

--- a/app/components/rdf-form-fields/estimated-cost-table/base-table.js
+++ b/app/components/rdf-form-fields/estimated-cost-table/base-table.js
@@ -102,8 +102,8 @@ export default class RdfFormFieldsEstimatedCostTableBaseTableComponent extends I
             new EstimatedCostEntry({
               estimatedCostEntrySubject: entry.object,
               description: parsedEntry.description,
-              cost: parsedEntry.cost,
-              share: parsedEntry.share,
+              cost: isNaN(parseInt(parsedEntry.cost)) ?  0 : parsedEntry.cost,
+              share: isNaN(parseInt(parsedEntry.share)) ? 100 : parsedEntry.share ,
               index: parsedEntry.index,
             })
           );

--- a/app/components/rdf-form-fields/estimated-cost-table/edit.js
+++ b/app/components/rdf-form-fields/estimated-cost-table/edit.js
@@ -20,6 +20,8 @@ import {
   validEstimatedCostTable,
 } from './base-table';
 
+import commasToDecimalPointsFix from '../../../helpers/subsidies/subsidies-decimal-point';
+
 const defaultRows = [
   {
     uuid: 'bda9c645-9520-44ff-bac4-8b77647a93e0',
@@ -314,7 +316,7 @@ export default class RdfFormFieldsEstimatedCostTableEditComponent extends BaseTa
       );
     }
 
-    entry['cost'].value = entry['cost'].value.replace(/[^0-9/-]/g, '.');
+    entry['cost'].value = commasToDecimalPointsFix(entry['cost'].value);
 
     if (isNaN(parseInt(entry.cost.value))) {
       this.updateTripleObject(
@@ -342,7 +344,7 @@ export default class RdfFormFieldsEstimatedCostTableEditComponent extends BaseTa
   @action
   updateShare(entry) {
     entry.share.errors = [];
-    entry['share'].value = entry['share'].value.replace(/[^0-9/-]/g, '.'); // make sure, only using decimal points
+    entry['share'].value = commasToDecimalPointsFix(entry['share'].value);
     if (this.isEmpty(entry.share.value)) {
       entry.share.errors.pushObject({
         message: 'Gemeentelijk aandeel in kosten is verplicht.',

--- a/app/components/rdf-form-fields/estimated-cost-table/edit.js
+++ b/app/components/rdf-form-fields/estimated-cost-table/edit.js
@@ -314,7 +314,6 @@ export default class RdfFormFieldsEstimatedCostTableEditComponent extends BaseTa
       );
     }
 
-   
     entry['cost'].value = entry['cost'].value.replace(/[^0-9/-]/g, '.');
 
     if (isNaN(parseInt(entry.cost.value))) {
@@ -323,12 +322,12 @@ export default class RdfFormFieldsEstimatedCostTableEditComponent extends BaseTa
         entry['cost'].predicate,
         'Field is empty'
       );
-    } else if(parseInt(entry.cost.value) < 0 ) {
-    this.updateTripleObject(
-      entry.estimatedCostEntrySubject,
-      entry['cost'].predicate,
-      'Field is negative'
-    );
+    } else if (parseInt(entry.cost.value) < 0) {
+      this.updateTripleObject(
+        entry.estimatedCostEntrySubject,
+        entry['cost'].predicate,
+        'Field is negative'
+      );
     } else {
       this.updateTripleObject(
         entry.estimatedCostEntrySubject,
@@ -381,7 +380,10 @@ export default class RdfFormFieldsEstimatedCostTableEditComponent extends BaseTa
       );
     }
 
-    if(parseInt(entry.share.value) <= 100 && parseInt(entry.share.value) >= 0){
+    if (
+      parseInt(entry.share.value) <= 100 &&
+      parseInt(entry.share.value) >= 0
+    ) {
       this.updateTripleObject(
         entry.estimatedCostEntrySubject,
         entry['share'].predicate,

--- a/app/components/rdf-form-fields/estimated-cost-table/edit.js
+++ b/app/components/rdf-form-fields/estimated-cost-table/edit.js
@@ -314,12 +314,21 @@ export default class RdfFormFieldsEstimatedCostTableEditComponent extends BaseTa
       );
     }
 
+   
+    entry['cost'].value = entry['cost'].value.replace(/[^0-9/-]/g, '.');
+
     if (isNaN(parseInt(entry.cost.value))) {
       this.updateTripleObject(
         entry.estimatedCostEntrySubject,
         entry['cost'].predicate,
         'Field is empty'
       );
+    } else if(parseInt(entry.cost.value) < 0 ) {
+    this.updateTripleObject(
+      entry.estimatedCostEntrySubject,
+      entry['cost'].predicate,
+      'Field is negative'
+    );
     } else {
       this.updateTripleObject(
         entry.estimatedCostEntrySubject,
@@ -334,7 +343,7 @@ export default class RdfFormFieldsEstimatedCostTableEditComponent extends BaseTa
   @action
   updateShare(entry) {
     entry.share.errors = [];
-
+    entry['share'].value = entry['share'].value.replace(/[^0-9/-]/g, '.'); // make sure, only using decimal points
     if (this.isEmpty(entry.share.value)) {
       entry.share.errors.pushObject({
         message: 'Gemeentelijk aandeel in kosten is verplicht.',
@@ -372,11 +381,13 @@ export default class RdfFormFieldsEstimatedCostTableEditComponent extends BaseTa
       );
     }
 
-    this.updateTripleObject(
-      entry.estimatedCostEntrySubject,
-      entry['share'].predicate,
-      entry['share'].value
-    );
+    if(parseInt(entry.share.value) <= 100 && parseInt(entry.share.value) >= 0){
+      this.updateTripleObject(
+        entry.estimatedCostEntrySubject,
+        entry['share'].predicate,
+        entry['share'].value
+      );
+    }
   }
 
   isPositiveInteger(value) {

--- a/app/components/rdf-form-fields/objective-table/table-cell.js
+++ b/app/components/rdf-form-fields/objective-table/table-cell.js
@@ -234,7 +234,6 @@ export default class RdfFormFieldsObjectiveTableTableCellComponent extends Compo
       undefined,
       this.storeOptions.sourceGraph
     );
-
     this.storeOptions.store.removeStatements([...triples]);
 
     if (newObject) {
@@ -253,7 +252,7 @@ export default class RdfFormFieldsObjectiveTableTableCellComponent extends Compo
   update(e) {
     this.errors = [];
     if (e && typeof e.preventDefault === 'function') e.preventDefault();
-
+    
     if (!this.isPositiveInteger(this.kilometers)) {
       this.errors.pushObject({
         message: 'Het aantal kilometers mag niet onder 0 liggen',
@@ -271,13 +270,16 @@ export default class RdfFormFieldsObjectiveTableTableCellComponent extends Compo
       );
     }
 
+    this.kilometers = this.kilometers.replace(/[^0-9/-]/g, '.');
     const parsedAmount = Number(this.kilometers);
-
-    this.updateTripleObject(
-      this.tableEntryUri,
-      kilometersPredicate,
-      rdflib.literal(parsedAmount)
-    );
+    if(parsedAmount >= 0){
+      this.updateTripleObject(
+        this.tableEntryUri,
+        kilometersPredicate,
+        rdflib.literal(parsedAmount)
+      );
+   }
+    
     return this.onUpdateCell();
   }
 

--- a/app/components/rdf-form-fields/objective-table/table-cell.js
+++ b/app/components/rdf-form-fields/objective-table/table-cell.js
@@ -252,7 +252,7 @@ export default class RdfFormFieldsObjectiveTableTableCellComponent extends Compo
   update(e) {
     this.errors = [];
     if (e && typeof e.preventDefault === 'function') e.preventDefault();
-    
+
     if (!this.isPositiveInteger(this.kilometers)) {
       this.errors.pushObject({
         message: 'Het aantal kilometers mag niet onder 0 liggen',
@@ -272,14 +272,14 @@ export default class RdfFormFieldsObjectiveTableTableCellComponent extends Compo
 
     this.kilometers = this.kilometers.replace(/[^0-9/-]/g, '.');
     const parsedAmount = Number(this.kilometers);
-    if(parsedAmount >= 0){
+    if (parsedAmount >= 0) {
       this.updateTripleObject(
         this.tableEntryUri,
         kilometersPredicate,
         rdflib.literal(parsedAmount)
       );
-   }
-    
+    }
+
     return this.onUpdateCell();
   }
 

--- a/app/components/rdf-form-fields/objective-table/table-cell.js
+++ b/app/components/rdf-form-fields/objective-table/table-cell.js
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { v4 as uuidv4 } from 'uuid';
 import { RDF } from '@lblod/submission-form-helpers';
+import commasToDecimalPointsFix from 'frontend-loket/helpers/subsidies/subsidies-decimal-point';
 
 const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
 
@@ -270,7 +271,7 @@ export default class RdfFormFieldsObjectiveTableTableCellComponent extends Compo
       );
     }
 
-    this.kilometers = this.kilometers.replace(/[^0-9/-]/g, '.');
+    this.kilometers = commasToDecimalPointsFix(this.kilometers);
     const parsedAmount = Number(this.kilometers);
     if (parsedAmount >= 0) {
       this.updateTripleObject(

--- a/app/helpers/subsidies/subsidies-decimal-point.js
+++ b/app/helpers/subsidies/subsidies-decimal-point.js
@@ -1,0 +1,3 @@
+export default function commasToDecimalPointsFix(input) {
+  return input.replace(/[^0-9/-]/g, '.');
+}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@glimmer/tracking": "^1.0.4",
     "@lblod/ember-acmidm-login": "^1.4.0",
     "@lblod/ember-mock-login": "^0.7.0",
-    "@lblod/ember-submission-form-fields": "^1.7.0",
+    "@lblod/ember-submission-form-fields": "^1.7.2",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "browser-update": "^3.3.38",


### PR DESCRIPTION
Fixed several errors on both tables.
It was possible to update fields with negative values, this has now been resolved.
When invalid values are saved, they are not saved in the database, important as it was possible to send negative values as shown in the picture below.

![image](https://user-images.githubusercontent.com/10469447/167646637-f4a32f1f-b3eb-43f0-a989-56989cff9c67.png)
