### PR TITLE
Set up release-it

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,0 +1,5 @@
+{
+  "npm": {
+    "publish": false
+  }
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
+    "release": "release-it",
     "start": "ember serve",
     "test": "npm-run-all lint test:*",
     "test:ember": "ember test"
@@ -64,7 +65,6 @@
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-moment-shim": "^3.8.0",
-    "ember-cli-release": "^1.0.0-beta.2",
     "ember-cli-sass": "^10.0.1",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-string-helpers": "^6.1.0",
@@ -103,6 +103,7 @@
     "qunit": "^2.17.2",
     "qunit-dom": "^2.0.0",
     "rdflib": "^2.2.19",
+    "release-it": "^15.4.1",
     "sass": "^1.49.7",
     "tracked-toolbox": "^1.2.3",
     "webpack": "^5.68.0",


### PR DESCRIPTION
This replaces ember-cli-release with release-it. ember-cli-release has been deprecated for a while and it brought in an old npm version which sometimes caused issues.

`npm run release` is all that's needed to create a new release. release-it will then prompt for some basic information.