### PR TITLE
Hotfix/bestuursperiode selector

### DIFF
--- a/app/components/mandatenbeheer/bestuursperioden-selector.hbs
+++ b/app/components/mandatenbeheer/bestuursperioden-selector.hbs
@@ -1,15 +1,15 @@
 <PowerSelect
-  @selected={{this.selectedBestuursorgaan}}
+  @selected={{this.args.selectedPeriod}}
   @options={{this._options}}
   class="is-optional"
-  @onChange={{this.selectBestuursorgaan}}
+  @onChange={{this.selectPeriod}}
   @searchEnabled={{false}}
-  as |orgaan|>
-    Bestuursperiode {{moment-format orgaan.bindingStart 'YYYY'}}
-    -
-    {{#if orgaan.bindingEinde}}
-      {{moment-format orgaan.bindingEinde 'YYYY'}}
-    {{else}}
-      heden
-    {{/if}}
+  as |period|>
+  Bestuursperiode {{moment-format period.startDate 'YYYY'}}
+  -
+  {{#if period.endDate}}
+    {{moment-format period.endDate 'YYYY'}}
+  {{else}}
+    heden
+  {{/if}}
 </PowerSelect>

--- a/app/components/mandatenbeheer/bestuursperioden-selector.hbs
+++ b/app/components/mandatenbeheer/bestuursperioden-selector.hbs
@@ -1,5 +1,5 @@
 <PowerSelect
-  @selected={{this.args.selectedPeriod}}
+  @selected={{@selectedPeriod}}
   @options={{this._options}}
   class="is-optional"
   @onChange={{this.selectPeriod}}

--- a/app/components/mandatenbeheer/bestuursperioden-selector.js
+++ b/app/components/mandatenbeheer/bestuursperioden-selector.js
@@ -1,5 +1,4 @@
 import Component from '@glimmer/component';
-import moment from 'moment';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 

--- a/app/components/mandatenbeheer/bestuursperioden-selector.js
+++ b/app/components/mandatenbeheer/bestuursperioden-selector.js
@@ -7,7 +7,7 @@ export default class MandatenbeheerBestuursperiodenSelectorComponent extends Com
 
   constructor() {
     super(...arguments);
-    this._options = this.args.options || [];
+    this._options = this.args.options.sortBy('startDate') || [];
   }
 
   @action

--- a/app/components/mandatenbeheer/bestuursperioden-selector.js
+++ b/app/components/mandatenbeheer/bestuursperioden-selector.js
@@ -7,7 +7,9 @@ export default class MandatenbeheerBestuursperiodenSelectorComponent extends Com
 
   constructor() {
     super(...arguments);
-    this._options = this.args.options.sortBy('startDate') || [];
+    this._options = (this.args.options || []).sort(
+      (a, b) => a.startDate > b.startDate
+    );
   }
 
   @action

--- a/app/components/mandatenbeheer/bestuursperioden-selector.js
+++ b/app/components/mandatenbeheer/bestuursperioden-selector.js
@@ -6,55 +6,13 @@ import { action } from '@ember/object';
 export default class MandatenbeheerBestuursperiodenSelectorComponent extends Component {
   @tracked _options;
 
-  getUniqueBestuursperiodes(bestuursorganen) {
-    let options = bestuursorganen
-      .map((b) => {
-        return { bindingStart: b.bindingStart, bindingEinde: b.bindingEinde };
-      })
-      .sortBy('bindingStart')
-      .reverse();
-    return options.filter(
-      (o, i) =>
-        options
-          .map((periode) => JSON.stringify(periode))
-          .indexOf(JSON.stringify(o)) === i
-    );
-  }
-
   constructor() {
     super(...arguments);
-    this._options = this.getUniqueBestuursperiodes(this.args.options) || [];
-  }
-
-  get selectedBestuursorgaan() {
-    if (this.args.selectedStartDate && this.args.selectedEndDate) {
-      return this._options.find((o) => {
-        return (
-          o.bindingStart.toDateString() ==
-            new Date(this.args.selectedStartDate).toDateString() &&
-          o.bindingEinde?.toDateString() ==
-            new Date(this.args.selectedEndDate).toDateString()
-        );
-      });
-    } else if (this.args.selectedStartDate) {
-      return this._options.find((o) => {
-        return (
-          o.bindingStart.toDateString() ==
-            new Date(this.args.selectedStartDate).toDateString() &&
-          !o.bindingEinde
-        );
-      });
-    } else {
-      return this._options[0];
-    }
+    this._options = this.args.options || [];
   }
 
   @action
-  selectBestuursorgaan(periode) {
-    const start = moment(periode.bindingStart).format('YYYY-MM-DD');
-    const einde = periode.bindingEinde
-      ? moment(periode.bindingEinde).format('YYYY-MM-DD')
-      : null;
-    this.args.onSelect(start, einde);
+  selectPeriod(periode) {
+    this.args.onSelect(periode);
   }
 }

--- a/app/controllers/eredienst-mandatenbeheer/mandatarissen.js
+++ b/app/controllers/eredienst-mandatenbeheer/mandatarissen.js
@@ -42,13 +42,13 @@ export default class EredienstMandatenbeheerMandatarissenController extends Cont
   }
 
   @action
-  selectPeriod(startDate, endDate) {
+  selectPeriod(period) {
     const queryParams = {
       page: 0,
-      startDate: startDate,
+      startDate: period.startDate,
     };
 
-    queryParams['endDate'] = endDate;
+    queryParams['endDate'] = period.endDate;
 
     this.router.transitionTo('eredienst-mandatenbeheer.mandatarissen', {
       queryParams,

--- a/app/controllers/mandatenbeheer/mandatarissen.js
+++ b/app/controllers/mandatenbeheer/mandatarissen.js
@@ -56,13 +56,13 @@ export default class MandatenbeheerMandatarissenController extends Controller {
   }
 
   @action
-  selectPeriod(startDate, endDate) {
+  selectPeriod(period) {
     const queryParams = {
       page: 0,
-      startDate: startDate,
+      startDate: period.startDate,
     };
 
-    queryParams['endDate'] = endDate;
+    queryParams['endDate'] = period.endDate;
 
     this.router.transitionTo('mandatenbeheer.mandatarissen', {
       queryParams,

--- a/app/routes/eredienst-mandatenbeheer.js
+++ b/app/routes/eredienst-mandatenbeheer.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
+import moment from 'moment';
 
 export default class EredienstMandatenbeheerRoute extends Route {
   @service currentSession;
@@ -27,66 +28,75 @@ export default class EredienstMandatenbeheerRoute extends Route {
     this.endDate = params.endDate;
 
     const bestuurseenheid = this.currentSession.group;
-
-    return RSVP.hash({
-      bestuurseenheid: bestuurseenheid,
-      bestuursorganen: this.getBestuursorganenInTijdByPeriod(
-        bestuurseenheid.get('id')
-      ),
-      bestuursperioden: this.getBestuursperioden(bestuurseenheid.get('id')),
+    const bestuursorganen = await this.getRelevantBestuursorganen(
+      bestuurseenheid.get('id')
+    );
+    const bestuursperiods =
+      this.calculateUniqueBestuursperiods(bestuursorganen);
+    const selectedPeriod = this.calculateSelectedPeriod(bestuursperiods, {
       startDate: this.startDate,
       endDate: this.endDate,
     });
-  }
 
-  /*
-   * Returns bestuursorgaan in tijd starting on the given a period
-   * for all bestuursorganen of the given bestuurseenheid.
-   * TODO: keep in sync with routes/mandatenbeheer.
-   *       Extract common code once we are sure of the common pattern.
-   */
-  async getBestuursorganenInTijdByPeriod(bestuurseenheidId) {
-    const bestuursorganen = await this.store.query('bestuursorgaan', {
-      'filter[bestuurseenheid][id]': bestuurseenheidId,
-      'filter[heeft-tijdsspecialisaties][:has:bevat]': true, // only organs with a mandate
+    const selectedBestuursOrganen = this.getBestuursorganenForPeriod(
+      bestuursorganen,
+      selectedPeriod
+    );
+
+    return RSVP.hash({
+      bestuurseenheid,
+      bestuursorganen: selectedBestuursOrganen,
+      bestuursperiods,
+      selectedPeriod,
     });
-
-    let organenStartingOnStartDate = [];
-
-    for (const bestuursorgaan of bestuursorganen.toArray()) {
-      const organen = await this.getBestuursorgaanInTijdByPeriod(
-        bestuursorgaan.get('id'),
-        this.startDate,
-        this.endDate
-      );
-      organenStartingOnStartDate = [...organenStartingOnStartDate, ...organen];
-    }
-
-    return organenStartingOnStartDate.filter((orgaan) => orgaan); // filter null values
   }
 
-  /*
-   * TODO: keep in sync with routes/mandatenbeheer.
-   *       Extract common code once we are sure of the common pattern.
-   */
-  async getBestuursorgaanInTijdByPeriod(bestuursorgaanId, startDate, endDate) {
-    const queryParams = {
-      sort: '-binding-start',
-      'filter[is-tijdsspecialisatie-van][id]': bestuursorgaanId,
-    };
+  calculateUniqueBestuursperiods(bestuursorganen) {
+    const periods = bestuursorganen.map((b) => ({
+      startDate: moment(b.bindingStart).format('YYYY-MM-DD'),
+      endDate: b.bindingEinde
+        ? moment(b.bindingEinde).format('YYYY-MM-DD')
+        : null,
+    }));
 
-    if (startDate && endDate) {
-      queryParams['filter[binding-start]'] = startDate;
-      queryParams['filter[binding-einde]'] = endDate;
-    } else if (startDate) {
-      queryParams['filter[binding-start]'] = startDate;
-      // Bestuursorganen can overlap in start date,
-      // so if no end date is provided, explicitly filter em out
-      queryParams['filter[:has-no:binding-einde]'] = true;
+    const comparablePeriods = periods.map((period) => JSON.stringify(period));
+    const uniquePeriods = [...new Set(comparablePeriods)].map((period) =>
+      JSON.parse(period)
+    );
+
+    return uniquePeriods;
+  }
+
+  calculateSelectedPeriod(periods, { startDate, endDate }) {
+    //Note: the assumptions: no messy data, i.e.
+    // - no intersection between periods
+    // - start < end
+    //So, basically it assumes e.g.
+    //  - [2001-2003][2003-2023] and possibly [2024-2025|null]
+    const sortedPeriods = periods.sortBy('startDate');
+    if (!(startDate || endDate)) {
+      const today = moment(new Date()).format('YYYY-MM-DD');
+
+      const currentPeriod = sortedPeriods.find(
+        (p) => p.startDate <= today && (today < p.endDate || !p.endDate)
+      );
+      const firstfuturePeriod = sortedPeriods.find((p) => p.startDate > today);
+      const firstPreviousPeriod = sortedPeriods.slice(-1)[0];
+
+      return currentPeriod || firstfuturePeriod || firstPreviousPeriod;
+    } else {
+      return { startDate, endDate };
     }
+  }
 
-    const organen = await this.store.query('bestuursorgaan', queryParams);
-    return organen.toArray();
+  getBestuursorganenForPeriod(bestuursorganen, period) {
+    return bestuursorganen.filter((b) => {
+      const start = moment(b.bindingStart).format('YYYY-MM-DD');
+      const end = b.bindingEinde
+        ? moment(b.bindingEinde).format('YYYY-MM-DD')
+        : null;
+      return start == period.startDate && end == period.endDate;
+    });
   }
 
   /*
@@ -94,8 +104,9 @@ export default class EredienstMandatenbeheerRoute extends Route {
    * @return Array of bestuursorganen in tijd ressembling the bestuursperiodes
    * TODO: keep in sync with routes/mandatenbeheer.
    *       Extract common code once we are sure of the common pattern.
+   * TODO: note, this is going to fail once we have more then 20 organen, oh well...
    */
-  async getBestuursperioden(bestuurseenheidId) {
+  async getRelevantBestuursorganen(bestuurseenheidId) {
     return await this.store.query('bestuursorgaan', {
       'filter[is-tijdsspecialisatie-van][bestuurseenheid][id]':
         bestuurseenheidId,

--- a/app/routes/eredienst-mandatenbeheer.js
+++ b/app/routes/eredienst-mandatenbeheer.js
@@ -73,7 +73,7 @@ export default class EredienstMandatenbeheerRoute extends Route {
     // - start < end
     //So, basically it assumes e.g.
     //  - [2001-2003][2003-2023] and possibly [2024-2025|null]
-    const sortedPeriods = periods.sortBy('startDate');
+    const sortedPeriods = periods.sort((a, b) => a.startDate > b.startDate);
     if (!(startDate || endDate)) {
       const today = moment(new Date()).format('YYYY-MM-DD');
 

--- a/app/routes/mandatenbeheer.js
+++ b/app/routes/mandatenbeheer.js
@@ -68,7 +68,9 @@ export default class MandatenbeheerRoute extends Route {
   calculateSelectedPeriod(periods, { startDate, endDate }) {
     //Note: the assumptions: no messy data, i.e.
     // - no intersection between periods
-    // - start > end
+    // - start < end
+    //So, basically it assumes e.g.
+    //  - [2001-2002][2003-2023] and possibly [2024-2025|null]
     const sortedPeriods = periods.sortBy('startDate');
     if (!(startDate || endDate)) {
       const today = moment(new Date()).format('YYYY-MM-DD');
@@ -76,10 +78,10 @@ export default class MandatenbeheerRoute extends Route {
       const currentPeriod = sortedPeriods.find(
         (p) => p.startDate <= today && (today < p.endDate || !p.endDate)
       );
-      const futurePeriod = sortedPeriods.find((p) => p.startDate > today);
-      const firstPeriod = sortedPeriods[0]; //TODO; Perhaps we could take the previous.
+      const firstfuturePeriod = sortedPeriods.find((p) => p.startDate > today);
+      const firstPreviousPeriod = sortedPeriods.slice(-1)[0];
 
-      return currentPeriod || futurePeriod || firstPeriod;
+      return currentPeriod || firstfuturePeriod || firstPreviousPeriod;
     } else {
       return { startDate, endDate };
     }

--- a/app/routes/mandatenbeheer.js
+++ b/app/routes/mandatenbeheer.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
+import moment from 'moment';
 
 export default class MandatenbeheerRoute extends Route {
   @service currentSession;
@@ -25,66 +26,59 @@ export default class MandatenbeheerRoute extends Route {
     this.endDate = params.endDate;
 
     const bestuurseenheid = this.currentSession.group;
+    const bestuursorganen = await this.getRelevantBestuursorganen(bestuurseenheid.get('id'));
+    const bestuursperiods = this.calculateUniqueBestuursperiods(bestuursorganen);
+    const selectedPeriod = this.calculateSelectedPeriod(bestuursperiods,
+                                                        { startDate: this.startDate, endDate: this.endDate});
+
+    const selectedBestuursOrganen = this.getBestuursorganenForPeriod(bestuursorganen, selectedPeriod);
 
     return RSVP.hash({
-      bestuurseenheid: bestuurseenheid,
-      bestuursorganen: this.getBestuursorganenInTijdByPeriod(
-        bestuurseenheid.get('id')
-      ),
-      bestuursperioden: this.getBestuursperioden(bestuurseenheid.get('id')),
-      startDate: this.startDate,
-      endDate: this.endDate,
+      bestuurseenheid,
+      bestuursorganen: selectedBestuursOrganen,
+      bestuursperiods,
+      selectedPeriod,
     });
   }
 
-  /*
-   * Returns bestuursorgaan in tijd starting on the given a period
-   * for all bestuursorganen of the given bestuurseenheid.
-   * TODO: keep in sync with routes/eredienst-mandatenbeheer.
-   *       Extract common code once we are sure of the common pattern.
-   */
-  async getBestuursorganenInTijdByPeriod(bestuurseenheidId) {
-    const bestuursorganen = await this.store.query('bestuursorgaan', {
-      'filter[bestuurseenheid][id]': bestuurseenheidId,
-      'filter[heeft-tijdsspecialisaties][:has:bevat]': true, // only organs with a mandate
-    });
+  calculateUniqueBestuursperiods(bestuursorganen) {
+    const periods = bestuursorganen
+          .map((b) => ({
+            startDate: moment(b.bindingStart).format('YYYY-MM-DD'),
+            endDate: b.bindingEinde ? moment(b.bindingEinde).format('YYYY-MM-DD') : null
+          }));
 
-    let organenStartingOnStartDate = [];
+    const comparablePeriods = periods.map(period => JSON.stringify(period));
+    const uniquePeriods = [ ...new Set(comparablePeriods) ].map(period => JSON.parse(period));
 
-    for (const bestuursorgaan of bestuursorganen.toArray()) {
-      const organen = await this.getBestuursorgaanInTijdByPeriod(
-        bestuursorgaan.get('id'),
-        this.startDate,
-        this.endDate
-      );
-      organenStartingOnStartDate = [...organenStartingOnStartDate, ...organen];
-    }
-
-    return organenStartingOnStartDate.filter((orgaan) => orgaan); // filter null values
+    return uniquePeriods;
   }
 
-  /*
-   * TODO: keep in sync with routes/eredienst-mandatenbeheer.
-   *       Extract common code once we are sure of the common pattern.
-   */
-  async getBestuursorgaanInTijdByPeriod(bestuursorgaanId, startDate, endDate) {
-    const queryParams = {
-      sort: '-binding-start',
-      'filter[is-tijdsspecialisatie-van][id]': bestuursorgaanId,
-    };
+  calculateSelectedPeriod(periods, { startDate, endDate } ) {
+    //Note: the assumptions: no messy data, i.e.
+    // - no intersection between periods
+    // - start > end
+    const sortedPeriods = periods.sortBy('startDate');
+    if(!(startDate || endDate)) {
+      const today = moment(new Date()).format('YYYY-MM-DD');
 
-    if (startDate && endDate) {
-      queryParams['filter[binding-start]'] = startDate;
-      queryParams['filter[binding-einde]'] = endDate;
-    } else if (startDate) {
-      queryParams['filter[binding-start]'] = startDate;
-      // Bestuursorganen can overlap in start date,
-      // so if no end date is provided, explicitly filter em out
-      queryParams['filter[:has-no:binding-einde]'] = true;
+      const currentPeriod = sortedPeriods.find(p => p.startDate <= today  && ( today < p.endDate || !p.endDate ));
+      const futurePeriod = sortedPeriods.find(p => p.startDate > today);
+      const firstPeriod = sortedPeriods[0]; //TODO; Perhaps we could take the previous.
+
+      return currentPeriod || futurePeriod || firstPeriod;
     }
+    else {
+      return { startDate, endDate };
+    }
+  }
 
-    const organen = await this.store.query('bestuursorgaan', queryParams);
-    return organen.toArray();
+  getBestuursorganenForPeriod(bestuursorganen, period) {
+    return bestuursorganen.filter(b => {
+      const start = moment(b.bindingStart).format('YYYY-MM-DD');
+      const end = b.bindingEinde ? moment(b.bindingEinde).format('YYYY-MM-DD') : null;
+      return start == period.startDate && end == period.endDate;
+    });
   }
 
   /*
@@ -92,8 +86,9 @@ export default class MandatenbeheerRoute extends Route {
    * @return Array of bestuursorganen in tijd ressembling the bestuursperiodes
    * TODO: keep in sync with routes/eredienst-mandatenbeheer.
    *       Extract common code once we are sure of the common pattern.
+   * TODO: note, this is going to fail once we have more then 20 organen, oh well...
    */
-  async getBestuursperioden(bestuurseenheidId) {
+  async getRelevantBestuursorganen(bestuurseenheidId) {
     return await this.store.query('bestuursorgaan', {
       'filter[is-tijdsspecialisatie-van][bestuurseenheid][id]':
         bestuurseenheidId,

--- a/app/routes/mandatenbeheer.js
+++ b/app/routes/mandatenbeheer.js
@@ -71,7 +71,7 @@ export default class MandatenbeheerRoute extends Route {
     // - start < end
     //So, basically it assumes e.g.
     //  - [2001-2003][2003-2023] and possibly [2024-2025|null]
-    const sortedPeriods = periods.sortBy('startDate');
+    const sortedPeriods = periods.sort((a, b) => a.startDate > b.startDate);
     if (!(startDate || endDate)) {
       const today = moment(new Date()).format('YYYY-MM-DD');
 

--- a/app/routes/mandatenbeheer.js
+++ b/app/routes/mandatenbeheer.js
@@ -70,7 +70,7 @@ export default class MandatenbeheerRoute extends Route {
     // - no intersection between periods
     // - start < end
     //So, basically it assumes e.g.
-    //  - [2001-2002][2003-2023] and possibly [2024-2025|null]
+    //  - [2001-2003][2003-2023] and possibly [2024-2025|null]
     const sortedPeriods = periods.sortBy('startDate');
     if (!(startDate || endDate)) {
       const today = moment(new Date()).format('YYYY-MM-DD');

--- a/app/templates/eredienst-mandatenbeheer/mandatarissen.hbs
+++ b/app/templates/eredienst-mandatenbeheer/mandatarissen.hbs
@@ -18,9 +18,8 @@
     <Group>
       <div class="">
         <Mandatenbeheer::BestuursperiodenSelector
-          @options={{this.bestuursperioden}}
-          @selectedStartDate={{this.startDate}}
-          @selectedEndDate={{this.endDate}}
+          @options={{this.mandatenbeheer.bestuursperiods}}
+          @selectedPeriod={{this.mandatenbeheer.selectedPeriod}}
           @onSelect={{this.selectPeriod}}/>
       </div>
     </Group>

--- a/app/templates/mandatenbeheer/mandatarissen.hbs
+++ b/app/templates/mandatenbeheer/mandatarissen.hbs
@@ -24,9 +24,8 @@
     <Group>
       <div class="">
         <Mandatenbeheer::BestuursperiodenSelector
-          @options={{this.bestuursperioden}}
-          @selectedStartDate={{this.startDate}}
-          @selectedEndDate={{this.endDate}}
+          @options={{this.mandatenbeheer.bestuursperiods}}
+          @selectedPeriod={{this.mandatenbeheer.selectedPeriod}}
           @onSelect={{this.selectPeriod}}/>
       </div>
     </Group>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-loket",
-  "version": "0.66.0",
+  "version": "0.66.1",
   "private": true,
   "description": "Frontend of loket",
   "repository": {


### PR DESCRIPTION
An attempt at re-wiring the bestuursperiode selector. This PR covers only the code-updates to work with mandatarissen. Let's keep it focused.
- Logic about what periods should be populated is moved outside of the component
- Component only works on periods (an intermediate data structure because no equivalent exists in the data model)
- The calculation of the default period is try to fetch current period, if not the future one, if not the first one
  - A lot of assumptions have been done about what the periods should look like. For non historical data, i.e. data ABB is under control of this should fit the bill. 

I tested it, by checking several select cases, and also making sure that once one eenheid is selected, the mandataris is correctly attached to the bestuursorgaan in the bestuursperiode. Feel free to test these too.

 A next pr will bring this to eredienst mandatarissen.  To keep things focused.
(Currently big copy paste, still reluctant to extract common bits ATM)
Note too: in this PR the selector for eredienst mandatarissen is broken.