### PR TITLE
Optimize some network calls

### DIFF
--- a/app/routes/eredienst-mandatenbeheer/mandataris.js
+++ b/app/routes/eredienst-mandatenbeheer/mandataris.js
@@ -6,7 +6,8 @@ export default class EredienstMandatenbeheerMandatarisRoute extends Route {
 
   model(params) {
     return this.store.findRecord('worship-mandatee', params.mandateeId, {
-      include: 'is-bestuurlijke-alias-van,bekleedt,type-half',
+      include:
+        'is-bestuurlijke-alias-van,bekleedt.bestuursfunctie,type-half,contacts',
     });
   }
 }

--- a/app/routes/eredienst-mandatenbeheer/mandatarissen.js
+++ b/app/routes/eredienst-mandatenbeheer/mandatarissen.js
@@ -31,7 +31,7 @@ export default class EredienstMandatenbeheerMandatarissenRoute extends Route.ext
       },
       include: [
         'type-half',
-        'bekleedt',
+        'bekleedt.bevat-in.is-tijdsspecialisatie-van',
         'is-bestuurlijke-alias-van',
         'bekleedt.bestuursfunctie',
       ].join(','),

--- a/app/routes/worship-ministers-management/minister/edit.js
+++ b/app/routes/worship-ministers-management/minister/edit.js
@@ -14,7 +14,13 @@ export default class WorshipMinistersManagementMinisterEditRoute extends Route {
       'worship-ministers-management.minister'
     );
 
-    const minister = await this.store.findRecord('minister', worshipMinisterId);
+    const minister = await this.store.findRecord(
+      'minister',
+      worshipMinisterId,
+      {
+        include: ['person', 'contacts', 'minister-position.function'].join(),
+      }
+    );
 
     let person = await minister.person;
     let positionContacts = await minister.contacts;


### PR DESCRIPTION
We forgot to use "includes" in some calls which causes the relationship to be fetched on access. This is a problem once we start switching to sync relationships.