### PR TITLE
Fix a problem where creating a public service based on a template no longer worked

### DIFF
--- a/app/serializers/public-service.js
+++ b/app/serializers/public-service.js
@@ -1,6 +1,6 @@
 import ApplicationSerializer from './application';
 
-export const ALLOWED_FIELDS = ['modified', 'status'];
+export const ALLOWED_FIELDS = ['concept', 'modified', 'status'];
 
 export default class PublicServiceSerializer extends ApplicationSerializer {
   serializeAttribute(snapshot, json, attributeName) {

--- a/tests/unit/serializers/public-service-test.js
+++ b/tests/unit/serializers/public-service-test.js
@@ -6,7 +6,7 @@ module('Unit | Serializer | public service', function (hooks) {
   setupTest(hooks);
 
   test('it only serializes the allowed fields', function (assert) {
-    assert.expect(2);
+    assert.expect(3);
 
     let store = this.owner.lookup('service:store');
     store.push({
@@ -21,6 +21,7 @@ module('Unit | Serializer | public service', function (hooks) {
           uri: 'http://foo.bar/1234',
         },
         relationships: {
+          concept: { data: { id: '1', type: 'conceptual-public-service' } },
           status: { data: { id: '1', type: 'concept' } },
           conceptTags: {
             data: [


### PR DESCRIPTION
The serialization logic that we added to prevent data from being overwritten also had the unintended side affect that we can no longer create a public service with a concept template. This also adds the concept to the allowed list.