### PR TITLE
Fix conversation header title

### DIFF
--- a/app/components/berichtencentrum/conversatie-view-header.hbs
+++ b/app/components/berichtencentrum/conversatie-view-header.hbs
@@ -13,9 +13,14 @@
       <span class="au-u-hidden-visually">Venster sluiten</span>
     </button>
   </AuToolbar>
-  <AuToolbar class="au-u-margin-bottom-small">
-      <AuHeading @level="2" @skin="3"  data-test-loket="berichtencentrum-header-type-communicatie">{{@conversatie.typeCommunicatie}}</AuHeading>
-  </AuToolbar>
+  <AuHeading
+    @level="2"
+    @skin="3"
+    class="au-u-margin-bottom-small"
+    data-test-loket="berichtencentrum-header-type-communicatie"
+  >
+    {{@conversatie.currentTypeCommunicatie}}
+  </AuHeading>
   <div class="grid u-spacer--small">
     <div class="col--12-12">
       <div class="au-c-content" data-test-loket="berichtencentrum-header-betreft">


### PR DESCRIPTION
While working on #135 I noticed that the title wasn't shown properly since it was using a non-existent attribute name.

![image](https://user-images.githubusercontent.com/3533236/179465777-68c8f667-72a4-4391-bf8e-78bf9236ddfa.png)
