### PR TITLE
Drop IE11 support

### DIFF
--- a/app/templates/legaal/cookieverklaring.hbs
+++ b/app/templates/legaal/cookieverklaring.hbs
@@ -9,7 +9,7 @@
   <p>Cookies maken over het algemeen de interactie tussen de bezoeker en de website of applicatie gemakkelijker en sneller en helpen de bezoeker om te navigeren tussen de verschillende delen van een website of applicatie.</p>
   <h3>Hoe kan u het gebruik van cookies weigeren of beheren?</h3>
   <p>U kunt de installatie van cookies weigeren via uw browserinstellingen. U kunt op elk gewenst moment ook de reeds geïnstalleerde cookies van uw computer of mobiele apparaat verwijderen, als volgt:</p>
-  <ul><li>Internet Explorer: <a href="https://support.microsoft.com/nl-be/help/17479/windows-internet-explorer-11-change-security-privacy-settings" target="_blank" rel="noreferrer noopener" class="au-c-link">https://support.microsoft.com/nl-be/help/17479/windows-internet-explorer-11-change-security-privacy-settings</a></li>
+  <ul>
     <li>Chrome:&nbsp;<a href="http://support.google.com/chrome/bin/answer.py?hl=nl&amp;answer=95647" target="_blank" rel="noreferrer noopener" class="au-c-link">http://support.google.com/chrome/bin/answer.py?hl=nl&amp;answer=95647</a></li>
     <li>Firefox:&nbsp;<a href="http://support.mozilla.org/nl/kb/cookies-in-en-uitschakelen-websites-voorkeuren?redirectlocale=nl&amp;redirectslug=Cookies+in-+en+uitschakelen" target="_blank" rel="noreferrer noopener" class="au-c-link">http://support.mozilla.org/nl/kb/cookies-in-en-uitschakelen-websites-voorkeuren?redirectlocale=nl&amp;redirectslug=Cookies+in-+en+uitschakelen</a></li>
     <li>Safari:&nbsp;<a href="http://support.apple.com/kb/PH5042" target="_blank" rel="noreferrer noopener" class="au-c-link">http://support.apple.com/kb/PH5042</a></li>

--- a/config/targets.js
+++ b/config/targets.js
@@ -7,21 +7,6 @@ const browsers = [
   'last 3 Safari versions',
 ];
 
-// Ember's browser support policy is changing, and IE11 support will end in
-// v4.0 onwards.
-//
-// See https://deprecations.emberjs.com/v3.x#toc_3-0-browser-support-policy
-//
-// If you need IE11 support on a version of Ember that still offers support
-// for it, uncomment the code block below.
-
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,9 +5,6 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function (defaults) {
   const customBuildConfig = {
     // Add options here
-    'ember-cli-babel': {
-      includePolyfill: true,
-    },
     'ember-simple-auth': {
       useSessionSetupMethod: true,
     },


### PR DESCRIPTION
IE11 is EOL so we can reduce the bundle size by removing the transpiling and polyfilling that was needed to support it.

Some build size comparisons:

Before this PR:
```
 - dist/assets/chunk.143.206ab5a803ee58c14354.js: 9.47 KB (3.83 KB gzipped)
 - dist/assets/chunk.178.839731d1225b85eb58ec.js: 1.68 KB (840 B gzipped)
 - dist/assets/chunk.31.579c949fdd5b6fa43ba2.js: 316 B (240 B gzipped)
 - dist/assets/chunk.410.7516bbffc7a8c7770a31.js: 57.76 KB (16.35 KB gzipped)
 - dist/assets/chunk.550.117764b5043b3b291430.js: 98.86 KB (29.66 KB gzipped)
 - dist/assets/chunk.706.bdbec56ffd9f81f85609.js: 1.45 MB (352.23 KB gzipped)
 - dist/assets/chunk.810.6f8743f7c4005c4f091f.js: 6.04 KB (2.48 KB gzipped)
 - dist/assets/chunk.916.6999a97b7348b712c4ad.js: 79.01 KB (25.5 KB gzipped)
 - dist/assets/frontend-loket-3003d81913011abb196262fe8146449f.js: 1.74 MB (179.17 KB gzipped)
 - dist/assets/vendor-f1105b537585f268b2f9d9ab7b162022.js: 2.26 MB (443.46 KB gzipped)
```

After removing IE11 from the targets config:
```
 - dist/assets/chunk.143.cbbfd6af156289df76b1.js: 9.06 KB (3.8 KB gzipped)
 - dist/assets/chunk.178.4f978fd85e4cc4f2ac4b.js: 1.53 KB (820 B gzipped)
 - dist/assets/chunk.993.d53f44047bb0bf35b17d.js: 301 B (238 B gzipped)
 - dist/assets/chunk.410.c7322b49013482841a89.js: 37.17 KB (11.87 KB gzipped)
 - dist/assets/chunk.550.3118b9a347e4fae14254.js: 98.55 KB (29.58 KB gzipped)
 - dist/assets/chunk.706.ce76a101671d976cc95d.js: 1.23 MB (322.79 KB gzipped)
 - dist/assets/chunk.810.f42f1985b35f2224a350.js: 4.97 KB (2.11 KB gzipped)
 - dist/assets/chunk.916.3179e3063ec9da06f5f0.js: 79.01 KB (25.51 KB gzipped)
 - dist/assets/frontend-loket-5d0387458c9de3f8819f242ddbbd95b7.js: 931.42 KB (115.25 KB gzipped)
 - dist/assets/vendor-9d6a8bd74507a6fea448363e7ac58f4a.js: 1.62 MB (377.18 KB gzipped)
```

After removing the polyfill:
```
 - (other files are the same as the previous snippet)
 - dist/assets/vendor-a79c6dddf7bb0e225dcc8135e80a7035.js: 1.53 MB (345.12 KB gzipped)
 ```