### PR TITLE
Add basic publish handling

### DIFF
--- a/app/components/public-services/details-page.hbs
+++ b/app/components/public-services/details-page.hbs
@@ -7,13 +7,14 @@
       <AuLoader @padding="small" />
     </div>
   {{else}}
-    <form id={{this.id}} {{on "submit" (perform this.saveSemanticForm)}} class="au-c-rdf-form {{@tabName}}">
+    <form id={{this.id}} {{on "submit" (perform this.handleFormSubmit)}} class="au-c-rdf-form {{@tabName}}">
       <RdfForm
         @groupClass="au-o-grid__item"
         @form={{this.form}}
         @graphs={{this.graphs}}
         @sourceNode={{this.sourceNode}}
         @formStore={{this.formStore}}
+        @forceShowErrors={{this.forceShowErrors}}
       />
     </form>
   {{/if}}
@@ -22,7 +23,11 @@
 <AuToolbar @border="top" @size="large" as |Group|>
   <Group>
     <AuButtonGroup>
-      <AuButton {{on "click" this.sending}} @disabled={{this.saveSemanticForm.isRunning}}>
+      <AuButton
+        @disabled={{this.publicServiceAction.isRunning}}
+        @loading={{this.publishPublicService.isRunning}}
+        {{on "click" this.sending}}
+      >
         Verzend naar Vlaamse overheid
       </AuButton>
 
@@ -30,9 +35,9 @@
         @skin="secondary"
         @disabled={{or
           (not this.hasUnsavedChanges)
-          this.saveSemanticForm.isRunning
+          this.publicServiceAction.isRunning
         }}
-        @loading={{this.saveSemanticForm.isRunning}}
+        @loading={{this.handleFormSubmit.isRunning}}
         form={{this.id}}
         type="submit"
       >
@@ -50,6 +55,7 @@
       @icon="bin"
       @iconAlignment="left"
       @skin="secondary"
+      @disabled={{this.publicServiceAction.isRunning}}
       {{on "click" this.removePublicService}}
     >
       <span class="au-u-hidden-visually">
@@ -72,10 +78,13 @@
   </:body>
   <:footer>
     <AuButtonGroup>
-      <AuButton @disabled={{this.saveSemanticForm.isRunning}}
-        @loading={{this.saveSemanticForm.isRunning}}
-        form={{this.id}}
-        type="submit">Verzend naar Vlaamse overheid</AuButton>
+      <AuButton
+        @disabled={{this.publishPublicService.isRunning}}
+        @loading={{this.publishPublicService.isRunning}}
+        {{on "click" (perform this.publishPublicService)}}
+      >
+        Verzend naar Vlaamse overheid
+      </AuButton>
       <AuButton @skin="secondary" {{on "click" this.sending}}>Annuleer</AuButton>
     </AuButtonGroup>
   </:footer>


### PR DESCRIPTION
This adds a basic publish handling setup.

The missing things are:
- ~~the actual API call to publish the public service~~
- some sort of [notifications system](https://tailwindui.com/components/application-ui/overlays/notifications). The subsidy module uses simple alerts, but I think a "notification" system would be better since we can also show messages after transitioning. The message is usually also shown in the top right corner so we don't have the issue that it is not visible due to the scroll position. Kaleidos has something like that, but ideally we add support for it to Appuniversum. I created https://github.com/appuniversum/ember-appuniversum/issues/297 to track that.