### PR TITLE
Resolve all `AuToolbarGroup` deprecations

### DIFF
--- a/app/components/bbcdr/report-edit-header.hbs
+++ b/app/components/bbcdr/report-edit-header.hbs
@@ -1,12 +1,12 @@
 <div class="au-o-box au-c-action-sidebar__header" tabindex="0">
-  <AuToolbar class="au-u-margin-bottom-small">
-    <AuToolbarGroup>
+  <AuToolbar class="au-u-margin-bottom-small" as |Group|>
+    <Group>
       {{#if @report.isNew}}
         <AuHeading @level="2" @skin="3">Maak nieuw rapport</AuHeading>
       {{else}}
         <AuHeading @level="2" @skin="3">Bekijk rapport</AuHeading>
       {{/if}}
-    </AuToolbarGroup>
+    </Group>
     <button type="button" class="au-c-close au-c-close--large" {{on 'click' @onClose}} data-test-loket="bbcdr-close-panel-btn">
       <AuIcon @icon="cross" @size="large" />
       <span class="au-u-hidden-visually">Verwijderen</span>

--- a/app/components/berichtencentrum/conversatie-view-header.hbs
+++ b/app/components/berichtencentrum/conversatie-view-header.hbs
@@ -1,13 +1,13 @@
 <div class="au-o-box au-c-action-sidebar__header" tabindex="0" ...attributes>
-  <AuToolbar class="au-u-margin-bottom-small">
-    <AuToolbarGroup>
+  <AuToolbar class="au-u-margin-bottom-small" as |Group|>
+    <Group>
       <AuPill data-test-loket="berichtencentrum-header-dossiernummer">Dossiernummer: {{@conversatie.dossiernummer}}</AuPill>
       {{!--     {{#if conversatie.reactietermijn}}
         <AuPill>
           Reactietermijn: {{berichtencentrum/display-moment-indays conversatie.reactietermijn}} dagen
         </AuPill>
       {{/if}} --}}
-    </AuToolbarGroup>
+    </Group>
     <button type="button" class="au-c-close au-c-close--large" {{on 'click' @close}} data-test-loket="berichtencentrum-header-cross">
       <AuIcon @icon="cross" @size="large" />
       <span class="au-u-hidden-visually">Venster sluiten</span>

--- a/app/components/exit-confirmation-modal.hbs
+++ b/app/components/exit-confirmation-modal.hbs
@@ -11,8 +11,8 @@
     </p>
   </Modal.Body>
   <Modal.Footer>
-    <AuToolbar>
-      <AuToolbarGroup>
+    <AuToolbar as |Group|>
+      <Group>
         <AuButtonGroup>
           <AuButton {{on "click" @onSave}}>
             Bewaar
@@ -21,8 +21,8 @@
             Annuleer
           </AuButton>
         </AuButtonGroup>
-      </AuToolbarGroup>
-      <AuToolbarGroup>
+      </Group>
+      <Group>
         <AuButton
           @skin="link-secondary"
           @icon="cross"
@@ -31,7 +31,7 @@
         >
           Verwerp wijzigingen
         </AuButton>
-      </AuToolbarGroup>
+      </Group>
     </AuToolbar>
   </Modal.Footer>
 </AuModal>

--- a/app/components/leidinggevendenbeheer/bestuursfunctie-card.hbs
+++ b/app/components/leidinggevendenbeheer/bestuursfunctie-card.hbs
@@ -1,5 +1,5 @@
-<AuToolbar @size="large" @border="bottom">
-  <AuToolbarGroup>
+<AuToolbar @size="large" @border="bottom" as |Group|>
+  <Group>
     <div>
       <AuHeading @level="2" @skin="4">{{@model.rol.label}}</AuHeading>
       <ul class="au-c-list-horizontal au-u-margin-top-small">
@@ -30,11 +30,11 @@
         </li>
       </ul>
     </div>
-  </AuToolbarGroup>
-  <AuToolbarGroup>
+  </Group>
+  <Group>
     <AuButton {{on 'click' @onClick}}>
       Bekijk en bewerk aanstellingsperiodes
       <AuIcon @icon="nav-right" @alignment="right" />
     </AuButton>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>

--- a/app/components/mandatenbeheer/persoon-mandaten-edit.hbs
+++ b/app/components/mandatenbeheer/persoon-mandaten-edit.hbs
@@ -1,7 +1,7 @@
- <AuToolbar @border="bottom" @size="large">
-  <AuToolbarGroup>
+ <AuToolbar @border="bottom" @size="large" as |Group|>
+  <Group>
     <AuHeading @skin="2">Bewerk mandaten<br><strong>{{@persoon.gebruikteVoornaam}} {{@persoon.achternaam}}</strong></AuHeading>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 
 <div class="au-c-body-container au-c-body-container--scroll">
@@ -57,8 +57,8 @@
   </div>
 </div>
 
-<AuToolbar @border="top" @size="large">
-  <AuToolbarGroup>
+<AuToolbar @border="top" @size="large" as |Group|>
+  <Group>
     <AuButton {{on 'click' this.finish}} @skin="secondary">Sluit</AuButton>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>

--- a/app/components/shared/persoon/create-persoon.hbs
+++ b/app/components/shared/persoon/create-persoon.hbs
@@ -138,8 +138,8 @@
     </div>
   </div>
 </div>
-<AuToolbar @border="top" @size="large">
-  <AuToolbarGroup>
+<AuToolbar @border="top" @size="large" as |Group|>
+  <Group>
     {{! TODO: use a form element with a submit event }}
     <AuButton
       @disabled={{this.save.isRunning}}
@@ -151,5 +151,5 @@
     <AuButton @skin="secondary" {{on "click" @onCancel}}>
       Annuleer
     </AuButton>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>

--- a/app/components/shared/persoon/persoon-search-form-pagination.hbs
+++ b/app/components/shared/persoon/persoon-search-form-pagination.hbs
@@ -1,5 +1,5 @@
-<AuToolbar @size="medium" @border="top">
-  <AuToolbarGroup class="au-c-toolbar__group--row">
+<AuToolbar @size="medium" @border="top" as |Group|>
+  <Group class="au-c-toolbar__group--row">
     <div class="au-c-pagination">
       <ul class="au-c-pagination__list">
         <li class="au-c-pagination__list-item">
@@ -27,5 +27,5 @@
         {{/if}}
       </ul>
     </div>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>

--- a/app/components/shared/persoon/persoon-search-form.hbs
+++ b/app/components/shared/persoon/persoon-search-form.hbs
@@ -1,18 +1,18 @@
 {{#if this.showDefaultHead}}
-  <AuToolbar @border="bottom" @size="large">
-    <AuToolbarGroup>
+  <AuToolbar @border="bottom" @size="large" as |Group|>
+    <Group>
       {{yield}}
-    </AuToolbarGroup>
-    <AuToolbarGroup>
+    </Group>
+    <Group>
       <AuButton @skin="primary" {{on 'click' @onCreateNewPerson}}>
         Voeg iemand buiten de lijst toe
       </AuButton>.
-    </AuToolbarGroup>
+    </Group>
   </AuToolbar>
 {{/if}}
 
-<AuToolbar @border="bottom" @size="large">
-  <AuToolbarGroup class="au-c-toolbar__group--row">
+<AuToolbar @border="bottom" @size="large" as |Group|>
+  <Group class="au-c-toolbar__group--row">
     <div class="au-o-grid au-o-grid--small">
       <div class="au-o-grid__item au-u-1-2">
         <AuLabel for="mandataris-voornaam">Zoek voornaam</AuLabel>
@@ -48,7 +48,7 @@
         />
       </div>
     </div>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 
 <div class="au-c-body-container au-c-body-container--scroll">
@@ -129,8 +129,8 @@
   {{/if}}
 {{/unless}}
 
-<AuToolbar @border="top" @size="large">
-  <AuToolbarGroup>
+<AuToolbar @border="top" @size="large" as |Group|>
+  <Group>
     <AuButton {{on 'click' this.cancel}} @skin="secondary">Annuleer</AuButton>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -68,8 +68,8 @@
   <div class="au-c-main-container__content">
     <div class="au-c-body-container">
       {{#unless this.isIndex}}
-        <AuToolbar @size="medium" @skin="tint" @border="bottom">
-          <AuToolbarGroup>
+        <AuToolbar @size="medium" @skin="tint" @border="bottom" as |Group|>
+          <Group>
             <ul class="au-c-list-horizontal au-c-list-horizontal--small">
               <li class="au-c-list-horizontal__item">
                 <AuLink @route="index">
@@ -82,7 +82,7 @@
               </li>
               <Shared::BreadCrumb/>
             </ul>
-          </AuToolbarGroup>
+          </Group>
         </AuToolbar>
       {{/unless}}
       <div id="content" class="au-c-body-container">

--- a/app/templates/bbcdr/rapporten.hbs
+++ b/app/templates/bbcdr/rapporten.hbs
@@ -2,20 +2,20 @@
 <div class="au-o-grid au-o-grid--flush au-o-grid--fixed">
   <div class="au-o-grid__item {{if this.hasActiveChildRoute "au-u-3-5@medium au-u-visible-medium-up" "au-u-1-1@medium"}}">
     <div class="au-c-body-container">
-      <AuToolbar @size="large">
-        <AuToolbarGroup>
+      <AuToolbar @size="large" as |Group|>
+        <Group>
           <AuHeading @skin="2">BBC DR</AuHeading>
-        </AuToolbarGroup>
-        <AuToolbarGroup>
+        </Group>
+        <Group>
           <AuButton {{on 'click' this.createNewReport}} data-test-loket='bbcdr-create-report-btn'>Lever nieuw rapport aan</AuButton>
-        </AuToolbarGroup>
+        </Group>
       </AuToolbar>
 
       <Bbcdr::ReportTable
-        @content={{this.model}} 
-        @sort={{this.sort}} 
-        @page={{this.page}} 
-        @size={{this.size}} 
+        @content={{this.model}}
+        @sort={{this.sort}}
+        @page={{this.page}}
+        @size={{this.size}}
         @displaySubset={{this.hasActiveChildRoute}}
         data-test-loket='bbcdr-report-table'
         class="au-c-body-container"

--- a/app/templates/berichtencentrum/berichten.hbs
+++ b/app/templates/berichtencentrum/berichten.hbs
@@ -3,16 +3,16 @@
 <div class="au-o-grid au-o-grid--flush au-o-grid--fixed">
   <div class="au-o-grid__item {{if this.hasActiveChildRoute "au-u-3-5@medium au-u-visible-medium-up" "au-u-1-1@medium"}}">
     <div class="au-c-body-container" tabindex="0">
-      <AuToolbar @size="large">
-        <AuToolbarGroup>
+      <AuToolbar @size="large" as |Group|>
+        <Group>
           <AuHeading @skin="2">Berichtencentrum</AuHeading>
-        </AuToolbarGroup>
-        <AuToolbarGroup>
+        </Group>
+        <Group>
           <button type="button" class="au-c-button au-c-button--tertiary" data-test-loket="berichtencentrum-setting-email-button" {{on 'click' this.showPreferences}}>
             <AuIcon @icon="settings" @alignment="left" />
             Ontvang mails bij nieuwe berichten
           </button>
-        </AuToolbarGroup>
+        </Group>
 
         <!-- Hiding search options b/c they're not implemented yet -->
   {{!--         <div class="grid u-hidden-mobile u-hidden">

--- a/app/templates/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/contact-info.hbs
+++ b/app/templates/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/contact-info.hbs
@@ -1,7 +1,7 @@
-<AuToolbar @border="bottom" @size="large">
-  <AuToolbarGroup>
+<AuToolbar @border="bottom" @size="large" as |Group|>
+  <Group>
     <AuHeading @skin="2">Bewerk algemene contactgegevens {{this.bestuursfunctie.rol.label}} {{this.bestuurseenheid.naam}}</AuHeading>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 
 <div class="au-c-body-container au-c-body-container--scroll">
@@ -36,18 +36,18 @@
   </div>
 </div>
 
-<AuToolbar @border="top" @size="large">
-  <AuToolbarGroup>
+<AuToolbar @border="top" @size="large" as |Group|>
+  <Group>
     <AuButton {{on "click" (perform this.save)}} @loading={{not this.save.isIdle}}>
       Bewaar contactgegevens
     </AuButton>
     <AuButton {{on "click" (perform this.resetChanges)}} @skin="secondary" @disabled={{not this.isDirty}}>
       Verwerp wijzigingen
     </AuButton>
-  </AuToolbarGroup>
-  <AuToolbarGroup>
+  </Group>
+  <Group>
     <AuButton {{on 'click' this.cancel}} @skin="secondary">Sluit</AuButton>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 
 {{#if this.showConfirmationDialog}}

--- a/app/templates/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/functionarissen/edit.hbs
+++ b/app/templates/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/functionarissen/edit.hbs
@@ -1,7 +1,7 @@
-<AuToolbar @border="bottom" @size="large">
-  <AuToolbarGroup>
+<AuToolbar @border="bottom" @size="large" as |Group|>
+  <Group>
     <AuHeading @skin="2">Bewerk aanstellingsperiode voor {{this.model.isBestuurlijkeAliasVan.gebruikteVoornaam}} {{this.model.isBestuurlijkeAliasVan.achternaam}} als {{this.model.bekleedt.rol.label}}</AuHeading>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 
 <Leidinggevendenbeheer::FunctionarisForm @model={{this.model}} as |isValid| >
@@ -17,8 +17,8 @@
     </AuAlert>
   </div>
 
-  <AuToolbar @border="top" @size="large">
-    <AuToolbarGroup>
+  <AuToolbar @border="top" @size="large" as |Group|>
+    <Group>
       <AuButtonGroup>
         <AuButton
           @disabled={{not isValid}}
@@ -31,6 +31,6 @@
           Annuleer
         </AuButton>
       </AuButtonGroup>
-    </AuToolbarGroup>
+    </Group>
   </AuToolbar>
 </Leidinggevendenbeheer::FunctionarisForm>

--- a/app/templates/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/functionarissen/index.hbs
+++ b/app/templates/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/functionarissen/index.hbs
@@ -1,19 +1,19 @@
 {{page-title this.bestuurseenheid.classificatie.label " " this.bestuurseenheid.naam " " this.bestuursfunctie.rol.label}}
 
-<AuToolbar @size="large" class="au-u-padding-bottom-none">
-  <AuToolbarGroup>
+<AuToolbar @size="large" class="au-u-padding-bottom-none" as |Group|>
+  <Group>
     <AuHeading @skin="2">Bekijk en bewerk aanstellingsperiode</AuHeading>
-  </AuToolbarGroup>
-  <AuToolbarGroup>
+  </Group>
+  <Group>
     <AuButton {{on 'click' this.handleVoegNieuweAanstellingsperiodeClick}}>
       <AuIcon @icon="add" @alignment="left" />
       Voeg nieuwe aanstellingsperiode toe
     </AuButton>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 
-<AuToolbar @size="large">
-  <AuToolbarGroup>
+<AuToolbar @size="large" as |Group|>
+  <Group>
     <ul class="au-c-list-horizontal">
       <li class="au-c-list-horizontal__item">
         {{#if this.bestuursfunctie.contactinfo.email}}
@@ -43,7 +43,7 @@
         </LinkTo>
       </li>
     </ul>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 
 <Leidinggevendenbeheer::FunctionarisTable

--- a/app/templates/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/functionarissen/new-person.hbs
+++ b/app/templates/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/functionarissen/new-person.hbs
@@ -1,7 +1,7 @@
-<AuToolbar @size="large" @border="bottom">
-  <AuToolbarGroup>
+<AuToolbar @size="large" @border="bottom" as |Group|>
+  <Group>
     <AuHeading @skin="2">Voeg persoon toe buiten de lijst van verkozenen</AuHeading>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 
 <Shared::Persoon::CreatePersoon

--- a/app/templates/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/functionarissen/new/index.hbs
+++ b/app/templates/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/functionarissen/new/index.hbs
@@ -1,10 +1,10 @@
-<AuToolbar @border="bottom" @size="large">
-  <AuToolbarGroup class="au-c-toolbar__group--row">
+<AuToolbar @border="bottom" @size="large" as |Group|>
+  <Group class="au-c-toolbar__group--row">
     <AuHeading @skin="3">Voeg een nieuwe aanstellingsperiode toe</AuHeading>
-  </AuToolbarGroup>
-  <AuToolbarGroup class="au-c-toolbar__group--row au-u-margin-top-none">
+  </Group>
+  <Group class="au-c-toolbar__group--row au-u-margin-top-none">
     <AuHeading @level="3" @skin="2">1. Kies een functionaris</AuHeading>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 
 <Shared::Persoon::PersoonSearchForm

--- a/app/templates/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/functionarissen/new/periode.hbs
+++ b/app/templates/leidinggevendenbeheer/bestuursfuncties/bestuursfunctie/functionarissen/new/periode.hbs
@@ -1,23 +1,23 @@
-<AuToolbar @border="bottom" @size="large">
-  <AuToolbarGroup class="au-c-toolbar__group--row">
+<AuToolbar @border="bottom" @size="large" as |Group|>
+  <Group class="au-c-toolbar__group--row">
     <AuHeading @skin="3">Voeg een nieuwe aanstellingsperiode toe</AuHeading>
-  </AuToolbarGroup>
-  <AuToolbarGroup class="au-c-toolbar__group--row au-u-margin-top-none">
+  </Group>
+  <Group class="au-c-toolbar__group--row au-u-margin-top-none">
     <AuHeading @level="3" @skin="2">
       2. Voeg aanstellingsperiode voor {{this.model.isBestuurlijkeAliasVan.gebruikteVoornaam}}
       {{this.model.isBestuurlijkeAliasVan.achternaam}} als {{this.model.bekleedt.rol.label}} toe</AuHeading>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 
 <Leidinggevendenbeheer::FunctionarisForm @model={{this.model}} as |isValid|>
-  <AuToolbar @border="top" @size="large">
-    <AuToolbarGroup>
+  <AuToolbar @border="top" @size="large" as |Group|>
+    <Group>
       <AuButton {{on 'click' this.goBackToSearch}} @skin="tertiary" @disabled={{this.save.isRunning}}>
         <AuIcon @icon="arrow-left" @alignment="left" />
         Vorige stap
       </AuButton>
-    </AuToolbarGroup>
-    <AuToolbarGroup>
+    </Group>
+    <Group>
       <AuButtonGroup>
         <AuButton @skin="secondary" @disabled={{this.save.isRunning}} {{on 'click' this.cancel}}>
           Annuleer
@@ -26,6 +26,6 @@
           Voeg aanstellingsperiode toe
         </AuButton>
       </AuButtonGroup>
-    </AuToolbarGroup>
+    </Group>
   </AuToolbar>
 </Leidinggevendenbeheer::FunctionarisForm>

--- a/app/templates/leidinggevendenbeheer/bestuursfuncties/index.hbs
+++ b/app/templates/leidinggevendenbeheer/bestuursfuncties/index.hbs
@@ -1,9 +1,9 @@
 {{page-title "Leidinggevendenbeheer" " " this.bestuurseenheid.classificatie.label " " this.bestuurseenheid.naam}}
 
-<AuToolbar @border="bottom" @size="large">
-  <AuToolbarGroup>
+<AuToolbar @border="bottom" @size="large" as |Group|>
+  <Group>
     <AuHeading @skin="2">Leidinggevendenbeheer{{if this.allowed " — Overzicht functies"}}</AuHeading>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 
 <div class="au-c-body-container au-c-body-container--scroll">

--- a/app/templates/mandatenbeheer/fracties.hbs
+++ b/app/templates/mandatenbeheer/fracties.hbs
@@ -1,14 +1,14 @@
 {{page-title "Mandatenbeheer " this.bestuurseenheid.classificatie.label " " this.bestuurseenheid.naam}}
-<AuToolbar @size="large" class="au-u-padding-bottom-none">
-  <AuToolbarGroup>
+<AuToolbar @size="large" class="au-u-padding-bottom-none" as |Group|>
+  <Group>
     <AuHeading @skin="2">Beheer Fracties</AuHeading>
-  </AuToolbarGroup>
-  <AuToolbarGroup>
+  </Group>
+  <Group>
     <AuButton {{on 'click' this.createNewFractie}}>Voeg fractie toe</AuButton>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
-<AuToolbar @size="large">
-  <AuToolbarGroup>
+<AuToolbar @size="large" as |Group|>
+  <Group>
     <div class="power-select">
       <Mandatenbeheer::BestuursperiodenSelector
         @options={{this.bestuursperioden}}
@@ -17,7 +17,7 @@
       />
 
     </div>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 
 {{#if this.saveFractie.isRunning}}

--- a/app/templates/mandatenbeheer/mandatarissen.hbs
+++ b/app/templates/mandatenbeheer/mandatarissen.hbs
@@ -1,15 +1,14 @@
 {{page-title "Mandatenbeheer " this.bestuurseenheid.classificatie.label " " this.bestuurseenheid.naam}}
 <div class="au-c-body-container {{if this.hasActiveChildRoute "au-u-hidden"}}">
-  <AuToolbar @size="large" @nowrap="true" class="au-u-padding-bottom-none">
-    <AuToolbarGroup>
+  <AuToolbar @size="large" @nowrap="true" class="au-u-padding-bottom-none" as |Group|>
+    <Group>
       <div class="au-o-flow">
         <AuHeading @skin="2">Mandatenbeheer</AuHeading>
         <Mandatenbeheer::MandatarissenTotals class="js-accordion" @bestuursorganen={{this.bestuursorganen}} />
-
       </div>
-    </AuToolbarGroup>
+    </Group>
 
-    <AuToolbarGroup>
+    <Group>
       <AuButtonGroup>
         <AuButton {{on 'click' this.handleBeheerFractiesClick}} @skin="secondary">
           Beheer fracties
@@ -18,19 +17,19 @@
           Voeg mandataris toe
         </AuButton>
       </AuButtonGroup>
-    </AuToolbarGroup>
+    </Group>
   </AuToolbar>
 
-  <AuToolbar @size="large">
-    <AuToolbarGroup>
+  <AuToolbar @size="large" as |Group|>
+    <Group>
       <div class="">
         <Mandatenbeheer::BestuursperiodenSelector
           @options={{this.bestuursperioden}}
           @selectedStartDate={{this.startDate}}
           @onSelect={{this.selectPeriod}}/>
       </div>
-    </AuToolbarGroup>
-    <AuToolbarGroup class="au-u-1-3@medium">
+    </Group>
+    <Group class="au-u-1-3@medium">
       <AuInput
         @value={{this.searchData}}
         @icon="search"
@@ -39,7 +38,7 @@
         placeholder="Zoek mandataris"
         {{on "input" (perform this.search value="target.value")}}
       />
-    </AuToolbarGroup>
+    </Group>
   </AuToolbar>
 
   <Mandatenbeheer::MandatarisTable

--- a/app/templates/mandatenbeheer/mandatarissen/new-person.hbs
+++ b/app/templates/mandatenbeheer/mandatarissen/new-person.hbs
@@ -1,7 +1,7 @@
-<AuToolbar @size="large" @border="bottom">
-  <AuToolbarGroup>
+<AuToolbar @size="large" @border="bottom" as |Group|>
+  <Group>
     <AuHeading @skin="2">Voeg persoon toe buiten de lijst van verkozenen</AuHeading>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 
 <Shared::Persoon::CreatePersoon

--- a/app/templates/personeelsbeheer/personeelsaantallen/index.hbs
+++ b/app/templates/personeelsbeheer/personeelsaantallen/index.hbs
@@ -1,7 +1,7 @@
-<AuToolbar @border="bottom" @size="large">
-  <AuToolbarGroup>
+<AuToolbar @border="bottom" @size="large" as |Group|>
+  <Group>
     <AuHeading @skin="2">Personeelsbeheer &mdash; Overzicht aantallen</AuHeading>
-  </AuToolbarGroup>
+  </Group>
 
   {{!-- TODO     <AuAlert @icon="info-circle" @title="Actie vereist" @skin={{"warning"}} class="au-u-margin-bottom-none">
       <p>Gelieve de aantallen die niet actueel zijn voor dit jaar aan te passen.</p>
@@ -10,8 +10,8 @@
 
 <div class="au-c-body-container au-c-body-container--scroll">
   {{#each this.model.datasets as |dataset|}}
-    <AuToolbar @size="large" @border="bottom">
-      <AuToolbarGroup>
+    <AuToolbar @size="large" @border="bottom" as |Group|>
+      <Group>
         <div>
           <AuHeading @level="2" @skin="4">
             <span class="au-u-margin-right-tiny">
@@ -29,15 +29,15 @@
           </AuHeading>
           <Personeelsbeheer::EmployeeDatasetSummary @dataset={{dataset}}/>
         </div>
-      </AuToolbarGroup>
-      <AuToolbarGroup>
+      </Group>
+      <Group>
         <div class="au-u-text-right">
           <LinkTo @route="personeelsbeheer.personeelsaantallen.latest" @model={{dataset.id}} class="au-c-button au-u-margin-bottom-tiny">
             Bekijk en bewerk aantallen
             <AuIcon @icon="nav-right" @alignment="right" />
           </LinkTo>
         </div>
-      </AuToolbarGroup>
+      </Group>
     </AuToolbar>
   {{/each}}
 </div>

--- a/app/templates/personeelsbeheer/personeelsaantallen/periodes/edit.hbs
+++ b/app/templates/personeelsbeheer/personeelsaantallen/periodes/edit.hbs
@@ -1,13 +1,13 @@
 
 <div class="au-c-body-container">
-  <AuToolbar @border="bottom" @size="large">
-    <AuToolbarGroup>
+  <AuToolbar @border="bottom" @size="large" as |Group|>
+    <Group>
       {{!-- {{#link-to 'personeelsbeheer.personeelsaantallen.index' class="link link--dark smaller"}}
         &leftarrow; Terug naar personeelsbeheer overzicht
       {{/link-to}} --}}
       <AuHeading @skin="2">Personeelsbeheer &mdash; {{this.dataset.title}}</AuHeading>
-    </AuToolbarGroup>
-    <AuToolbarGroup>
+    </Group>
+    <Group>
       {{#if this.save.last.isError}}
         <AuAlert @icon="info-circle" @title="Wijzigingen niet opgeslagen, probeer later opnieuw." @skin={{"error"}} @size={{"small"}}>
         </AuAlert>
@@ -27,7 +27,7 @@
           </p>
         {{/if}}
       {{/if}}
-    </AuToolbarGroup>
+    </Group>
   </AuToolbar>
 
   <div class="au-c-body-container au-c-body-container--scroll">

--- a/app/templates/subsidy/applications/available-subsidies-loading.hbs
+++ b/app/templates/subsidy/applications/available-subsidies-loading.hbs
@@ -1,7 +1,7 @@
 {{page-title "Subsidiebeheer"}}
 
-<AuToolbar @border="bottom" @size="large" @nowrap="{{true}}">
-  <AuToolbarGroup class="au-u-1-2@medium">
+<AuToolbar @border="bottom" @size="large" @nowrap="{{true}}" as |Group|>
+  <Group class="au-u-1-2@medium">
     <div>
       <AuHeading @skin="2">Beschikbare subsidiemaatregelen</AuHeading>
       <p>
@@ -10,13 +10,13 @@
               rel="noopener noreferrer">inhoudelijke informatie over de subsidies</a> die je hier kan aanvragen.
       </p>
     </div>
-  </AuToolbarGroup>
-  <AuToolbarGroup>
+  </Group>
+  <Group>
     <LinkTo @route="subsidy.applications" class="au-c-button au-c-button--secondary" type="button">
       <AuIcon @icon="arrow-left" @alignment="left"/>
       Terug naar lopende subsidiedossiers
     </LinkTo>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 <div class="au-c-data-table">
   <div class="au-c-data-table__wrapper">

--- a/app/templates/subsidy/applications/available-subsidies.hbs
+++ b/app/templates/subsidy/applications/available-subsidies.hbs
@@ -1,7 +1,7 @@
 {{page-title "Beschikbare subsidiemaatregelen"}}
 
-<AuToolbar @border="bottom" @size="large" @nowrap="{{true}}">
-  <AuToolbarGroup class="au-u-1-2@medium">
+<AuToolbar @border="bottom" @size="large" @nowrap="{{true}}" as |Group|>
+  <Group class="au-u-1-2@medium">
     <div>
       <AuHeading @skin="2">Beschikbare subsidiemaatregelen</AuHeading>
       <p>
@@ -9,12 +9,12 @@
                   rel="noopener noreferrer">inhoudelijke informatie over de subsidies</a> die je hier kan aanvragen.
       </p>
     </div>
-  </AuToolbarGroup>
-  <AuToolbarGroup>
+  </Group>
+  <Group>
     <LinkTo @route="subsidy.applications" class="au-c-button au-c-button--secondary" type="button">
       <AuIcon @icon="arrow-left" @alignment="left"/> Terug naar lopende subsidiedossiers
     </LinkTo>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 
 <AuDataTable

--- a/app/templates/subsidy/applications/edit.hbs
+++ b/app/templates/subsidy/applications/edit.hbs
@@ -1,7 +1,7 @@
 {{page-title "Bekijk subsidieaanvraag"}}
 
-<AuToolbar @nowrap={{true}} @size="large" class="au-u-padding-bottom-tiny">
-  <AuToolbarGroup class="au-c-toolbar__group--col">
+<AuToolbar @nowrap={{true}} @size="large" class="au-u-padding-bottom-tiny" as |Group|>
+  <Group class="au-c-toolbar__group--col">
     <div>
       <AuHeading @skin="2">
         {{this.consumption.subsidyMeasureOffer.title}}
@@ -14,8 +14,8 @@
         {{/if}}
       </AuHeading>
     </div>
-  </AuToolbarGroup>
-  <AuToolbarGroup class="au-c-toolbar__group--col">
+  </Group>
+  <Group class="au-c-toolbar__group--col">
     <AuButtonGroup>
       {{#if this.canDelete}}
         <AuButton
@@ -47,11 +47,11 @@
         <AuIcon @icon="cross" @alignment="left"/>Sluit
       </AuLink>
     </AuButtonGroup>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 
-<AuToolbar @border="bottom" @size="large">
-  <AuToolbarGroup class="au-c-toolbar__group--row au-c-toolbar__group--align-top">
+<AuToolbar @border="bottom" @size="large" as |Group|>
+  <Group class="au-c-toolbar__group--row au-c-toolbar__group--align-top">
     <ul class="au-o-grid au-o-grid--tiny">
       <li class="au-o-grid__item au-u-1-2 au-u-1-3@small au-u-1-6@medium">
         <AuLabel>Bestuurseenheid</AuLabel>
@@ -85,7 +85,7 @@
         </li>
       {{/if}}
     </ul>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 
 <div class="au-c-sidebar-container">

--- a/app/templates/subsidy/applications/edit/step/edit.hbs
+++ b/app/templates/subsidy/applications/edit/step/edit.hbs
@@ -13,24 +13,24 @@
     </div>
   </div>
 
-  <AuToolbar @size="large">
+  <AuToolbar @size="large" as |Group|>
     {{#if (and this.forceShowErrors (not this.isValidForm))}}
-      <AuToolbarGroup class="au-c-toolbar__group--row">
+      <Group class="au-c-toolbar__group--row">
         <AuAlert @icon="alert-triangle" @title="Kan dossier niet versturen" @skin="error"
                  @size="small" @closable="true" class="au-u-margin-bottom-none">
           <p>Kan formulier niet versturen door ontbrekende of foutief ingevulde velden.</p>
         </AuAlert>
-      </AuToolbarGroup>
+      </Group>
     {{/if}}
     {{#if this.error}}
-      <AuToolbarGroup class="au-c-toolbar__group--row">
+      <Group class="au-c-toolbar__group--row">
         <AuAlert @icon="alert-triangle" @title="Oeps! Dit is een beetje gênant ..." @skin="error"
                  @size="small" @closable="true" class="au-u-margin-bottom-none">
           <p>Het lijkt er op dat er iets onverwacht is fout gelopen bij het {{this.error.action}} van het formulier.</p>
         </AuAlert>
-      </AuToolbarGroup>
+      </Group>
     {{/if}}
-    <AuToolbarGroup class="au-u-margin-top-small au-u-margin-bottom-small">
+    <Group class="au-u-margin-top-small au-u-margin-bottom-small">
       <!-- DEFAULT CRUD CASE -->
       {{#if this.canSubmit }}
         <AuButton @disabled={{if (or this.saveConcept.isRunning this.submit.isRunning this.delete.isRunning) "true"}}
@@ -148,10 +148,10 @@
           </div>
         {{/unless}}
       {{/if}}
-    </AuToolbarGroup>
+    </Group>
 
     <!-- USER NOTIFICATIONS -->
-    <AuToolbarGroup>
+    <Group>
       <ul class="au-o-grid">
         <!-- SAVING -->
         {{#if this.saveConcept.isRunning}}
@@ -194,7 +194,6 @@
           </li>
         {{/if}}
       </ul>
-    </AuToolbarGroup>
+    </Group>
   </AuToolbar>
-
 </div>

--- a/app/templates/subsidy/applications/index-loading.hbs
+++ b/app/templates/subsidy/applications/index-loading.hbs
@@ -1,19 +1,19 @@
 {{page-title "Subsidiebeheer"}}
 
-<AuToolbar @border="bottom" @size="large" @nowrap="{{true}}">
-  <AuToolbarGroup>
+<AuToolbar @border="bottom" @size="large" @nowrap="{{true}}" as |Group|>
+  <Group>
     <div>
       <AuHeading @skin="2" data-test-loket="subsidiebeheer-page-title">Lopende subsidiedossiers</AuHeading>
       <p>Lopende subsidieaanvragen voor uw bestuur.</p>
     </div>
-  </AuToolbarGroup>
-  <AuToolbarGroup>
+  </Group>
+  <Group>
     <div class="au-u-text-right">
       <LinkTo @route="subsidy.applications.available-subsidies" class="au-c-button" type="button">
         Vraag nieuwe subsidie aan
       </LinkTo>
     </div>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 <div class="au-c-data-table">
   <div class="au-c-data-table__wrapper">

--- a/app/templates/subsidy/applications/index.hbs
+++ b/app/templates/subsidy/applications/index.hbs
@@ -1,19 +1,19 @@
 {{page-title "Subsidiebeheer " this.bestuurseenheid.classificatie.label " " this.bestuurseenheid.naam}}
 
-<AuToolbar @border="bottom" @size="large" @nowrap="{{true}}">
-  <AuToolbarGroup>
+<AuToolbar @border="bottom" @size="large" @nowrap="{{true}}" as |Group|>
+  <Group>
     <div>
       <AuHeading @skin="2" data-test-loket="subsidiebeheer-page-title">Lopende subsidiedossiers</AuHeading>
       <p>Lopende subsidieaanvragen voor uw bestuur.</p>
     </div>
-  </AuToolbarGroup>
-  <AuToolbarGroup>
+  </Group>
+  <Group>
     <div class="au-u-text-right">
       <LinkTo @route="subsidy.applications.available-subsidies" class="au-c-button" type="button">Vraag nieuwe subsidie
         aan
       </LinkTo>
     </div>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 
 <AuDataTable

--- a/app/templates/supervision/submissions/edit.hbs
+++ b/app/templates/supervision/submissions/edit.hbs
@@ -1,8 +1,8 @@
-<AuToolbar @border="bottom" @size="large">
-  <AuToolbarGroup class="au-c-toolbar__group--row">
+<AuToolbar @border="bottom" @size="large" as |Group|>
+  <Group class="au-c-toolbar__group--row">
     <AuHeading @skin="2" class="">Bekijk aanlevering dossier</AuHeading>
-  </AuToolbarGroup>
-  <AuToolbarGroup class="au-c-toolbar__group--row">
+  </Group>
+  <Group class="au-c-toolbar__group--row">
     <ul class="au-o-grid">
       <li class="au-o-grid__item au-u-1-2 au-u-1-6@medium">
         <AuLabel>Gewijzigd door</AuLabel>
@@ -41,7 +41,7 @@
         </li>
       {{/if}}
     </ul>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 
 <div class="au-c-body-container au-c-body-container--scroll">
@@ -60,22 +60,22 @@
   </div>
 </div>
 
-<AuToolbar @border="top" @size="large">
+<AuToolbar @border="top" @size="large" as |Group|>
   {{#if this.model.submitted}}
-  <AuToolbarGroup class="au-c-toolbar__group--row">
+  <Group class="au-c-toolbar__group--row">
     <AuAlert @icon="check" @title="Dossier verstuurd" @skin="success" @size="small" class="au-u-margin-bottom-none">
       <p>Dit dossier werd verstuurd op {{moment-format this.model.submission.sentDate 'DD-MM-YYYY'}}</p>
     </AuAlert>
-  </AuToolbarGroup>
+  </Group>
   {{/if}}
   {{#if (and this.forceShowErrors (not this.isValidForm))}}
-  <AuToolbarGroup class="au-c-toolbar__group--row">
+  <Group class="au-c-toolbar__group--row">
     <AuAlert @icon="alert-triangle" @title="Kan dossier niet versturen"  @skin="error" @size="small" class="au-u-margin-bottom-none">
       <p>Kan formulier niet versturen door ontbrekende of foutief ingevulde velden.</p>
     </AuAlert>
-  </AuToolbarGroup>
+  </Group>
   {{/if}}
-  <AuToolbarGroup>
+  <Group>
     {{#unless this.model.submitted}}
       <AuButton data-test-field-uri="submit-form-button"
                 @disabled={{if (or this.save.isRunning this.submit.isRunning this.delete.isRunning) "true"}}
@@ -97,10 +97,10 @@
     {{else}}
       <AuLink @route="supervision.submissions.index" @skin="secondary">Sluit</AuLink>
     {{/unless}}
-  </AuToolbarGroup>
+  </Group>
 
   {{#unless this.model.submitted}}
-  <AuToolbarGroup>
+  <Group>
     <AuButton @disabled={{if (or this.save.isRunning this.submit.isRunning this.delete.isRunning) "true"}}
               @loading={{if this.delete.isRunning "true"}}
               @skin={{"tertiary"}}
@@ -108,6 +108,6 @@
               {{on "click" (perform this.delete)}}>
       <AuIcon @icon="bin" @alignment="left" /> Verwijder dossier
     </AuButton>
-  </AuToolbarGroup>
+  </Group>
   {{/unless}}
 </AuToolbar>

--- a/app/templates/supervision/submissions/index.hbs
+++ b/app/templates/supervision/submissions/index.hbs
@@ -1,11 +1,11 @@
 {{page-title  "Toezicht " this.bestuurseenheid.classificatie.label " " this.bestuurseenheid.naam}}
-<AuToolbar @border="bottom" @size="large">
-  <AuToolbarGroup>
+<AuToolbar @border="bottom" @size="large" as |Group|>
+  <Group>
     <AuHeading @skin="2" data-test-loket="inzendingen-page-title">Toezicht</AuHeading>
-  </AuToolbarGroup>
-  <AuToolbarGroup>
+  </Group>
+  <Group>
     <LinkTo @route="supervision.submissions.new" class="au-c-button" type="button" data-test-field-uri="new-form-button">Maak nieuwe melding</LinkTo>
-  </AuToolbarGroup>
+  </Group>
 </AuToolbar>
 
 <AuDataTable


### PR DESCRIPTION
Invoking the component directly has been deprecated and the yielded version should be used instead.