### PR TITLE
Add a custom `ConceptSelector` field

### DIFF
--- a/app/components/rdf-form-fields/concept-selector.hbs
+++ b/app/components/rdf-form-fields/concept-selector.hbs
@@ -9,8 +9,8 @@
   <this.selectComponent
     @triggerId={{this.inputId}}
     @selected={{this.selected}}
-    @searchEnabled={{not this.shouldPreloadData}}
-    @search={{perform this.search}}
+    @searchEnabled={{this.isSearchEnabled}}
+    @search={{if this.backendSearch (perform this.search)}}
     @searchField="label"
     @options={{this.options}}
     @onClose={{fn (mut this.hasBeenFocused) true}}

--- a/app/components/rdf-form-fields/concept-selector.hbs
+++ b/app/components/rdf-form-fields/concept-selector.hbs
@@ -1,0 +1,32 @@
+<AuLabel
+  @error={{this.hasErrors}}
+  @required={{this.isRequired}}
+  for={{this.inputId}}
+>
+  {{@field.label}}
+</AuLabel>
+<div class={{if this.hasErrors "ember-power-select--error"}}>
+  <this.selectComponent
+    @triggerId={{this.inputId}}
+    @selected={{this.selected}}
+    @searchEnabled={{not this.shouldPreloadData}}
+    @search={{perform this.search}}
+    @searchField="label"
+    @options={{this.options}}
+    @onClose={{fn (mut this.hasBeenFocused) true}}
+    @onChange={{this.updateSelection}}
+    @allowClear={{true}}
+    @searchMessage={{this.searchMessage}}
+    @loadingMessage="Aan het laden..."
+    @noMatchesMessage="Geen resultaten gevonden"
+    @disabled={{@show}}
+    data-test-field-uri={{@field.uri.value}}
+    as |concept|
+  >
+    {{concept.label}}
+  </this.selectComponent>
+</div>
+
+{{#each this.errors as |error|}}
+  <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>
+{{/each}}

--- a/app/components/rdf-form-fields/concept-selector.js
+++ b/app/components/rdf-form-fields/concept-selector.js
@@ -1,0 +1,132 @@
+import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+import {
+  triplesForPath,
+  updateSimpleFormValue,
+  removeDatasetForSimpleFormValue,
+} from '@lblod/submission-form-helpers';
+import { restartableTask, timeout } from 'ember-concurrency';
+import { NamedNode } from 'rdflib';
+import PowerSelect from 'ember-power-select/components/power-select';
+import PowerSelectMultiple from 'ember-power-select/components/power-select-multiple';
+
+export default class RdfFormFieldsConceptSchemeSelectorComponent extends InputFieldComponent {
+  @service store;
+
+  @tracked selected = null;
+  options = [];
+  inputId = 'concept-selector-' + guidFor(this);
+
+  constructor() {
+    super(...arguments);
+    this.loadSelectOptions();
+    this.loadPersistedValues();
+  }
+
+  get searchMessage() {
+    return this.args.field.options.searchMessage || 'Typ om te zoeken';
+  }
+
+  get shouldPreloadData() {
+    return Boolean(this.args.field.options.preload);
+  }
+
+  get isMultiSelect() {
+    return Boolean(this.args.field.options.multiple);
+  }
+
+  get selectComponent() {
+    return this.isMultiSelect ? PowerSelectMultiple : PowerSelect;
+  }
+
+  loadSelectOptions() {
+    if (this.shouldPreloadData) {
+      this.options = this.loadConcepts();
+    }
+  }
+
+  loadConcepts(query = {}) {
+    let { conceptScheme, preloadAmount = 20 } = this.args.field.options;
+
+    return this.store.query('concept', {
+      'filter[concept-schemes][:uri:]': conceptScheme,
+      sort: 'label',
+      'page[size]': preloadAmount,
+      ...query,
+    });
+  }
+
+  async loadPersistedValues() {
+    const matches = triplesForPath(this.storeOptions, true).values;
+
+    if (matches.length > 0) {
+      if (this.isMultiSelect) {
+        let conceptPromises = matches.map(async (concept) => {
+          let conceptUri = concept.value;
+          return await this.loadConceptRecordByUri(conceptUri);
+        });
+
+        let concepts = await Promise.all(conceptPromises);
+        this.selected = sortByLabel(concepts);
+      } else {
+        let conceptUri = matches[0].value;
+        this.selected = await this.loadConceptRecordByUri(conceptUri);
+      }
+    }
+  }
+
+  async loadConceptRecordByUri(uri) {
+    let response = await this.store.query('concept', {
+      'filter[:uri:]': uri,
+    });
+
+    return response.firstObject;
+  }
+
+  @action
+  updateSelection(newSelection) {
+    this.selected = newSelection;
+
+    // Cleanup old value(s) in the store
+    const matches = triplesForPath(this.storeOptions, true).values;
+    matches.forEach((m) =>
+      removeDatasetForSimpleFormValue(m, this.storeOptions)
+    );
+
+    if (this.isMultiSelect) {
+      if (newSelection.length > 0) {
+        newSelection.forEach((concept) => {
+          updateSimpleFormValue(this.storeOptions, new NamedNode(concept.uri));
+        });
+      }
+    } else {
+      if (newSelection) {
+        updateSimpleFormValue(
+          this.storeOptions,
+          new NamedNode(newSelection.uri)
+        );
+      }
+    }
+
+    this.hasBeenFocused = true;
+    super.updateValidations();
+  }
+
+  @restartableTask
+  *search(value) {
+    yield timeout(300);
+
+    return yield this.loadConcepts({
+      filter: value,
+    });
+  }
+}
+
+function sortByLabel(concepts = []) {
+  return [...concepts].sort((a, b) => {
+    return a.label.localeCompare(b.label);
+  });
+}

--- a/app/components/rdf-form-fields/concept-selector.js
+++ b/app/components/rdf-form-fields/concept-selector.js
@@ -26,12 +26,20 @@ export default class RdfFormFieldsConceptSchemeSelectorComponent extends InputFi
     this.loadPersistedValues();
   }
 
-  get searchMessage() {
-    return this.args.field.options.searchMessage || 'Typ om te zoeken';
+  get shouldPreloadData() {
+    return this.args.field.options.preload ?? true;
   }
 
-  get shouldPreloadData() {
-    return Boolean(this.args.field.options.preload);
+  get isSearchEnabled() {
+    return this.args.field.options.search ?? true;
+  }
+
+  get isBackendSearch() {
+    return this.args.field.options.backendSearch ?? true;
+  }
+
+  get searchMessage() {
+    return this.args.field.options.searchMessage || 'Typ om te zoeken';
   }
 
   get isMultiSelect() {

--- a/app/routes/public-services/details.js
+++ b/app/routes/public-services/details.js
@@ -1,8 +1,9 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import { loadPublicServiceDetails } from 'frontend-loket/utils/public-services';
-import RichTextEditor from 'frontend-loket/components/rdf-form-fields/rich-text-editor';
 import { registerFormFields } from '@lblod/ember-submission-form-fields';
+import ConceptSelector from 'frontend-loket/components/rdf-form-fields/concept-selector';
+import RichTextEditor from 'frontend-loket/components/rdf-form-fields/rich-text-editor';
+import { loadPublicServiceDetails } from 'frontend-loket/utils/public-services';
 
 export default class PublicServicesDetailsRoute extends Route {
   @service store;
@@ -26,6 +27,10 @@ export default class PublicServicesDetailsRoute extends Route {
       {
         displayType: 'http://lblod.data.gift/display-types/richText',
         edit: RichTextEditor,
+      },
+      {
+        displayType: 'http://lblod.data.gift/display-types/conceptSelector',
+        edit: ConceptSelector,
       },
     ]);
   }


### PR DESCRIPTION
This field works similar to the `ConceptSchemeSelector` and `ConceptSchemeMultiSelector` fields, but with several improvements:

- it loads the data when the component is rendered or when the user searches, which improves the form rendering
- it allows preloading the options in case there aren't that many so searching isn't beneficial
- it supports both single and multi select modes by adding some configuration

It can be tested in the LPDC module by adjusting `conceptSchemeSelector` and `conceptSchemeMultiSelector` display types to `conceptSelector` and providing options through `form:options`.

Available options:
```ts
type Options = {
  conceptScheme: string; // required and sets the concept scheme to which the concepts belong
  multiple?: boolean; // switches to the multi-select mode if set to true. defaults to `false`
  preload?: boolean; // loads some records when the component is rendered. defaults to `true`
  preloadAmount?: int; // the amount of records that will be preloaded, defaults to `20`.
  search?: boolean; // should we show the search field in the select component. defaults to `true`
  backendSearch?: boolean; // should we request data from the backend when searching. If set to false it will only search in the preloaded options. This option requires that `search` is set to `true`. defaults to `true`
}
```