### PR TITLE
Add a basic feature flag system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN git clone https://github.com/lblod/handleiding-digitaal-loket.git handleidin
       && rm -r handleiding/.git \
       && mv handleiding /app/dist/handleiding
 
-FROM semtech/ember-proxy-service:1.4.0
+FROM semtech/ember-proxy-service:1.5.1
 
 ENV STATIC_FOLDERS_REGEX "^/(assets|font|files|handleiding|toezicht/bestanden|@appuniversum)/"
 

--- a/app/helpers/is-feature-enabled.js
+++ b/app/helpers/is-feature-enabled.js
@@ -1,0 +1,13 @@
+import config from 'frontend-loket/config/environment';
+import { assert } from '@ember/debug';
+
+export default function isFeatureEnabled(featureName) {
+  let featureFlagValue = config.features?.[featureName];
+
+  assert(
+    `The "${featureName}" feature is not defined. Make sure the feature is defined in the "features" object in the config/environment.js file and that there are no typos in the name.`,
+    Boolean(featureFlagValue)
+  );
+
+  return featureFlagValue === 'true' || featureFlagValue === true;
+}

--- a/config/environment.js
+++ b/config/environment.js
@@ -39,6 +39,7 @@ module.exports = function (environment) {
         },
       },
     },
+    features: {},
   };
 
   if (environment === 'development') {

--- a/tests/unit/helpers/is-feature-enabled-test.js
+++ b/tests/unit/helpers/is-feature-enabled-test.js
@@ -1,0 +1,40 @@
+import config from 'frontend-loket/config/environment';
+import isFeatureEnabled from 'frontend-loket/helpers/is-feature-enabled';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | is-feature-enabled', function () {
+  test('it works', function (assert) {
+    let originalFeaturesConfig = config.features;
+
+    config.features = {
+      foo: 'bar',
+    };
+
+    assert.false(
+      isFeatureEnabled('foo'),
+      "it returns false if the value isn't the boolean `true` or the string 'true'"
+    );
+
+    config.features.foo = true;
+    assert.true(
+      isFeatureEnabled('foo'),
+      'it returns true if the value is the boolean `true`'
+    );
+
+    config.features.foo = 'true';
+    assert.true(
+      isFeatureEnabled('foo'),
+      "it returns true if the value is the string 'true'"
+    );
+
+    assert.throws(
+      () => {
+        isFeatureEnabled('baz');
+      },
+      /The "baz" feature is not defined. Make sure the feature is defined in the "features" object in the config\/environment.js file and that there are no typos in the name./,
+      "it throws an assertion error if the feature name doesn't exist"
+    );
+
+    config.features = originalFeaturesConfig;
+  });
+});


### PR DESCRIPTION
new feature flags should be added to the `features` object in the `config/environment.js` file.

A feature is considered "enabled" if it has a value of `true` (boolean) or `"true"` (string). This allows us to use the string replacement system provided by the proxy service.

```js
features: {
  'foo': '{{SOME_ENV_VARIABLE_NAME}}',
}
```

We can then check if the feature is enabled like this:

Templates
```hbs

{{#if (is-feature-enabled "foo")}}
  Shown if the feature is enabled
{{/if}}
```

JS:
```js
import isFeatureEnabled from 'frontend-loket/helpers/is-feature-enabled';

if (isFeatureEnabled('foo')) {
  console.log('foo is enabled');
}
```

If the backend replaces the `{{SOME_ENV_VARIABLE_NAME}}` string with `"true"` the feature will be enabled.

For DX convenience you can enable the feature during local development by setting it to `true`:

```js
if (environment === 'development') {
  ENV.features.foo = true;
}
```