### PR TITLE
[Mandatenbeheer] Fixing duplicate bestuursorgaan naam

### DIFF
--- a/app/components/mandatenbeheer/mandataris-table.hbs
+++ b/app/components/mandatenbeheer/mandataris-table.hbs
@@ -20,9 +20,10 @@
     <c.body data-test-loket="mandatarissen-body" as |row|>
       {{#unless @displaySubset}}
         <td class="au-u-visible-small-up">
-          {{#each row.bekleedt.bevatIn as |bestuursorgaan|}}
-            {{bestuursorgaan.isTijdsspecialisatieVan.naam}}<br>
-          {{/each}}
+        {{#each (get @mandatarisBestuursorganen row.id) as |bestuursorgaan index|}}
+          {{#if (gt index 0)}}<br>{{/if}}
+          {{bestuursorgaan.naam}}
+        {{/each}}
         </td>
       {{/unless}}
       <td class="au-u-visible-small-up">

--- a/app/models/mandataris.js
+++ b/app/models/mandataris.js
@@ -20,3 +20,17 @@ export default class MandatarisModel extends AgentInPosition {
   @belongsTo('mandataris-status-code', { inverse: null }) status;
   @hasMany('contact-punt', { inverse: 'mandatarissen' }) contactPoints;
 }
+
+export async function getUniqueBestuursorganen(mandataris) {
+  let mandate = await mandataris.bekleedt;
+  let bestuursorganenInTijd = await mandate.bevatIn;
+
+  let bestuursorganen = new Set();
+
+  for (const bestuursorgaanInTijd of bestuursorganenInTijd.toArray()) {
+    let bestuursorgaan = await bestuursorgaanInTijd.isTijdsspecialisatieVan;
+    bestuursorganen.add(bestuursorgaan);
+  }
+
+  return Array.from(bestuursorganen);
+}

--- a/app/routes/eredienst-mandatenbeheer/mandatarissen.js
+++ b/app/routes/eredienst-mandatenbeheer/mandatarissen.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 // eslint-disable-next-line ember/no-mixins
 import DataTableRouteMixin from 'ember-data-table/mixins/route';
 import { inject as service } from '@ember/service';
+import { getUniqueBestuursorganen } from 'frontend-loket/models/mandataris';
 import { hash } from 'rsvp';
 
 export default class EredienstMandatenbeheerMandatarissenRoute extends Route.extend(
@@ -61,18 +62,4 @@ export default class EredienstMandatenbeheerMandatarissenRoute extends Route.ext
     controller.mandatenbeheer = this.mandatenbeheer;
     controller.mandatarisBestuursorganen = this.mandatarisBestuursorganen;
   }
-}
-
-async function getUniqueBestuursorganen(mandataris) {
-  let mandate = await mandataris.bekleedt;
-  let bestuursorganenInTijd = await mandate.bevatIn;
-
-  let bestuursorganen = new Set();
-
-  for (const bestuursorgaanInTijd of bestuursorganenInTijd.toArray()) {
-    let bestuursorgaan = await bestuursorgaanInTijd.isTijdsspecialisatieVan;
-    bestuursorganen.add(bestuursorgaan);
-  }
-
-  return Array.from(bestuursorganen);
 }

--- a/app/routes/mandatenbeheer/mandatarissen.js
+++ b/app/routes/mandatenbeheer/mandatarissen.js
@@ -3,6 +3,7 @@ import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
+import { getUniqueBestuursorganen } from 'frontend-loket/models/mandataris';
 import DataTableRouteMixin from 'ember-data-table/mixins/route';
 
 export default class MandatenbeheerMandatarissenRoute extends Route.extend(
@@ -65,17 +66,4 @@ export default class MandatenbeheerMandatarissenRoute extends Route.extend(
   reloadModel() {
     this.refresh();
   }
-}
-async function getUniqueBestuursorganen(mandataris) {
-  let mandate = await mandataris.bekleedt;
-  let bestuursorganenInTijd = await mandate.bevatIn;
-
-  let bestuursorganen = new Set();
-
-  for (const bestuursorgaanInTijd of bestuursorganenInTijd.toArray()) {
-    let bestuursorgaan = await bestuursorgaanInTijd.isTijdsspecialisatieVan;
-    bestuursorganen.add(bestuursorgaan);
-  }
-
-  return Array.from(bestuursorganen);
 }

--- a/app/templates/mandatenbeheer/mandatarissen.hbs
+++ b/app/templates/mandatenbeheer/mandatarissen.hbs
@@ -50,6 +50,7 @@
     @size={{this.size}}
     @editRoute="mandatenbeheer.mandatarissen.edit"
     @displaySubset={{this.hasActiveChildRoute}}
+    @mandatarisBestuursorganen={{this.mandatarisBestuursorganen}}
   />
 
 </div>


### PR DESCRIPTION
This reuses the same code from #205

Moving the `getUniqueBestuursorganen()` to mandataris class to reuse it in eredienst-mandatenbeheer.