### PR TITLE
PersoonSearchFormPagination linting and bugfix

### DIFF
--- a/.lint-todo
+++ b/.lint-todo
@@ -90,3 +90,5 @@ add|ember-template-lint|no-html-comments|176|8|176|8|08f6fb89e624ced332e22803d2f
 add|ember-template-lint|no-html-comments|186|8|186|8|b22a97a8e2d6a0b2c0b6630b09f0b9cae9d86a89|1649980800000|||app/templates/subsidy/applications/edit/step/edit.hbs
 add|ember-template-lint|simple-unless|134|8|134|8|02b279bc993a1ee6632c7e6edf341a2aabc519cb|1649980800000|||app/templates/subsidy/applications/edit/step/edit.hbs
 add|ember-template-lint|no-action|11|24|11|24|ddedce34a8333bd81cbc747afcadd4a6a78eac1d|1650931200000|||app/components/personeelsbeheer/employee-observation-table-cell.hbs
+remove|ember-template-lint|no-action|11|41|11|41|5de42254dc8f13fe8065c6a49238adab52d87cd6|1650412800000|||app/components/shared/persoon/persoon-search-form-pagination.hbs
+remove|ember-template-lint|no-action|20|41|20|41|ee7587da2f9edf362804b746083101ae33f681e7|1650412800000|||app/components/shared/persoon/persoon-search-form-pagination.hbs

--- a/app/components/shared/persoon/persoon-search-form-pagination.hbs
+++ b/app/components/shared/persoon/persoon-search-form-pagination.hbs
@@ -3,23 +3,23 @@
     <div class="au-c-pagination">
       <ul class="au-c-pagination__list">
         <li class="au-c-pagination__list-item">
-          <span class="au-u-hidden-visually">Resultaten </span><strong>{{this.startItem}} - {{this.endItem}}</strong> van {{this.total}}
+          <span class="au-u-hidden-visually">Resultaten </span><strong>{{this.startItem}} - {{this.endItem}}</strong> van {{@total}}
         </li>
         {{#if this.hasMultiplePages}}
           {{#unless this.isFirstPage}}
             <li class="au-c-pagination__list-item">
-              <AuButton @skin="tertiary" {{action "changePage" this.links.prev}}>
+              <AuButton @skin="tertiary" {{on "click" (fn this.changePage @links.prev)}}>
                 <AuIcon @icon="nav-left" @alignment="left" />
                 vorige
-                <span class="au-u-hidden-visually"> {{this.pageSize}} resultaten</span>
+                <span class="au-u-hidden-visually"> {{@size}} resultaten</span>
               </AuButton>
             </li>
           {{/unless}}
           {{#unless this.isLastPage}}
             <li class="au-c-pagination__list-item">
-              <AuButton @skin="tertiary" {{action "changePage" this.links.next}}>
+              <AuButton @skin="tertiary" {{on "click" (fn this.changePage @links.next)}}>
                 volgende
-                <span class="au-u-hidden-visually"> {{this.pageSize}} resultaten</span>
+                <span class="au-u-hidden-visually"> {{@size}} resultaten</span>
                 <AuIcon @icon="nav-right" @alignment="right" />
               </AuButton>
             </li>

--- a/app/components/shared/persoon/persoon-search-form-pagination.js
+++ b/app/components/shared/persoon/persoon-search-form-pagination.js
@@ -2,18 +2,8 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
 export default class PersoonSearchFormPagination extends Component {
-  classNames = ['data-table-pagination'];
-
-  constructor() {
-    super(...arguments);
-  }
-
   get currentPage() {
-    if (this.args.page) {
-      if (this.args.links.self.number !== this.args.page) return 1;
-      return parseInt(this.args.page) + 1;
-    }
-    return 1;
+    return this.args.page ? parseInt(this.args.page) + 1 : 1;
   }
 
   get firstPage() {

--- a/app/components/shared/persoon/persoon-search-form-pagination.js
+++ b/app/components/shared/persoon/persoon-search-form-pagination.js
@@ -1,50 +1,60 @@
-/* eslint-disable ember/no-classic-components, ember/no-classic-classes, ember/require-tagless-components, ember/require-computed-property-dependencies, ember/no-get, ember/require-computed-macros, ember/no-actions-hash */
-import Component from '@ember/component';
-import { computed } from '@ember/object';
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
-export default Component.extend({
-  classNames: ['data-table-pagination'],
-  currentPage: computed('page', {
-    get() {
-      return this.page ? parseInt(this.page) + 1 : 1;
-    },
-    set(key, value) {
-      this.set('page', value - 1);
-      return value;
-    },
-  }),
-  firstPage: computed('links', function () {
-    return this.get('links.first.number') || 1;
-  }),
-  lastPage: computed('links', function () {
-    const max = this.get('links.last.number') || -1;
+export default class PersoonSearchFormPagination extends Component {
+  classNames = ['data-table-pagination'];
+
+  constructor() {
+    super(...arguments);
+  }
+
+  get currentPage() {
+    if (this.args.page) {
+      if (this.args.links.self.number !== this.args.page) return 1;
+      return parseInt(this.args.page) + 1;
+    }
+    return 1;
+  }
+
+  get firstPage() {
+    return this.args.links.first.number || 1;
+  }
+
+  get lastPage() {
+    const max = this.args.links.last.number || -1;
     return max ? max + 1 : max;
-  }),
-  isFirstPage: computed('firstPage', 'currentPage', function () {
-    return this.firstPage == this.currentPage;
-  }),
-  isLastPage: computed('lastPage', 'currentPage', function () {
-    return this.lastPage == this.currentPage;
-  }),
-  hasMultiplePages: computed('lastPage', function () {
+  }
+
+  get isFirstPage() {
+    return this.firstPage === this.currentPage;
+  }
+
+  get isLastPage() {
+    return this.lastPage === this.currentPage;
+  }
+
+  get hasMultiplePages() {
     return this.lastPage > 0;
-  }),
-  startItem: computed('size', 'currentPage', function () {
-    return this.size * (this.currentPage - 1) + 1;
-  }),
-  endItem: computed('startItem', 'nbOfItems', function () {
-    return this.startItem + this.nbOfItems - 1;
-  }),
-  pageOptions: computed('firstPage', 'lastPage', function () {
+  }
+
+  get startItem() {
+    return this.args.size * (this.currentPage - 1) + 1;
+  }
+
+  get endItem() {
+    return this.startItem + this.args.nbOfItems - 1;
+  }
+
+  get pageOptions() {
     const nbOfPages = this.lastPage - this.firstPage + 1;
     return Array.from(
       new Array(nbOfPages),
-      (val, index) => this.firstPage + index
+      (_val, index) => this.firstPage + index
     );
-  }),
-  actions: {
-    changePage(link) {
-      this.onSelectPage(link['number'] || 0);
-    },
-  },
-});
+  }
+
+  @action
+  changePage(link) {
+    this.args.onSelectPage(link['number'] || 0);
+  }
+}

--- a/app/components/shared/persoon/persoon-search-form.js
+++ b/app/components/shared/persoon/persoon-search-form.js
@@ -65,6 +65,7 @@ export default class SharedPersoonPersoonSearchFormComponent extends Component {
     };
     this.queryParams = queryParams;
     this.personen = yield this.getPersoon.perform(queryParams);
+    if (this.personen.meta.pagination.self.number !== this.page) this.page = 0;
   }
 
   @task
@@ -82,7 +83,7 @@ export default class SharedPersoonPersoonSearchFormComponent extends Component {
   }
 
   @action
-  async selectPage(page) {
+  async selectPage(page = 0) {
     this.page = page;
     let queryParams = this.queryParams;
     queryParams['page'] = { number: page };


### PR DESCRIPTION
When triggering a search with Zoek Voornaam and browsing above page 1, if an other search is triggered with input Familienaam, `this.currentPage` shouldn't keep the previous value.

This is causing errors and missleads the user (e.g in image 2 : The vorige button shouldn't be displayed as the page is 0 but since `this.currentPage` is keeping values from the first search this is the expected result). 

![Page 2 - Loket voor lokale besturen](https://user-images.githubusercontent.com/38471754/180734510-512f71a0-1ee9-4531-8208-28b49c6352a3.png)

![Page 1 - Loket voor lokale besturen](https://user-images.githubusercontent.com/38471754/180731600-05c42de6-43d5-4bdc-aeca-2da0cd03d5cd.png)

- Resolves the todo no-action.

- PersoonSearchFormPagination linter fix.

- `this.currentPage` fix