### PR TITLE
Set the base app title

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -7,6 +7,8 @@ export default class ApplicationController extends Controller {
   @service() currentSession;
   @service() router;
 
+  appTitle = 'Loket voor lokale besturen';
+
   get isIndex() {
     return this.router.currentRouteName === 'index';
   }

--- a/app/index.html
+++ b/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Digitaal loket</title>
+    <title>Loket voor lokale besturen</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,4 +1,10 @@
-<AuMainHeader @brandLink="{{unless this.session.isAuthenticated "https://www.vlaanderen.be/nl"}}" @homeRoute="index" @appTitle="Loket voor lokale besturen">
+{{page-title this.appTitle}}
+
+<AuMainHeader
+  @brandLink={{unless this.session.isAuthenticated "https://www.vlaanderen.be/nl"}}
+  @homeRoute="index"
+  @appTitle={{this.appTitle}}
+>
   <li class="au-c-list-horizontal__item">
     <AuLink @route="help" @skin="secondary">
       <AuIcon @icon="question-circle" @alignment="left" />


### PR DESCRIPTION
This ensures that the base application title is set so it's displayed when navigating into a module. This provides more context for screenreaders and bookmarks.

Before: "Personeelsbeheer"
After: "Personeelsbeheer | Loket voor lokale besturen"