### PR TITLE
Only show unique "bestuursorgaan" names

### DIFF
--- a/app/routes/eredienst-mandatenbeheer/mandatarissen.js
+++ b/app/routes/eredienst-mandatenbeheer/mandatarissen.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 // eslint-disable-next-line ember/no-mixins
 import DataTableRouteMixin from 'ember-data-table/mixins/route';
 import { inject as service } from '@ember/service';
+import { hash } from 'rsvp';
 
 export default class EredienstMandatenbeheerMandatarissenRoute extends Route.extend(
   DataTableRouteMixin
@@ -13,6 +14,15 @@ export default class EredienstMandatenbeheerMandatarissenRoute extends Route.ext
   beforeModel() {
     const mandatenbeheer = this.modelFor('eredienst-mandatenbeheer');
     this.mandatenbeheer = mandatenbeheer;
+  }
+
+  async afterModel(mandatarissen) {
+    let mandatarisBestuursorganen = mandatarissen.reduce((data, mandataris) => {
+      data[mandataris.id] = getUniqueBestuursorganen(mandataris);
+      return data;
+    }, {});
+
+    this.mandatarisBestuursorganen = await hash(mandatarisBestuursorganen);
   }
 
   mergeQueryOptions(params) {
@@ -49,5 +59,20 @@ export default class EredienstMandatenbeheerMandatarissenRoute extends Route.ext
       'eredienst-mandatenbeheer.mandatarissen'
     )['filter'];
     controller.mandatenbeheer = this.mandatenbeheer;
+    controller.mandatarisBestuursorganen = this.mandatarisBestuursorganen;
   }
+}
+
+async function getUniqueBestuursorganen(mandataris) {
+  let mandate = await mandataris.bekleedt;
+  let bestuursorganenInTijd = await mandate.bevatIn;
+
+  let bestuursorganen = new Set();
+
+  for (const bestuursorgaanInTijd of bestuursorganenInTijd.toArray()) {
+    let bestuursorgaan = await bestuursorgaanInTijd.isTijdsspecialisatieVan;
+    bestuursorganen.add(bestuursorgaan);
+  }
+
+  return Array.from(bestuursorganen);
 }

--- a/app/templates/eredienst-mandatenbeheer/mandatarissen.hbs
+++ b/app/templates/eredienst-mandatenbeheer/mandatarissen.hbs
@@ -50,8 +50,9 @@
       </c.header>
       <c.body data-test-loket="mandatarissen-body" as |row|>
         <td class="au-u-visible-small-up">
-          {{#each row.bekleedt.bevatIn as |bestuursorgaan|}}
-            {{bestuursorgaan.isTijdsspecialisatieVan.naam}}<br>
+          {{#each (get this.mandatarisBestuursorganen row.id) as |bestuursorgaan index|}}
+            {{#if (gt index 0)}}<br>{{/if}}
+            {{bestuursorgaan.naam}}
           {{/each}}
         </td>
         <td class="au-u-visible-small-up">


### PR DESCRIPTION
This change prevents the same bestuursorgaan from being displayed multiple times. This can happen if a mandataris is linked to a mandate which exists in multiple "bestuursorganen in tijd" but belong to the same "bestuursorgaan".