### PR TITLE
Bugfix/bestuursperiode selector and overlapping start dates

### DIFF
--- a/app/components/mandatenbeheer/bestuursperioden-selector.js
+++ b/app/components/mandatenbeheer/bestuursperioden-selector.js
@@ -40,7 +40,8 @@ export default class MandatenbeheerBestuursperiodenSelectorComponent extends Com
       return this._options.find((o) => {
         return (
           o.bindingStart.toDateString() ==
-          new Date(this.args.selectedStartDate).toDateString()
+            new Date(this.args.selectedStartDate).toDateString() &&
+          !o.bindingEinde
         );
       });
     } else {

--- a/app/controllers/mandatenbeheer/mandatarissen.js
+++ b/app/controllers/mandatenbeheer/mandatarissen.js
@@ -15,6 +15,14 @@ export default class MandatenbeheerMandatarissenController extends Controller {
   sort = 'is-bestuurlijke-alias-van.achternaam';
   size = 20;
 
+  get startDate() {
+    return this.mandatenbeheer.startDate;
+  }
+
+  get endDate() {
+    return this.mandatenbeheer.endDate;
+  }
+
   get hasActiveChildRoute() {
     return (
       this.router.currentRouteName.startsWith(
@@ -48,12 +56,16 @@ export default class MandatenbeheerMandatarissenController extends Controller {
   }
 
   @action
-  selectPeriod(startDate) {
+  selectPeriod(startDate, endDate) {
+    const queryParams = {
+      page: 0,
+      startDate: startDate,
+    };
+
+    queryParams['endDate'] = endDate;
+
     this.router.transitionTo('mandatenbeheer.mandatarissen', {
-      queryParams: {
-        page: 0,
-        startDate: startDate,
-      },
+      queryParams,
     });
   }
 }

--- a/app/routes/eredienst-mandatenbeheer.js
+++ b/app/routes/eredienst-mandatenbeheer.js
@@ -76,8 +76,15 @@ export default class EredienstMandatenbeheerRoute extends Route {
       'filter[is-tijdsspecialisatie-van][id]': bestuursorgaanId,
     };
 
-    if (startDate) queryParams['filter[binding-start]'] = startDate;
-    if (endDate) queryParams['filter[binding-einde]'] = endDate;
+    if (startDate && endDate) {
+      queryParams['filter[binding-start]'] = startDate;
+      queryParams['filter[binding-einde]'] = endDate;
+    } else if (startDate) {
+      queryParams['filter[binding-start]'] = startDate;
+      // Bestuursorganen can overlap in start date,
+      // so if no end date is provided, explicitly filter em out
+      queryParams['filter[:has-no:binding-einde]'] = true;
+    }
 
     const organen = await this.store.query('bestuursorgaan', queryParams);
     return organen.toArray();

--- a/app/routes/eredienst-mandatenbeheer.js
+++ b/app/routes/eredienst-mandatenbeheer.js
@@ -20,9 +20,8 @@ export default class EredienstMandatenbeheerRoute extends Route {
       this.router.transitionTo('index');
   }
 
-  //TODO: this was based on mandatenbeheer, but turned out we needed to modify this,
-  //     since a lot of edge cases weren't taken into account.
-  //     Most likely we just fixed bugs, and these changes should be merged back again to mandatenbeheer
+  //TODO: this needs to be kept in sync with mandatenbeheer
+  // Let's first wait a little more before extracing commmon bits
   async model(params) {
     this.startDate = params.startDate;
     this.endDate = params.endDate;
@@ -41,9 +40,9 @@ export default class EredienstMandatenbeheerRoute extends Route {
   }
 
   /*
-   * Returns bestuursorgaan in tijd starting on the given start date
+   * Returns bestuursorgaan in tijd starting on the given a period
    * for all bestuursorganen of the given bestuurseenheid.
-   * TODO: ripped from routes/mandatenbeheer (BUT MODIFIED due to probably a bug in mandatenbeheer).
+   * TODO: keep in sync with routes/mandatenbeheer.
    *       Extract common code once we are sure of the common pattern.
    */
   async getBestuursorganenInTijdByPeriod(bestuurseenheidId) {
@@ -67,7 +66,7 @@ export default class EredienstMandatenbeheerRoute extends Route {
   }
 
   /*
-   * TODO: ripped from routes/mandatenbeheer.
+   * TODO: keep in sync with routes/mandatenbeheer.
    *       Extract common code once we are sure of the common pattern.
    */
   async getBestuursorgaanInTijdByPeriod(bestuursorgaanId, startDate, endDate) {
@@ -91,9 +90,9 @@ export default class EredienstMandatenbeheerRoute extends Route {
   }
 
   /*
-   * Get all the bestuursorganen in tijd of a bestuursorgaan with at least 1 political mandate.
+   * Get all the bestuursorganen in tijd of a bestuursorgaan with at least 1 political or worship mandate.
    * @return Array of bestuursorganen in tijd ressembling the bestuursperiodes
-   * TODO: ripped from routes/mandatenbeheer (BUT MODIFIED due to probably a bug in mandatenbeheer)
+   * TODO: keep in sync with routes/mandatenbeheer.
    *       Extract common code once we are sure of the common pattern.
    */
   async getBestuursperioden(bestuurseenheidId) {

--- a/app/templates/mandatenbeheer/mandatarissen.hbs
+++ b/app/templates/mandatenbeheer/mandatarissen.hbs
@@ -26,6 +26,7 @@
         <Mandatenbeheer::BestuursperiodenSelector
           @options={{this.bestuursperioden}}
           @selectedStartDate={{this.startDate}}
+          @selectedEndDate={{this.endDate}}
           @onSelect={{this.selectPeriod}}/>
       </div>
     </Group>


### PR DESCRIPTION
To cover the nasty/edgy cases where we have bestuursorganen with
overlapping startdates, but mixed enddates (i.e. some empty, some
defined), we needed to tweak the bestuursperiodeslector and their
respective consumers to take these cases into account.