### PR TITLE
Fix the read-only mode of the properties tab

### DIFF
--- a/app/templates/public-services/details/properties.hbs
+++ b/app/templates/public-services/details/properties.hbs
@@ -2,6 +2,7 @@
 
 <PublicServices::DetailsPage
   @publicService={{@model.publicService}}
+  @readOnly={{@model.readOnly}}
   @formId="149a7247-0294-44a5-a281-0a4d3782b4fd"
   @tabName="au-c-rdf-form--properties"
 />


### PR DESCRIPTION
It seems we forgot to pass update this in the previous PR.