### PR TITLE
Changed mandatatis rangorde to simple string

### DIFF
--- a/app/components/mandatenbeheer/mandataris-edit.js
+++ b/app/components/mandatenbeheer/mandataris-edit.js
@@ -77,10 +77,7 @@ export default Component.extend({
       this.get('mandataris.beleidsdomein').setObjects(this.beleidsdomeinen);
       this.set('mandataris.start', this.startDate);
       this.set('mandataris.einde', this.endDate);
-
-      if (this.rangorde) this.set('mandataris.rangorde', this.rangorde);
-      else this.set('mandataris.rangorde', undefined);
-
+      this.set('mandataris.rangorde', this.rangorde);
       this.set('mandataris.status', this.status);
 
       return yield this.mandataris.save();

--- a/app/components/mandatenbeheer/mandataris-edit.js
+++ b/app/components/mandatenbeheer/mandataris-edit.js
@@ -46,7 +46,7 @@ export default Component.extend({
     this.set('mandaat', await this.get('mandataris.bekleedt'));
     this.set('startDate', this.get('mandataris.start'));
     this.set('endDate', this.get('mandataris.einde'));
-    this.set('rangorde', this.get('mandataris.rangorde.content'));
+    this.set('rangorde', this.get('mandataris.rangorde'));
     this.set('status', await this.get('mandataris.status'));
   },
 
@@ -78,11 +78,7 @@ export default Component.extend({
       this.set('mandataris.start', this.startDate);
       this.set('mandataris.einde', this.endDate);
 
-      if (this.rangorde)
-        this.set('mandataris.rangorde', {
-          content: this.rangorde,
-          language: 'nl',
-        });
+      if (this.rangorde) this.set('mandataris.rangorde', this.rangorde);
       else this.set('mandataris.rangorde', undefined);
 
       this.set('mandataris.status', this.status);

--- a/app/components/mandatenbeheer/mandataris-summary.js
+++ b/app/components/mandatenbeheer/mandataris-summary.js
@@ -9,7 +9,7 @@ export default class MandatenbeheerMandatarisSummaryComponent extends Component 
   @reads('args.mandataris.start') start;
   @reads('args.mandataris.einde') einde;
   @reads('args.mandataris.heeftLidmaatschap.binnenFractie.naam') fractie;
-  @reads('args.mandataris.rangorde.content') rangorde;
+  @reads('args.mandataris.rangorde') rangorde;
   @reads('args.mandataris.status.label') status;
 
   @computed('args.mandataris.beleidsdomein.@each.id')

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -1,7 +1,7 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export default class MandatarisModel extends Model {
-  @attr('language-string') rangorde;
+  @attr('string') rangorde;
   @attr('datetime') start;
   @attr('datetime') einde;
   @belongsTo('mandaat', { inverse: null }) bekleedt;

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -1,7 +1,7 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export default class MandatarisModel extends Model {
-  @attr('string') rangorde;
+  @attr rangorde;
   @attr('datetime') start;
   @attr('datetime') einde;
   @belongsTo('mandaat', { inverse: null }) bekleedt;


### PR DESCRIPTION
This PR makes the attribute type of the rangorde of a mandataris a simple string instead of a `language-string` from `ember-mu-transform-helpers`.

This is due to a bug in Virtuoso https://github.com/openlink/virtuoso-opensource/issues/1055, where some triples with language tags are not removed when you are updating the mandataris rangorde. The first value mu-cl-resources can find is displayed, which is not necessarily the latest value. With these changes, the value is a simple string and these are properly removed when updating to a new value.

This PR requires https://github.com/lblod/app-digitaal-loket/pull/185.