### PR TITLE
Prevent to save a `mandataris` without a `mandaat`

### DIFF
--- a/app/components/mandatenbeheer/mandaat-bestuursorganen-selector.hbs
+++ b/app/components/mandatenbeheer/mandaat-bestuursorganen-selector.hbs
@@ -1,3 +1,4 @@
+<div class={{if @error "ember-power-select--error"}}>
 <PowerSelect
         @loadingMessage = 'Aan het laden...'
         @noMatchesMessage = 'Geen resultaten'
@@ -14,3 +15,4 @@
         as |mandaat|>
   {{mandaat.bestuursfunctie.label}}
 </PowerSelect>
+</div>

--- a/app/controllers/eredienst-mandatenbeheer/new.js
+++ b/app/controllers/eredienst-mandatenbeheer/new.js
@@ -36,6 +36,7 @@ export default class EredienstMandatenbeheerNewController extends Controller {
   setMandaat(mandaat) {
     const { worshipMandatee } = this.model;
     worshipMandatee.bekleedt = mandaat;
+    worshipMandatee.errors.remove('bekleedt');
     setExpectedEndDate(this.store, worshipMandatee, mandaat);
   }
 
@@ -56,7 +57,7 @@ export default class EredienstMandatenbeheerNewController extends Controller {
         worshipMandatee.id
       );
     } else {
-      worshipMandatee.errors.add('mandaat', 'Mandaat is een vereist veld.');
+      worshipMandatee.errors.add('bekleedt', 'Mandaat is een vereist veld.');
     }
   }
 }

--- a/app/controllers/eredienst-mandatenbeheer/new.js
+++ b/app/controllers/eredienst-mandatenbeheer/new.js
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { dropTask } from 'ember-concurrency';
+import { isMandaatSelected } from 'frontend-loket/models/worship-mandatee';
 import { setExpectedEndDate } from 'frontend-loket/utils/eredienst-mandatenbeheer';
 
 export default class EredienstMandatenbeheerNewController extends Controller {
@@ -11,7 +12,6 @@ export default class EredienstMandatenbeheerNewController extends Controller {
 
   queryParams = ['personId'];
   @tracked personId = '';
-  @tracked shouldSelectMandaat = true;
 
   get shouldSelectPerson() {
     return !this.model?.person;
@@ -34,7 +34,6 @@ export default class EredienstMandatenbeheerNewController extends Controller {
 
   @action
   setMandaat(mandaat) {
-    this.shouldSelectMandaat = false;
     const { worshipMandatee } = this.model;
     worshipMandatee.bekleedt = mandaat;
     setExpectedEndDate(this.store, worshipMandatee, mandaat);
@@ -50,16 +49,14 @@ export default class EredienstMandatenbeheerNewController extends Controller {
     event.preventDefault();
 
     let { worshipMandatee } = this.model;
-    if (this.shouldSelectMandaat) {
-      return {}; // Room for some error handling
-    } else {
+    if (yield isMandaatSelected(worshipMandatee)) {
       yield worshipMandatee.save();
-      this.shouldSelectMandaat = true;
-
       this.router.transitionTo(
         'eredienst-mandatenbeheer.mandataris.edit',
         worshipMandatee.id
       );
+    } else {
+      worshipMandatee.errors.add('mandaat', 'Mandaat is een vereist veld.');
     }
   }
 }

--- a/app/controllers/eredienst-mandatenbeheer/new.js
+++ b/app/controllers/eredienst-mandatenbeheer/new.js
@@ -11,6 +11,7 @@ export default class EredienstMandatenbeheerNewController extends Controller {
 
   queryParams = ['personId'];
   @tracked personId = '';
+  @tracked shouldSelectMandaat = true;
 
   get shouldSelectPerson() {
     return !this.model?.person;
@@ -33,6 +34,7 @@ export default class EredienstMandatenbeheerNewController extends Controller {
 
   @action
   setMandaat(mandaat) {
+    this.shouldSelectMandaat = false;
     const { worshipMandatee } = this.model;
     worshipMandatee.bekleedt = mandaat;
     setExpectedEndDate(this.store, worshipMandatee, mandaat);
@@ -48,11 +50,16 @@ export default class EredienstMandatenbeheerNewController extends Controller {
     event.preventDefault();
 
     let { worshipMandatee } = this.model;
-    yield worshipMandatee.save();
+    if (this.shouldSelectMandaat) {
+      return {}; // Room for some error handling
+    } else {
+      yield worshipMandatee.save();
+      this.shouldSelectMandaat = true;
 
-    this.router.transitionTo(
-      'eredienst-mandatenbeheer.mandataris.edit',
-      worshipMandatee.id
-    );
+      this.router.transitionTo(
+        'eredienst-mandatenbeheer.mandataris.edit',
+        worshipMandatee.id
+      );
+    }
   }
 }

--- a/app/models/worship-mandatee.js
+++ b/app/models/worship-mandatee.js
@@ -6,3 +6,8 @@ export default class WorshipMandateeModel extends Mandataris {
   @attr('date') expectedEndDate;
   @attr reasonStopped;
 }
+
+export async function isMandaatSelected(worshipMandatee) {
+  let mandate = await worshipMandatee.bekleedt;
+  return Boolean(mandate);
+}

--- a/app/templates/eredienst-mandatenbeheer/new.hbs
+++ b/app/templates/eredienst-mandatenbeheer/new.hbs
@@ -59,7 +59,7 @@
     <div class="au-u-2-3@medium au-o-box">
       <div class="au-u-margin-bottom-small">
         {{#let (if @model.worshipMandatee.errors.mandaat true false) as |showError|}}
-        <AuLabel for="mandaat" @error={{showError}}>Mandaat</AuLabel>
+        <AuLabel for="mandaat" @error={{showError}} @required={{true}}>Mandaat</AuLabel>
         <Mandatenbeheer::MandaatBestuursorganenSelector
           @bestuursorganen={{@model.bestuursorganen}}
           @mandaat={{@model.worshipMandatee.bekleedt}}

--- a/app/templates/eredienst-mandatenbeheer/new.hbs
+++ b/app/templates/eredienst-mandatenbeheer/new.hbs
@@ -58,7 +58,7 @@
   >
     <div class="au-u-2-3@medium au-o-box">
       <div class="au-u-margin-bottom-small">
-        {{#let (if @model.worshipMandatee.errors.mandaat true false) as |showError|}}
+        {{#let (if @model.worshipMandatee.errors.bekleedt true false) as |showError|}}
         <AuLabel for="mandaat" @error={{showError}} @required={{true}}>Mandaat</AuLabel>
         <Mandatenbeheer::MandaatBestuursorganenSelector
           @bestuursorganen={{@model.bestuursorganen}}
@@ -68,7 +68,7 @@
         />
         {{#if showError}}
           <AuHelpText @error={{true}}>
-            {{#each @model.worshipMandatee.errors.mandaat as |errors|}}
+            {{#each @model.worshipMandatee.errors.bekleedt as |errors|}}
               {{errors.message}}
             {{/each}}
           </AuHelpText>

--- a/app/templates/eredienst-mandatenbeheer/new.hbs
+++ b/app/templates/eredienst-mandatenbeheer/new.hbs
@@ -58,12 +58,22 @@
   >
     <div class="au-u-2-3@medium au-o-box">
       <div class="au-u-margin-bottom-small">
-        <AuLabel for="mandaat">Mandaat</AuLabel>
+        {{#let (if @model.worshipMandatee.errors.mandaat true false) as |showError|}}
+        <AuLabel for="mandaat" @error={{showError}}>Mandaat</AuLabel>
         <Mandatenbeheer::MandaatBestuursorganenSelector
           @bestuursorganen={{@model.bestuursorganen}}
           @mandaat={{@model.worshipMandatee.bekleedt}}
           @onSelect={{this.setMandaat}}
+          @error={{showError}}
         />
+        {{#if showError}}
+          <AuHelpText @error={{true}}>
+            {{#each @model.worshipMandatee.errors.mandaat as |errors|}}
+              {{errors.message}}
+            {{/each}}
+          </AuHelpText>
+        {{/if}}
+        {{/let}}
       </div>
 
       <div class="au-o-grid au-o-grid--tiny au-u-margin-bottom-small">


### PR DESCRIPTION
This sets a check when creating a new `mandataris`.
The user **must** select a `mandaat` from the selector to create a new `mandataris`.

UX Improvements to be made ?

- `Verplicht` pill for mandaat label.
- Error handling to inform the user (or simply disable the save button for now until a mandaat is selected).