### PR TITLE
Update to Appuniversum v1.4.1+

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,98 +1,110 @@
 {{page-title this.appTitle}}
-<AuToaster />
-<AuMainHeader
-  @brandLink={{unless this.session.isAuthenticated "https://www.vlaanderen.be/nl"}}
-  @homeRoute="index"
-  @appTitle={{this.appTitle}}
->
-  <li class="au-c-list-horizontal__item">
-    <AuLink @route="help" @skin="secondary">
-      <AuIcon @icon="question-circle" @alignment="left" />
-      Help
-    </AuLink>
-  </li>
-  <li class="au-c-list-horizontal__item">
-    {{#if this.session.isAuthenticated}}
-      <AuDropdown
-        @title="{{this.currentSession.user.voornaam}} {{this.currentSession.user.achternaam}} - {{this.currentSession.groupClassification.label}} {{this.currentSession.group.naam}}"
-        @buttonLabel="Account settings"
-        @alignment="right"
-        role="menu"
-      >
-        <Acmidm::Switch as |acmidm|>
+
+<AuApp>
+  <AuMainHeader
+    @brandLink={{unless
+      this.session.isAuthenticated
+      "https://www.vlaanderen.be/nl"
+    }}
+    @homeRoute="index"
+    @appTitle={{this.appTitle}}
+  >
+    <li class="au-c-list-horizontal__item">
+      <AuLink @route="help" @skin="secondary">
+        <AuIcon @icon="question-circle" @alignment="left" />
+        Help
+      </AuLink>
+    </li>
+    <li class="au-c-list-horizontal__item">
+      {{#if this.session.isAuthenticated}}
+        <AuDropdown
+          @title="{{this.currentSession.user.voornaam}} {{this.currentSession.user.achternaam}} - {{this.currentSession.groupClassification.label}} {{this.currentSession.group.naam}}"
+          @buttonLabel="Account settings"
+          @alignment="right"
+          role="menu"
+        >
+          <Acmidm::Switch as |acmidm|>
+            <AuButton
+              @disabled={{acmidm.isSwitching}}
+              @skin="link"
+              @icon="switch"
+              @iconAlignment="left"
+              role="menuitem"
+              {{on "click" acmidm.switch}}
+              {{!template-lint-disable require-context-role}}
+            >
+              Wissel van bestuurseenheid
+            </AuButton>
+          </Acmidm::Switch>
+
           <AuButton
-            @disabled={{acmidm.isSwitching}}
             @skin="link"
-            @icon="switch"
+            @icon="logout"
             @iconAlignment="left"
             role="menuitem"
-            {{on "click" acmidm.switch}}
-            {{!template-lint-disable require-context-role}}
+            {{on "click" this.logout}}
           >
-            Wissel van bestuurseenheid
+            Afmelden
           </AuButton>
-        </Acmidm::Switch>
+        </AuDropdown>
+      {{else}}
+        <LoginButton @isCompact={{true}} />
+      {{/if}}
+    </li>
+  </AuMainHeader>
 
-        <AuButton
-          @skin="link"
-          @icon="logout"
-          @iconAlignment="left"
-          role="menuitem"
-          {{on "click" this.logout}}
-        >
-          Afmelden
-        </AuButton>
-      </AuDropdown>
-    {{else}}
-      <LoginButton @isCompact={{true}} />
-    {{/if}}
-  </li>
-</AuMainHeader>
-
-{{#if this.session.isAuthenticated}}
-<main id="main" class="au-c-main-container">
-  {{#if this.isIndex}}
-  <div class="au-c-main-container__sidebar">
-    <div class="au-c-sidebar">
-      <div class="au-c-sidebar__content">
-        <Shared::MainMenu/>
-      </div>
-      <div class="au-c-sidebar__footer">
-        <a href="https://loket.lokaalbestuur.vlaanderen.be/handleiding/" target="_blank" rel="noopener noreferrer" class="au-c-link au-c-link--secondary au-c-link--icon">
-          <AuIcon @icon="documents" @alignment="left" /> Bekijk handleiding
-        </a>
-      </div>
-    </div>
-  </div>
+  {{#if this.session.isAuthenticated}}
+    <AuMainContainer as |main|>
+      {{#if this.isIndex}}
+        <main.sidebar>
+          <div class="au-c-sidebar">
+            <div class="au-c-sidebar__content">
+              <Shared::MainMenu />
+            </div>
+            <div class="au-c-sidebar__footer">
+              <a
+                href="https://loket.lokaalbestuur.vlaanderen.be/handleiding/"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="au-c-link au-c-link--secondary au-c-link--icon"
+              >
+                <AuIcon @icon="documents" @alignment="left" />
+                Bekijk handleiding
+              </a>
+            </div>
+          </div>
+        </main.sidebar>
+      {{/if}}
+      <main.content>
+        <AuBodyContainer>
+          {{#unless this.isIndex}}
+            <AuToolbar @size="medium" @skin="tint" @border="bottom" as |Group|>
+              <Group>
+                <ul class="au-c-list-horizontal au-c-list-horizontal--small">
+                  <li class="au-c-list-horizontal__item">
+                    <AuLink @route="index">
+                      <AuIcon @icon="arrow-left" @alignment="left" />
+                      Overzicht modules
+                    </AuLink>
+                  </li>
+                  <li class="au-c-list-horizontal__item">
+                    <Shared::CompactMenu />
+                  </li>
+                  <Shared::BreadCrumb />
+                </ul>
+              </Group>
+            </AuToolbar>
+          {{/unless}}
+          <AuBodyContainer id="content">
+            {{outlet}}
+          </AuBodyContainer>
+        </AuBodyContainer>
+      </main.content>
+    </AuMainContainer>
+  {{else}}
+    {{outlet}}
   {{/if}}
-  <div class="au-c-main-container__content">
-    <div class="au-c-body-container">
-      {{#unless this.isIndex}}
-        <AuToolbar @size="medium" @skin="tint" @border="bottom" as |Group|>
-          <Group>
-            <ul class="au-c-list-horizontal au-c-list-horizontal--small">
-              <li class="au-c-list-horizontal__item">
-                <AuLink @route="index">
-                  <AuIcon @icon="arrow-left" @alignment="left" />
-                  Overzicht modules
-                </AuLink>
-              </li>
-              <li class="au-c-list-horizontal__item">
-                <Shared::CompactMenu/>
-              </li>
-              <Shared::BreadCrumb/>
-            </ul>
-          </Group>
-        </AuToolbar>
-      {{/unless}}
-      <div id="content" class="au-c-body-container">
-        {{outlet}}
-      </div>
-    </div>
-  </div>
-</main>
-{{else}}
-  {{outlet}}
-{{/if}}
+</AuApp>
 
 <EpmModalContainer />
+<AuToaster />

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@appuniversum/appuniversum": "^1.2.0",
-    "@appuniversum/ember-appuniversum": "1.3.0",
+    "@appuniversum/ember-appuniversum": "^1.5.0",
     "@codemirror/basic-setup": "^0.20.0",
     "@codemirror/lang-html": "^6.0.0",
     "@codemirror/lang-xml": "^6.0.0",


### PR DESCRIPTION
~~Wrapping the app in `AuApp` solves a lot of issues, but not everything. The body container previously used display flex + columns, which we depended on in some pages to align toolbars to the bottom (while making the content above scrollable). This no longer works and that can be seen in the Toezicht module.~~

The issue was fixed in Appuniversum v1.4.1 so we can unpin the version. It also includes the `AuApp` wrapper since that's a good change regardless and I had already written the code.