### PR TITLE
Only serialize the status and modified fields

### DIFF
--- a/app/serializers/public-service.js
+++ b/app/serializers/public-service.js
@@ -1,0 +1,23 @@
+import ApplicationSerializer from './application';
+
+export const ALLOWED_FIELDS = ['modified', 'status'];
+
+export default class PublicServiceSerializer extends ApplicationSerializer {
+  serializeAttribute(snapshot, json, attributeName) {
+    if (ALLOWED_FIELDS.includes(attributeName)) {
+      super.serializeAttribute(...arguments);
+    }
+  }
+
+  serializeBelongsTo(snapshot, json, relationship) {
+    if (ALLOWED_FIELDS.includes(relationship.key)) {
+      super.serializeBelongsTo(...arguments);
+    }
+  }
+
+  serializeHasMany(snapshot, json, relationship) {
+    if (ALLOWED_FIELDS.includes(relationship.key)) {
+      super.serializeBelongsTo(...arguments);
+    }
+  }
+}

--- a/tests/unit/serializers/public-service-test.js
+++ b/tests/unit/serializers/public-service-test.js
@@ -1,0 +1,66 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { ALLOWED_FIELDS } from 'frontend-loket/serializers/public-service';
+
+module('Unit | Serializer | public service', function (hooks) {
+  setupTest(hooks);
+
+  test('it only serializes the allowed fields', function (assert) {
+    assert.expect(2);
+
+    let store = this.owner.lookup('service:store');
+    store.push({
+      data: {
+        id: '1',
+        type: 'public-service',
+        attributes: {
+          name: [
+            { content: 'foo', language: 'en' },
+            { content: 'bar', language: 'nl' },
+          ],
+          uri: 'http://foo.bar/1234',
+        },
+        relationships: {
+          status: { data: { id: '1', type: 'concept' } },
+          conceptTags: {
+            data: [
+              {
+                id: '2',
+                type: 'concept',
+              },
+              {
+                id: '3',
+                type: 'concept',
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    let record = store.peekRecord('public-service', '1');
+    record.modified = new Date();
+
+    let serializedRecord = record.serialize();
+    let serializedAttributeNames = Object.keys(
+      serializedRecord.data.attributes
+    );
+    let serializedRelationshipNames = Object.keys(
+      serializedRecord.data.relationships
+    );
+
+    for (let attribute of serializedAttributeNames) {
+      assert.true(
+        ALLOWED_FIELDS.includes(attribute),
+        'The attribute is allowed to be serialized'
+      );
+    }
+
+    for (let relationship of serializedRelationshipNames) {
+      assert.true(
+        ALLOWED_FIELDS.includes(relationship),
+        'The relationship is allowed to be serialized'
+      );
+    }
+  });
+});


### PR DESCRIPTION
These are the only fields that are modified with Ember Data. The others are modified through the semantic form so they are considered "read only" fields. This prevents mu-cl-resources from overwriting data that was updated through the form with old values.