### PR TITLE
Fix the backend search option of the ConceptSelector component

### DIFF
--- a/app/components/rdf-form-fields/concept-selector.hbs
+++ b/app/components/rdf-form-fields/concept-selector.hbs
@@ -10,7 +10,7 @@
     @triggerId={{this.inputId}}
     @selected={{this.selected}}
     @searchEnabled={{this.isSearchEnabled}}
-    @search={{if this.backendSearch (perform this.search)}}
+    @search={{if this.isBackendSearch (perform this.search)}}
     @searchField="label"
     @options={{this.options}}
     @onClose={{fn (mut this.hasBeenFocused) true}}


### PR DESCRIPTION
A last minute rename broke the backend search logic from running.