### PR TITLE
[WIP] ExpectedEndDate for worship-mandatee

### DIFF
--- a/app/routes/eredienst-mandatenbeheer/new.js
+++ b/app/routes/eredienst-mandatenbeheer/new.js
@@ -27,6 +27,10 @@ export default class EredienstMandatenbeheerNewRoute extends Route {
 
       let worshipMandatee = this.store.createRecord('worship-mandatee');
       worshipMandatee.isBestuurlijkeAliasVan = person;
+      let bestuursperiodesEndDates = tijdsspecialisaties.map(
+        ({ bindingEinde }) => bindingEinde
+      );
+      worshipMandatee.expectedEndDate = bestuursperiodesEndDates[0];
 
       return {
         worshipMandatee,

--- a/app/templates/eredienst-mandatenbeheer/mandataris/edit.hbs
+++ b/app/templates/eredienst-mandatenbeheer/mandataris/edit.hbs
@@ -63,6 +63,14 @@
         />
       </div>
     </div>
+    <div class="au-u-margin-bottom-small">
+      <AuLabel for="mandate-expected-end-date">GeplandeEinddatumAanstelling</AuLabel>
+      <AuDatePicker
+        @value={{this.model.expectedEndDate}}
+        @disabled={{true}}
+        @id="mandate-expected-end-date"
+      />
+    </div>
   </div>
 
   <AuHr @size="small" />

--- a/app/templates/eredienst-mandatenbeheer/new.hbs
+++ b/app/templates/eredienst-mandatenbeheer/new.hbs
@@ -86,6 +86,15 @@
         </div>
       </div>
 
+      <div class="au-u-margin-bottom-small">
+        <AuLabel for="mandate-expected-end-date">GeplandeEinddatumAanstelling</AuLabel>
+        <AuDatePicker
+          @value={{@model.worshipMandatee.expectedEndDate}}
+          @disabled={{true}}
+          @id="mandate-expected-end-date"
+        />
+      </div>
+
       <AuAlert @skin="info" @icon="info-circle" @size="small">
         <p>
           Klik op "Mandaat toevoegen" om contactgegevens verder aan te vullen.


### PR DESCRIPTION
DL-4194

New field `GeplandeEinddatumAanstelling` is added and is disabled by default.

Concerning the mandate `Bestuurslid (van rechtswege) van het bestuur van de eredienst`, since this mandate never ends, currently the expectedEndDate takes the furthest periodeEndDate. We could set a case where if it's this mandate, we show a field with endDate = N/A, but is this going to work on other environments ?