### PR TITLE
Fix an empty label problem in the ConceptSelector component

### DIFF
--- a/app/components/rdf-form-fields/concept-selector.js
+++ b/app/components/rdf-form-fields/concept-selector.js
@@ -68,7 +68,7 @@ export default class RdfFormFieldsConceptSchemeSelectorComponent extends InputFi
   }
 
   async loadPersistedValues() {
-    const matches = triplesForPath(this.storeOptions, true).values;
+    const matches = triplesForPath(this.storeOptions).values;
 
     if (matches.length > 0) {
       if (this.isMultiSelect) {


### PR DESCRIPTION
Passing `true` to the triplesForPath util creates new triples in the store if they are missing. This isn't the behavior that we want since we assume all concepts already exist in the database.