### PR TITLE
Replace hardcoded RDF namespaces with imports

### DIFF
--- a/app/components/public-services/details-page.js
+++ b/app/components/public-services/details-page.js
@@ -7,12 +7,12 @@ import {
   ForkingStore,
   validateForm,
 } from '@lblod/ember-submission-form-fields';
-import { FORM, RDF } from '@lblod/submission-form-helpers';
 import { NamedNode } from 'rdflib';
 import { dropTask, task, dropTaskGroup } from 'ember-concurrency';
 import ConfirmDeletionModal from 'frontend-loket/components/public-services/confirm-deletion-modal';
 import ConfirmSubmitModal from 'frontend-loket/components/public-services/confirm-submit-modal';
 import UnsavedChangesModal from 'frontend-loket/components/public-services/details/unsaved-changes-modal';
+import { FORM, RDF } from 'frontend-loket/rdf/namespaces';
 import { loadPublicServiceDetails } from 'frontend-loket/utils/public-services';
 
 const FORM_MAPPING = {

--- a/app/components/public-services/details-page.js
+++ b/app/components/public-services/details-page.js
@@ -7,7 +7,8 @@ import {
   ForkingStore,
   validateForm,
 } from '@lblod/ember-submission-form-fields';
-import { NamedNode, Namespace } from 'rdflib';
+import { FORM, RDF } from '@lblod/submission-form-helpers';
+import { NamedNode } from 'rdflib';
 import { dropTask, task, dropTaskGroup } from 'ember-concurrency';
 import ConfirmDeletionModal from 'frontend-loket/components/public-services/confirm-deletion-modal';
 import ConfirmSubmitModal from 'frontend-loket/components/public-services/confirm-submit-modal';
@@ -28,9 +29,6 @@ const FORM_GRAPHS = {
 const SERVICE_STATUSES = {
   sent: 'http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c',
 };
-
-const FORM = new Namespace('http://lblod.data.gift/vocabularies/forms/');
-const RDF = new Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#');
 
 export default class PublicServicesDetailsPageComponent extends Component {
   @service modals;

--- a/app/components/rdf-form-fields/accountability-table/edit.js
+++ b/app/components/rdf-form-fields/accountability-table/edit.js
@@ -3,12 +3,11 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { triplesForPath } from '@lblod/submission-form-helpers';
-import { NamedNode, Namespace } from 'rdflib';
+import { NamedNode } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { RDF } from '@lblod/submission-form-helpers';
 import { A } from '@ember/array';
-
-const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
+import { MU } from 'frontend-loket/rdf/namespaces';
 
 const subsidyBaseUri = 'http://lblod.data.gift/vocabularies/subsidie/ukraine/';
 

--- a/app/components/rdf-form-fields/accountability-table/edit.js
+++ b/app/components/rdf-form-fields/accountability-table/edit.js
@@ -5,9 +5,8 @@ import { inject as service } from '@ember/service';
 import { triplesForPath } from '@lblod/submission-form-helpers';
 import { NamedNode } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
-import { RDF } from '@lblod/submission-form-helpers';
 import { A } from '@ember/array';
-import { MU } from 'frontend-loket/rdf/namespaces';
+import { MU, RDF } from 'frontend-loket/rdf/namespaces';
 
 const subsidyBaseUri = 'http://lblod.data.gift/vocabularies/subsidie/ukraine/';
 

--- a/app/components/rdf-form-fields/accountability-table/table-row.js
+++ b/app/components/rdf-form-fields/accountability-table/table-row.js
@@ -4,7 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { keepLatestTask, timeout } from 'ember-concurrency';
 import { literal, NamedNode } from 'rdflib';
-import { XSD } from '@lblod/submission-form-helpers';
+import { XSD } from 'frontend-loket/rdf/namespaces';
 import { scheduleOnce } from '@ember/runloop';
 
 const subsidyBaseUri = 'http://lblod.data.gift/vocabularies/subsidie/ukraine/';

--- a/app/components/rdf-form-fields/application-form-table/edit.js
+++ b/app/components/rdf-form-fields/application-form-table/edit.js
@@ -1,12 +1,12 @@
 import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { RDF, triplesForPath, XSD } from '@lblod/submission-form-helpers';
+import { triplesForPath } from '@lblod/submission-form-helpers';
 import { literal, NamedNode } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { next } from '@ember/runloop';
 import { guidFor } from '@ember/object/internals';
-import { LBLOD_SUBSIDIE, MU } from 'frontend-loket/rdf/namespaces';
+import { LBLOD_SUBSIDIE, MU, RDF, XSD } from 'frontend-loket/rdf/namespaces';
 
 const applicationFormTableBaseUri =
   'http://data.lblod.info/application-form-tables';

--- a/app/components/rdf-form-fields/application-form-table/edit.js
+++ b/app/components/rdf-form-fields/application-form-table/edit.js
@@ -2,11 +2,11 @@ import InputFieldComponent from '@lblod/ember-submission-form-fields/components/
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { RDF, triplesForPath, XSD } from '@lblod/submission-form-helpers';
-import { literal, NamedNode, Namespace } from 'rdflib';
+import { literal, NamedNode } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { next } from '@ember/runloop';
 import { guidFor } from '@ember/object/internals';
-import { MU } from 'frontend-loket/rdf/namespaces';
+import { LBLOD_SUBSIDIE, MU } from 'frontend-loket/rdf/namespaces';
 
 const applicationFormTableBaseUri =
   'http://data.lblod.info/application-form-tables';
@@ -43,10 +43,6 @@ const totalAmountPredicate = new NamedNode(
   'http://lblod.data.gift/vocabularies/subsidie/totalAmount'
 );
 const createdPredicate = new NamedNode('http://purl.org/dc/terms/created');
-
-const LBLOD_SUBSIDIE = new Namespace(
-  'http://lblod.data.gift/vocabularies/subsidie/'
-);
 
 const inputFieldNames = [
   'actorName',

--- a/app/components/rdf-form-fields/application-form-table/edit.js
+++ b/app/components/rdf-form-fields/application-form-table/edit.js
@@ -1,14 +1,12 @@
 import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { triplesForPath, XSD } from '@lblod/submission-form-helpers';
+import { RDF, triplesForPath, XSD } from '@lblod/submission-form-helpers';
 import { literal, NamedNode, Namespace } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
-import { RDF } from '@lblod/submission-form-helpers';
 import { next } from '@ember/runloop';
 import { guidFor } from '@ember/object/internals';
-
-const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
+import { MU } from 'frontend-loket/rdf/namespaces';
 
 const applicationFormTableBaseUri =
   'http://data.lblod.info/application-form-tables';

--- a/app/components/rdf-form-fields/application-form-table/show.js
+++ b/app/components/rdf-form-fields/application-form-table/show.js
@@ -1,7 +1,8 @@
 import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
 import { tracked } from '@glimmer/tracking';
 import { triplesForPath } from '@lblod/submission-form-helpers';
-import { NamedNode, Namespace } from 'rdflib';
+import { NamedNode } from 'rdflib';
+import { LBLOD_SUBSIDIE } from 'frontend-loket/rdf/namespaces';
 
 const extBaseUri = 'http://mu.semte.ch/vocabularies/ext/';
 
@@ -21,10 +22,6 @@ const numberChildrenPerInfrastructurePredicate = new NamedNode(
   `http://mu.semte.ch/vocabularies/ext/numberChildrenPerInfrastructure`
 );
 const createdPredicate = new NamedNode('http://purl.org/dc/terms/created');
-
-const LBLOD_SUBSIDIE = new Namespace(
-  'http://lblod.data.gift/vocabularies/subsidie/'
-);
 
 class EntryProperties {
   @tracked value;

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table.js
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table.js
@@ -6,8 +6,12 @@ import { triplesForPath } from '@lblod/submission-form-helpers';
 import { scheduleOnce } from '@ember/runloop';
 import { NamedNode } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
-import { RDF } from '@lblod/submission-form-helpers';
-import { DBPEDIA, LBLOD_SUBSIDIE, MU } from 'frontend-loket/rdf/namespaces';
+import {
+  DBPEDIA,
+  LBLOD_SUBSIDIE,
+  MU,
+  RDF,
+} from 'frontend-loket/rdf/namespaces';
 
 const climateTableBaseUri = 'http://data.lblod.info/climate-tables';
 const lblodSubsidieBaseUri = 'http://lblod.data.gift/vocabularies/subsidie/';

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table.js
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table.js
@@ -7,12 +7,12 @@ import { scheduleOnce } from '@ember/runloop';
 import { NamedNode, Namespace } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { RDF } from '@lblod/submission-form-helpers';
+import { MU } from 'frontend-loket/rdf/namespaces';
 
 const LBLOD_SUBSIDIE = new Namespace(
   'http://lblod.data.gift/vocabularies/subsidie/'
 );
 const DBPEDIA = new Namespace('http://dbpedia.org/ontology/');
-const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
 
 const climateTableBaseUri = 'http://data.lblod.info/climate-tables';
 const lblodSubsidieBaseUri = 'http://lblod.data.gift/vocabularies/subsidie/';

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table.js
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table.js
@@ -4,15 +4,10 @@ import { A } from '@ember/array';
 import { action } from '@ember/object';
 import { triplesForPath } from '@lblod/submission-form-helpers';
 import { scheduleOnce } from '@ember/runloop';
-import { NamedNode, Namespace } from 'rdflib';
+import { NamedNode } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { RDF } from '@lblod/submission-form-helpers';
-import { MU } from 'frontend-loket/rdf/namespaces';
-
-const LBLOD_SUBSIDIE = new Namespace(
-  'http://lblod.data.gift/vocabularies/subsidie/'
-);
-const DBPEDIA = new Namespace('http://dbpedia.org/ontology/');
+import { DBPEDIA, LBLOD_SUBSIDIE, MU } from 'frontend-loket/rdf/namespaces';
 
 const climateTableBaseUri = 'http://data.lblod.info/climate-tables';
 const lblodSubsidieBaseUri = 'http://lblod.data.gift/vocabularies/subsidie/';

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-burgemeesters.js
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-burgemeesters.js
@@ -5,8 +5,7 @@ import { A } from '@ember/array';
 import { scheduleOnce } from '@ember/runloop';
 import { literal, NamedNode } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
-import { RDF, XSD } from '@lblod/submission-form-helpers';
-import { MU } from 'frontend-loket/rdf/namespaces';
+import { MU, RDF, XSD } from 'frontend-loket/rdf/namespaces';
 
 const climateBaseUri = 'http://data.lblod.info/vocabularies/subsidie/climate/';
 const climateTableBaseUri = 'http://data.lblod.info/climate-tables';

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-burgemeesters.js
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-burgemeesters.js
@@ -3,11 +3,10 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { A } from '@ember/array';
 import { scheduleOnce } from '@ember/runloop';
-import { literal, NamedNode, Namespace } from 'rdflib';
+import { literal, NamedNode } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { RDF, XSD } from '@lblod/submission-form-helpers';
-
-const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
+import { MU } from 'frontend-loket/rdf/namespaces';
 
 const climateBaseUri = 'http://data.lblod.info/vocabularies/subsidie/climate/';
 const climateTableBaseUri = 'http://data.lblod.info/climate-tables';

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-custom-action.js
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-custom-action.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { literal, NamedNode, Namespace } from 'rdflib';
+import { literal, NamedNode } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
@@ -10,9 +10,7 @@ import {
   XSD,
   removeSimpleFormValue,
 } from '@lblod/submission-form-helpers';
-import { MU } from 'frontend-loket/rdf/namespaces';
-
-const QB = new Namespace('http://purl.org/linked-data/cube#');
+import { MU, QB } from 'frontend-loket/rdf/namespaces';
 
 const climateBaseUri = 'http://data.lblod.info/vocabularies/subsidie/climate/';
 const climateTableBaseUri = 'http://data.lblod.info/climate-tables';

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-custom-action.js
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-custom-action.js
@@ -5,12 +5,8 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { scheduleOnce } from '@ember/runloop';
-import {
-  RDF,
-  XSD,
-  removeSimpleFormValue,
-} from '@lblod/submission-form-helpers';
-import { MU, QB } from 'frontend-loket/rdf/namespaces';
+import { removeSimpleFormValue } from '@lblod/submission-form-helpers';
+import { MU, QB, RDF, XSD } from 'frontend-loket/rdf/namespaces';
 
 const climateBaseUri = 'http://data.lblod.info/vocabularies/subsidie/climate/';
 const climateTableBaseUri = 'http://data.lblod.info/climate-tables';

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-custom-action.js
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-custom-action.js
@@ -5,14 +5,13 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { scheduleOnce } from '@ember/runloop';
-
 import {
   RDF,
   XSD,
   removeSimpleFormValue,
 } from '@lblod/submission-form-helpers';
+import { MU } from 'frontend-loket/rdf/namespaces';
 
-const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
 const QB = new Namespace('http://purl.org/linked-data/cube#');
 
 const climateBaseUri = 'http://data.lblod.info/vocabularies/subsidie/climate/';

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-vastgoedplan.js
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-vastgoedplan.js
@@ -1,14 +1,12 @@
 import Component from '@glimmer/component';
-import { literal, NamedNode, Namespace } from 'rdflib';
+import { literal, NamedNode } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { A } from '@ember/array';
 import { scheduleOnce } from '@ember/runloop';
-
 import { RDF, XSD } from '@lblod/submission-form-helpers';
-
-const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
+import { MU } from 'frontend-loket/rdf/namespaces';
 
 const climateBaseUri = 'http://data.lblod.info/vocabularies/subsidie/climate/';
 const climateTableBaseUri = 'http://data.lblod.info/climate-tables';

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-vastgoedplan.js
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-vastgoedplan.js
@@ -5,8 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { A } from '@ember/array';
 import { scheduleOnce } from '@ember/runloop';
-import { RDF, XSD } from '@lblod/submission-form-helpers';
-import { MU } from 'frontend-loket/rdf/namespaces';
+import { MU, RDF, XSD } from 'frontend-loket/rdf/namespaces';
 
 const climateBaseUri = 'http://data.lblod.info/vocabularies/subsidie/climate/';
 const climateTableBaseUri = 'http://data.lblod.info/climate-tables';

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-werf.js
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-werf.js
@@ -1,14 +1,12 @@
 import Component from '@glimmer/component';
-import { literal, NamedNode, Namespace } from 'rdflib';
+import { literal, NamedNode } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { tracked } from '@glimmer/tracking';
 import { A } from '@ember/array';
 import { action } from '@ember/object';
 import { scheduleOnce } from '@ember/runloop';
-
 import { RDF, XSD } from '@lblod/submission-form-helpers';
-
-const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
+import { MU } from 'frontend-loket/rdf/namespaces';
 
 const climateBaseUri = 'http://data.lblod.info/vocabularies/subsidie/climate/';
 const climateTableBaseUri = 'http://data.lblod.info/climate-tables';

--- a/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-werf.js
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table/table-row-werf.js
@@ -5,8 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import { A } from '@ember/array';
 import { action } from '@ember/object';
 import { scheduleOnce } from '@ember/runloop';
-import { RDF, XSD } from '@lblod/submission-form-helpers';
-import { MU } from 'frontend-loket/rdf/namespaces';
+import { MU, RDF, XSD } from 'frontend-loket/rdf/namespaces';
 
 const climateBaseUri = 'http://data.lblod.info/vocabularies/subsidie/climate/';
 const climateTableBaseUri = 'http://data.lblod.info/climate-tables';

--- a/app/components/rdf-form-fields/engagement-table/edit.js
+++ b/app/components/rdf-form-fields/engagement-table/edit.js
@@ -4,9 +4,8 @@ import { tracked } from '@glimmer/tracking';
 import { triplesForPath } from '@lblod/submission-form-helpers';
 import { NamedNode } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
-import { RDF } from '@lblod/submission-form-helpers';
 import { next } from '@ember/runloop';
-import { MU } from 'frontend-loket/rdf/namespaces';
+import { MU, RDF } from 'frontend-loket/rdf/namespaces';
 
 const engagementTableBaseUri = 'http://data.lblod.info/engagement-tables';
 const engagementEntryBaseUri = 'http://data.lblod.info/engagement-entries';

--- a/app/components/rdf-form-fields/engagement-table/edit.js
+++ b/app/components/rdf-form-fields/engagement-table/edit.js
@@ -2,12 +2,11 @@ import InputFieldComponent from '@lblod/ember-submission-form-fields/components/
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { triplesForPath } from '@lblod/submission-form-helpers';
-import { NamedNode, Namespace } from 'rdflib';
+import { NamedNode } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { RDF } from '@lblod/submission-form-helpers';
 import { next } from '@ember/runloop';
-
-const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
+import { MU } from 'frontend-loket/rdf/namespaces';
 
 const engagementTableBaseUri = 'http://data.lblod.info/engagement-tables';
 const engagementEntryBaseUri = 'http://data.lblod.info/engagement-entries';

--- a/app/components/rdf-form-fields/estimated-cost-table/base-table.js
+++ b/app/components/rdf-form-fields/estimated-cost-table/base-table.js
@@ -2,9 +2,7 @@ import { tracked } from '@glimmer/tracking';
 
 import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
 import { triplesForPath } from '@lblod/submission-form-helpers';
-import { NamedNode, Namespace } from 'rdflib';
-
-export const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
+import { NamedNode } from 'rdflib';
 
 export const estimatedCostTableBaseUri =
   'http://lblod.data.gift/id/subsidie/bicycle-infrastructure/table';

--- a/app/components/rdf-form-fields/estimated-cost-table/edit.js
+++ b/app/components/rdf-form-fields/estimated-cost-table/edit.js
@@ -9,7 +9,6 @@ import { next } from '@ember/runloop';
 import BaseTable from './base-table';
 import { EstimatedCostEntry } from './base-table';
 import {
-  MU,
   estimatedCostTableBaseUri,
   EstimatedCostTableType,
   estimatedCostTablePredicate,
@@ -19,6 +18,7 @@ import {
   costPredicate,
   validEstimatedCostTable,
 } from './base-table';
+import { MU } from 'frontend-loket/rdf/namespaces';
 
 import commasToDecimalPointsFix from '../../../helpers/subsidies/subsidies-decimal-point';
 

--- a/app/components/rdf-form-fields/estimated-cost-table/edit.js
+++ b/app/components/rdf-form-fields/estimated-cost-table/edit.js
@@ -3,7 +3,6 @@ import { tracked } from '@glimmer/tracking';
 
 import { NamedNode } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
-import { RDF } from '@lblod/submission-form-helpers';
 import { next } from '@ember/runloop';
 
 import BaseTable from './base-table';
@@ -18,7 +17,7 @@ import {
   costPredicate,
   validEstimatedCostTable,
 } from './base-table';
-import { MU } from 'frontend-loket/rdf/namespaces';
+import { MU, RDF } from 'frontend-loket/rdf/namespaces';
 
 import commasToDecimalPointsFix from '../../../helpers/subsidies/subsidies-decimal-point';
 

--- a/app/components/rdf-form-fields/objective-table/edit.js
+++ b/app/components/rdf-form-fields/objective-table/edit.js
@@ -2,12 +2,11 @@ import InputFieldComponent from '@lblod/ember-submission-form-fields/components/
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { triplesForPath } from '@lblod/submission-form-helpers';
-import { NamedNode, Namespace } from 'rdflib';
+import { NamedNode } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { RDF } from '@lblod/submission-form-helpers';
 import { scheduleOnce } from '@ember/runloop';
-
-const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
+import { MU } from 'frontend-loket/rdf/namespaces';
 
 const bicycleInfrastructureUri =
   'http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#';

--- a/app/components/rdf-form-fields/objective-table/edit.js
+++ b/app/components/rdf-form-fields/objective-table/edit.js
@@ -4,9 +4,8 @@ import { action } from '@ember/object';
 import { triplesForPath } from '@lblod/submission-form-helpers';
 import { NamedNode } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
-import { RDF } from '@lblod/submission-form-helpers';
 import { scheduleOnce } from '@ember/runloop';
-import { MU } from 'frontend-loket/rdf/namespaces';
+import { MU, RDF } from 'frontend-loket/rdf/namespaces';
 
 const bicycleInfrastructureUri =
   'http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#';

--- a/app/components/rdf-form-fields/objective-table/table-cell.js
+++ b/app/components/rdf-form-fields/objective-table/table-cell.js
@@ -4,9 +4,8 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { literal, NamedNode } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
-import { RDF } from '@lblod/submission-form-helpers';
 import commasToDecimalPointsFix from 'frontend-loket/helpers/subsidies/subsidies-decimal-point';
-import { MU } from 'frontend-loket/rdf/namespaces';
+import { MU, RDF } from 'frontend-loket/rdf/namespaces';
 
 const bicycleInfrastructureUri =
   'http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#';

--- a/app/components/rdf-form-fields/objective-table/table-cell.js
+++ b/app/components/rdf-form-fields/objective-table/table-cell.js
@@ -2,12 +2,11 @@ import Component from '@glimmer/component';
 import { schedule } from '@ember/runloop';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { literal, NamedNode, Namespace } from 'rdflib';
+import { literal, NamedNode } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { RDF } from '@lblod/submission-form-helpers';
 import commasToDecimalPointsFix from 'frontend-loket/helpers/subsidies/subsidies-decimal-point';
-
-const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
+import { MU } from 'frontend-loket/rdf/namespaces';
 
 const bicycleInfrastructureUri =
   'http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#';

--- a/app/components/rdf-form-fields/plan-living-together-table/edit.js
+++ b/app/components/rdf-form-fields/plan-living-together-table/edit.js
@@ -4,11 +4,9 @@ import { A } from '@ember/array';
 import { action } from '@ember/object';
 import { triplesForPath } from '@lblod/submission-form-helpers';
 import { scheduleOnce } from '@ember/runloop';
-import { NamedNode, Namespace } from 'rdflib';
+import { NamedNode } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
-import { RDF } from '@lblod/submission-form-helpers';
-
-const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
+import { MU, RDF } from 'frontend-loket/rdf/namespaces';
 
 const planBaseUri =
   'http://lblod.data.gift/vocabularies/subsidie/plan-samenleven/';

--- a/app/components/rdf-form-fields/plan-living-together-table/table-row.js
+++ b/app/components/rdf-form-fields/plan-living-together-table/table-row.js
@@ -2,12 +2,11 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { A } from '@ember/array';
 import { action } from '@ember/object';
-import { literal, NamedNode, Namespace } from 'rdflib';
+import { literal, NamedNode } from 'rdflib';
 import { scheduleOnce } from '@ember/runloop';
 import { v4 as uuidv4 } from 'uuid';
 import { RDF, XSD } from '@lblod/submission-form-helpers';
-
-const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
+import { MU } from 'frontend-loket/rdf/namespaces';
 
 const planBaseUri =
   'http://lblod.data.gift/vocabularies/subsidie/plan-samenleven/';

--- a/app/components/rdf-form-fields/plan-living-together-table/table-row.js
+++ b/app/components/rdf-form-fields/plan-living-together-table/table-row.js
@@ -5,8 +5,7 @@ import { action } from '@ember/object';
 import { literal, NamedNode } from 'rdflib';
 import { scheduleOnce } from '@ember/runloop';
 import { v4 as uuidv4 } from 'uuid';
-import { RDF, XSD } from '@lblod/submission-form-helpers';
-import { MU } from 'frontend-loket/rdf/namespaces';
+import { MU, RDF, XSD } from 'frontend-loket/rdf/namespaces';
 
 const planBaseUri =
   'http://lblod.data.gift/vocabularies/subsidie/plan-samenleven/';

--- a/app/rdf/namespaces.js
+++ b/app/rdf/namespaces.js
@@ -1,0 +1,3 @@
+import { Namespace } from 'rdflib';
+
+export const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');

--- a/app/rdf/namespaces.js
+++ b/app/rdf/namespaces.js
@@ -1,5 +1,7 @@
 import { Namespace } from 'rdflib';
 
+export { FORM, RDF, XSD } from '@lblod/submission-form-helpers';
+
 export const DBPEDIA = new Namespace('http://dbpedia.org/ontology/');
 export const LBLOD_SUBSIDIE = new Namespace(
   'http://lblod.data.gift/vocabularies/subsidie/'

--- a/app/rdf/namespaces.js
+++ b/app/rdf/namespaces.js
@@ -1,3 +1,8 @@
 import { Namespace } from 'rdflib';
 
+export const DBPEDIA = new Namespace('http://dbpedia.org/ontology/');
+export const LBLOD_SUBSIDIE = new Namespace(
+  'http://lblod.data.gift/vocabularies/subsidie/'
+);
 export const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
+export const QB = new Namespace('http://purl.org/linked-data/cube#');

--- a/app/routes/subsidy/applications/edit/step/edit.js
+++ b/app/routes/subsidy/applications/edit/step/edit.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import fetch from 'fetch';
 import { ForkingStore } from '@lblod/ember-submission-form-fields';
-import { FORM, RDF } from '@lblod/submission-form-helpers';
+import { FORM, RDF } from 'frontend-loket/rdf/namespaces';
 import { NamedNode } from 'rdflib';
 
 const FORM_GRAPH = new NamedNode('http://data.lblod.info/form');

--- a/app/routes/subsidy/applications/edit/step/edit.js
+++ b/app/routes/subsidy/applications/edit/step/edit.js
@@ -2,10 +2,9 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import fetch from 'fetch';
 import { ForkingStore } from '@lblod/ember-submission-form-fields';
-import { RDF } from '@lblod/submission-form-helpers';
-import { NamedNode, Namespace } from 'rdflib';
+import { FORM, RDF } from '@lblod/submission-form-helpers';
+import { NamedNode } from 'rdflib';
 
-const FORM = new Namespace('http://lblod.data.gift/vocabularies/forms/');
 const FORM_GRAPH = new NamedNode('http://data.lblod.info/form');
 const META_GRAPH = new NamedNode('http://data.lblod.info/metagraph');
 const SOURCE_GRAPH = new NamedNode(`http://data.lblod.info/sourcegraph`);

--- a/app/routes/supervision/submissions/edit.js
+++ b/app/routes/supervision/submissions/edit.js
@@ -3,7 +3,7 @@ import { warn } from '@ember/debug';
 import { inject as service } from '@ember/service';
 import fetch from 'fetch';
 import { ForkingStore } from '@lblod/ember-submission-form-fields';
-import { FORM, RDF } from '@lblod/submission-form-helpers';
+import { FORM, RDF } from 'frontend-loket/rdf/namespaces';
 import { NamedNode } from 'rdflib';
 import { SENT_STATUS } from '../../../models/submission-document-status';
 

--- a/app/routes/supervision/submissions/edit.js
+++ b/app/routes/supervision/submissions/edit.js
@@ -3,11 +3,9 @@ import { warn } from '@ember/debug';
 import { inject as service } from '@ember/service';
 import fetch from 'fetch';
 import { ForkingStore } from '@lblod/ember-submission-form-fields';
-import { NamedNode, Namespace } from 'rdflib';
+import { FORM, RDF } from '@lblod/submission-form-helpers';
+import { NamedNode } from 'rdflib';
 import { SENT_STATUS } from '../../../models/submission-document-status';
-
-const RDF = new Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#');
-const FORM = new Namespace('http://lblod.data.gift/vocabularies/forms/');
 
 export default class SupervisionSubmissionsEditRoute extends Route {
   @service router;

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@lblod/ember-mock-login": "^0.7.0",
     "@lblod/ember-rdfa-editor": "^0.59.1",
     "@lblod/ember-submission-form-fields": "^2.0.3",
+    "@lblod/submission-form-helpers": "^2.1.0",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "browser-update": "^3.3.38",


### PR DESCRIPTION
We were defining a lot of custom rdflib namespaces which were either already exported, or used in multiple places.

This refactors the code a bit to reuse the existing ones, and make the others more reusable.