### PR TITLE
E-inclusion Subsidy - amount validator component

### DIFF
--- a/app/components/rdf-form-fields/e-inclusion-max-validator.hbs
+++ b/app/components/rdf-form-fields/e-inclusion-max-validator.hbs
@@ -1,12 +1,12 @@
 <AuLabel
   @error={{this.hasErrors}}
-  @required=true
+  @required={{true}}
   for={{this.inputId}}
 >
   {{@field.label}}
 </AuLabel>
 <AuHelpText class="au-u-margin-bottom-small">
-Aan de hand van een <a href="https://assets.vlaanderen.be/image/upload/v1658218571/VR_2021_1507_BVR_uitrol_lokaal_e-inclusiebeleid_-_4_BIS_Bijlage_overzicht_maximumbedragen_ctuwpd.pdf" target="_blank">verdeelsleutel</a> werd het maximale bedrag berekend 
+Aan de hand van een <a href="https://assets.vlaanderen.be/image/upload/v1658218571/VR_2021_1507_BVR_uitrol_lokaal_e-inclusiebeleid_-_4_BIS_Bijlage_overzicht_maximumbedragen_ctuwpd.pdf" target="_blank" rel="noopener noreferrer">verdeelsleutel</a> werd het maximale bedrag berekend 
 dat elke Vlaamse gemeente of stad, die in aanmerking komt, kan aanvragen.
 </AuHelpText>
 <AuInput

--- a/app/components/rdf-form-fields/e-inclusion-max-validator.hbs
+++ b/app/components/rdf-form-fields/e-inclusion-max-validator.hbs
@@ -1,13 +1,13 @@
-<AuLabel
-  @error={{this.hasErrors}}
-  @required={{true}}
-  for={{this.inputId}}
->
+<AuLabel @error={{this.hasErrors}} @required={{true}} for={{this.inputId}}>
   {{@field.label}}
 </AuLabel>
 <AuHelpText class="au-u-margin-bottom-small">
-Aan de hand van een <a href="https://assets.vlaanderen.be/image/upload/v1658218571/VR_2021_1507_BVR_uitrol_lokaal_e-inclusiebeleid_-_4_BIS_Bijlage_overzicht_maximumbedragen_ctuwpd.pdf" target="_blank" rel="noopener noreferrer">verdeelsleutel</a> werd het maximale bedrag berekend 
-dat elke Vlaamse gemeente of stad, die in aanmerking komt, kan aanvragen.
+  Aan de hand van een
+  <AuLinkExternal
+    href="https://assets.vlaanderen.be/image/upload/v1658218571/VR_2021_1507_BVR_uitrol_lokaal_e-inclusiebeleid_-_4_BIS_Bijlage_overzicht_maximumbedragen_ctuwpd.pdf"
+  >verdeelsleutel</AuLinkExternal>
+  werd het maximale bedrag berekend dat elke Vlaamse gemeente of stad, die in
+  aanmerking komt, kan aanvragen.
 </AuHelpText>
 <AuInput
   @error={{this.hasErrors}}

--- a/app/components/rdf-form-fields/e-inclusion-max-validator.hbs
+++ b/app/components/rdf-form-fields/e-inclusion-max-validator.hbs
@@ -1,0 +1,24 @@
+<AuLabel
+  @error={{this.hasErrors}}
+  @required=true
+  for={{this.inputId}}
+>
+  {{@field.label}}
+</AuLabel>
+<AuHelpText class="au-u-margin-bottom-small">
+Aan de hand van een <a href="https://assets.vlaanderen.be/image/upload/v1658218571/VR_2021_1507_BVR_uitrol_lokaal_e-inclusiebeleid_-_4_BIS_Bijlage_overzicht_maximumbedragen_ctuwpd.pdf" target="_blank">verdeelsleutel</a> werd het maximale bedrag berekend 
+dat elke Vlaamse gemeente of stad, die in aanmerking komt, kan aanvragen.
+</AuHelpText>
+<AuInput
+  @error={{this.hasErrors}}
+  @value={{this.value}}
+  @disabled={{@show}}
+  @type="number"
+  id={{this.inputId}}
+  lang="nl-BE"
+  {{on "change" this.validate}}
+/>
+
+{{#each this.errors as |error|}}
+  <AuHelpText @error={{true}}>{{error.message}}</AuHelpText>
+{{/each}}

--- a/app/components/rdf-form-fields/e-inclusion-max-validator.js
+++ b/app/components/rdf-form-fields/e-inclusion-max-validator.js
@@ -3,6 +3,7 @@ import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
 import { A } from '@ember/array';
 import { action } from '@ember/object';
+import { scheduleOnce } from '@ember/runloop';
 import { NamedNode } from 'rdflib';
 import { LBLOD_SUBSIDIE } from 'frontend-loket/rdf/namespaces';
 
@@ -14,20 +15,15 @@ const validAmountPredicate = new NamedNode(
 
 export default class RdfFormFieldsEInclusionMaxValidatorComponent extends SimpleInputFieldComponent {
   inputId = 'e-inclusion-max-validator' + guidFor(this);
-  @tracked maximumvalue;
+  maximumvalue;
   @tracked errors = A();
 
   constructor() {
     super(...arguments);
-    this.loadProvidedValue();
+    scheduleOnce('actions', this, this.initComponent);
   }
 
-  loadProvidedValue() {
-    super.loadProvidedValue();
-    if (this.value == null) {
-      this.value = 0;
-    }
-
+  initComponent() {
     const maxValue = this.args.formStore.match(
       undefined,
       LBLOD_SUBSIDIE('drawingRightEInclusion'),
@@ -79,13 +75,14 @@ export default class RdfFormFieldsEInclusionMaxValidatorComponent extends Simple
     } else if (!this.isValidAmountLB(num)) {
       this.errors.pushObject({
         message:
-          'Het aangevraagde bedrag overschrijdt de maximale waarde voor dit bestuuur: €' +
+          'Het aangevraagde bedrag overschrijdt de maximale waarde voor dit bestuur: €' +
           Math.round(this.maximumvalue),
       });
       this.updateTripleObject(source, validAmountPredicate, null);
     } else {
       this.updateTripleObject(source, validAmountPredicate, true);
     }
+    console.log('Got Here');
     this.updateTripleObject(source, amountPredicate, num);
   }
 

--- a/app/components/rdf-form-fields/e-inclusion-max-validator.js
+++ b/app/components/rdf-form-fields/e-inclusion-max-validator.js
@@ -96,8 +96,8 @@ export default class RdfFormFieldsEInclusionMaxValidatorComponent extends Simple
 
   isValidEuroAmount(value) {
     const split = value.toString().split('.')[1];
-    if(split){
-      return split.length <= 2
+    if (split) {
+      return split.length <= 2;
     }
     return true;
   }

--- a/app/components/rdf-form-fields/e-inclusion-max-validator.js
+++ b/app/components/rdf-form-fields/e-inclusion-max-validator.js
@@ -4,6 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { A } from '@ember/array';
 import { action } from '@ember/object';
 import { NamedNode } from 'rdflib';
+import { scheduleOnce } from '@ember/runloop';
 import { LBLOD_SUBSIDIE } from 'frontend-loket/rdf/namespaces';
 
 const lblodSubsidieBaseUri = 'http://lblod.data.gift/vocabularies/subsidie/';
@@ -19,6 +20,10 @@ export default class RdfFormFieldsEInclusionMaxValidatorComponent extends Simple
 
   constructor() {
     super(...arguments);
+    scheduleOnce('actions', this, this.initComponent);
+  }
+
+  initComponent() {
     const maxValue = this.args.formStore.match(
       undefined,
       LBLOD_SUBSIDIE('drawingRightEInclusion'),

--- a/app/components/rdf-form-fields/e-inclusion-max-validator.js
+++ b/app/components/rdf-form-fields/e-inclusion-max-validator.js
@@ -3,7 +3,6 @@ import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
 import { A } from '@ember/array';
 import { action } from '@ember/object';
-import { scheduleOnce } from '@ember/runloop';
 import { NamedNode } from 'rdflib';
 import { LBLOD_SUBSIDIE } from 'frontend-loket/rdf/namespaces';
 
@@ -20,10 +19,6 @@ export default class RdfFormFieldsEInclusionMaxValidatorComponent extends Simple
 
   constructor() {
     super(...arguments);
-    scheduleOnce('actions', this, this.initComponent);
-  }
-
-  initComponent() {
     const maxValue = this.args.formStore.match(
       undefined,
       LBLOD_SUBSIDIE('drawingRightEInclusion'),
@@ -82,7 +77,6 @@ export default class RdfFormFieldsEInclusionMaxValidatorComponent extends Simple
     } else {
       this.updateTripleObject(source, validAmountPredicate, true);
     }
-    console.log('Got Here');
     this.updateTripleObject(source, amountPredicate, num);
   }
 

--- a/app/components/rdf-form-fields/e-inclusion-max-validator.js
+++ b/app/components/rdf-form-fields/e-inclusion-max-validator.js
@@ -8,6 +8,9 @@ import { LBLOD_SUBSIDIE } from 'frontend-loket/rdf/namespaces';
 
 const lblodSubsidieBaseUri = 'http://lblod.data.gift/vocabularies/subsidie/';
 const amountPredicate = new NamedNode(`${lblodSubsidieBaseUri}amount`);
+const validAmountPredicate = new NamedNode(
+  `${lblodSubsidieBaseUri}validatedAmount`
+);
 
 export default class RdfFormFieldsEInclusionMaxValidatorComponent extends SimpleInputFieldComponent {
   inputId = 'e-inclusion-max-validator' + guidFor(this);
@@ -29,10 +32,11 @@ export default class RdfFormFieldsEInclusionMaxValidatorComponent extends Simple
       undefined,
       LBLOD_SUBSIDIE('drawingRightEInclusion'),
       undefined,
-      metaGraph
+      this.args.graphs.metaGraph
     )[0].object.value;
 
     this.maximumvalue = maxValue;
+    this.validate();
   }
 
   updateTripleObject(subject, predicate, newObject = null) {
@@ -66,19 +70,23 @@ export default class RdfFormFieldsEInclusionMaxValidatorComponent extends Simple
       this.errors.pushObject({
         message: 'Geef een bedrag groter dan 0 in',
       });
-    } else if (!this.isValidEuroAmount(num)) {
+      this.updateTripleObject(source, validAmountPredicate, null);
+    } else if (!this.isValidEuroAmount(this.value)) {
       this.errors.pushObject({
         message: 'Geef een bedrag met maximaal 2 cijfers na de komma in',
       });
+      this.updateTripleObject(source, validAmountPredicate, null);
     } else if (!this.isValidAmountLB(num)) {
       this.errors.pushObject({
         message:
-          'Het aangevraagde bedrag overschrijdt de maximale waarde voor dit bestuuur: ' +
-          this.maximumvalue,
+          'Het aangevraagde bedrag overschrijdt de maximale waarde voor dit bestuuur: €' +
+          Math.round(this.maximumvalue),
       });
+      this.updateTripleObject(source, validAmountPredicate, null);
     } else {
-      this.updateTripleObject(source, amountPredicate, num);
+      this.updateTripleObject(source, validAmountPredicate, true);
     }
+    this.updateTripleObject(source, amountPredicate, num);
   }
 
   isRealPositiveNumber(value) {
@@ -87,12 +95,11 @@ export default class RdfFormFieldsEInclusionMaxValidatorComponent extends Simple
   }
 
   isValidEuroAmount(value) {
-    const num = Number(value);
-    if (Number.isInteger(num)) {
-      return true;
+    const split = value.toString().split('.')[1];
+    if(split){
+      return split.length <= 2
     }
-
-    return num.toString().split('.')[1].length <= 2;
+    return true;
   }
 
   isValidAmountLB(value) {

--- a/app/routes/subsidy/applications/edit.js
+++ b/app/routes/subsidy/applications/edit.js
@@ -5,6 +5,7 @@ import { registerFormFields } from '@lblod/ember-submission-form-fields';
 import ApplicationFormTableEditComponent from 'frontend-loket/components/rdf-form-fields/application-form-table/edit';
 import ApplicationFormTableShowComponent from 'frontend-loket/components/rdf-form-fields/application-form-table/show';
 import ClimateSubsidyCostsTableComponent from 'frontend-loket/components/rdf-form-fields/climate-subsidy-costs-table';
+import EInclusionMaxValidatorComponent from 'frontend-loket/components/rdf-form-fields/e-inclusion-max-validator';
 import EngagementTableEditComponent from 'frontend-loket/components/rdf-form-fields/engagement-table/edit';
 import EngagementTableShowComponent from 'frontend-loket/components/rdf-form-fields/engagement-table/show';
 import EstimatedCostEditComponent from 'frontend-loket/components/rdf-form-fields/estimated-cost-table/edit';
@@ -62,6 +63,11 @@ export default class SubsidyApplicationsEditRoute extends Route {
         displayType:
           'http://lblod.data.gift/display-types/climateSubsidyCostTable',
         edit: ClimateSubsidyCostsTableComponent,
+      },
+      {
+        displayType:
+          'http://lblod.data.gift/display-types/eInclusionMaxValidator',
+        edit: EInclusionMaxValidatorComponent,
       },
       {
         displayType: 'http://lblod.data.gift/display-types/engagementTable',


### PR DESCRIPTION
The E-inclusion subsidy contains a field amount ("Gevraagde subsidiebedrag") in section "Inhoudelijke aanvraag".
This field has multiple checks ( > 0, not more than 3 digits after decimal, smaller than maximum amount) and show the correct error if a validation has failed. **You do need to run this with app PR#237**: https://github.com/lblod/app-digitaal-loket/pull/237