### PR TITLE
Fix duplicate entries in the mandate position select

### DIFF
--- a/app/components/mandatenbeheer/bestuursperioden-selector.js
+++ b/app/components/mandatenbeheer/bestuursperioden-selector.js
@@ -11,8 +11,7 @@ export default class MandatenbeheerBestuursperiodenSelectorComponent extends Com
       .map((b) => {
         return { bindingStart: b.bindingStart, bindingEinde: b.bindingEinde };
       })
-      .sortBy('bindingStart')
-      .reverse();
+      .sortBy('bindingStart');
     return options.filter(
       (o, i) =>
         options
@@ -24,6 +23,7 @@ export default class MandatenbeheerBestuursperiodenSelectorComponent extends Com
   constructor() {
     super(...arguments);
     this._options = this.getUniqueBestuursperiodes(this.args.options) || [];
+    console.log(this._options);
   }
 
   get selectedBestuursorgaan() {

--- a/app/components/mandatenbeheer/bestuursperioden-selector.js
+++ b/app/components/mandatenbeheer/bestuursperioden-selector.js
@@ -23,7 +23,6 @@ export default class MandatenbeheerBestuursperiodenSelectorComponent extends Com
   constructor() {
     super(...arguments);
     this._options = this.getUniqueBestuursperiodes(this.args.options) || [];
-    console.log(this._options);
   }
 
   get selectedBestuursorgaan() {

--- a/app/routes/eredienst-mandatenbeheer/new.js
+++ b/app/routes/eredienst-mandatenbeheer/new.js
@@ -23,7 +23,6 @@ export default class EredienstMandatenbeheerNewRoute extends Route {
         this.store.findRecord('persoon', personId, {
           backgroundReload: false,
         }),
-        this.store.findAll('half-election'),
         this.bestuursorganen.length > 1
           ? [this.bestuursorganen.at(0)] // The recent bindingStart selected by default
           : this.bestuursorganen,

--- a/app/routes/eredienst-mandatenbeheer/new.js
+++ b/app/routes/eredienst-mandatenbeheer/new.js
@@ -13,7 +13,8 @@ export default class EredienstMandatenbeheerNewRoute extends Route {
 
   beforeModel() {
     const mandatenbeheer = this.modelFor('eredienst-mandatenbeheer');
-    this.bestuursorganen = mandatenbeheer.bestuursorganen;
+    this.bestuursorganen =
+      mandatenbeheer.bestuursorganen.sortBy('bindingStart');
   }
 
   async model({ personId }) {
@@ -23,7 +24,9 @@ export default class EredienstMandatenbeheerNewRoute extends Route {
           backgroundReload: false,
         }),
         this.store.findAll('half-election'),
-        this.bestuursorganen,
+        this.bestuursorganen.length > 1
+          ? [this.bestuursorganen.at(0)] // The recent bindingStart selected by default
+          : this.bestuursorganen,
       ]);
 
       let worshipMandatee = this.store.createRecord('worship-mandatee');


### PR DESCRIPTION
DL-4163

We get all IDs when not selecting a bestuursperiode, leading to duplicate results when we call `mandaat?filter[bevat-in][id]={IDs}&sort=bestuursfunctie.label`.

This changes the order of entities inside the `BestuursperiodenSelector` so the recent date is set first.

When a user isn't selecting a bestuursperiode and wants to create a new mandatee, the bestuursperiode by default is the most recent on the `new` route.