### PR TITLE
Fix the `@showDefaultHead` argument

### DIFF
--- a/app/components/shared/persoon/persoon-search-form.js
+++ b/app/components/shared/persoon/persoon-search-form.js
@@ -9,7 +9,6 @@ export default class SharedPersoonPersoonSearchFormComponent extends Component {
   @service store;
 
   @tracked pageSize = 20;
-  @tracked showDefaultHead = true;
   @tracked queryParams;
   @tracked error;
   @tracked page;
@@ -31,6 +30,10 @@ export default class SharedPersoonPersoonSearchFormComponent extends Component {
 
   get hasSearched() {
     return this.search.performCount > 0;
+  }
+
+  get showDefaultHead() {
+    return this.args.showDefaultHead ?? true;
   }
 
   constructor() {


### PR DESCRIPTION
This argument value was lost when the component was converted to a Glimmer component so it always defaulted to `true`.