### PR TITLE
Missing mandatory fields

### DIFF
--- a/app/components/shared/persoon/create-persoon.hbs
+++ b/app/components/shared/persoon/create-persoon.hbs
@@ -115,7 +115,7 @@
       <div>
         {{#let (if this.errors.geboorte true false) as |showError|}}
         <AuLabel for="mandataris-geboorte"
-          @required={{true}}
+          @required={{this.isGeboorteFieldRequired}}
           @error={{showError}}
           >
           Geboortedatum

--- a/app/components/shared/persoon/create-persoon.hbs
+++ b/app/components/shared/persoon/create-persoon.hbs
@@ -113,14 +113,27 @@
       {{/let}}
       {{/if}}
       <div>
-        <AuLabel for="mandataris-geboorte">Geboortedatum</AuLabel>
+        {{#let (if this.errors.geboorte true false) as |showError|}}
+        <AuLabel for="mandataris-geboorte"
+          @required={{true}}
+          @error={{showError}}
+          >
+          Geboortedatum
+        </AuLabel>
         <AuDatePicker
           @value={{this.birthDate}}
           @min={{this.minDate}}
           @max={{this.maxDate}}
           @id="mandataris-geboorte"
           @onChange={{this.setDateOfBirth}}
+          @error={{showError}}
         />
+        {{#if showError}}
+          <AuHelpText @error="true">
+            {{this.errors.geboorte}}
+          </AuHelpText>
+        {{/if}}
+      {{/let}}
       </div>
       <div>
         <AuLabel @error={{if this.errors.geslacht true}} @required={{true}}>

--- a/app/components/shared/persoon/create-persoon.js
+++ b/app/components/shared/persoon/create-persoon.js
@@ -75,6 +75,10 @@ export default class SharedPersoonCreatePersoonComponent extends Component {
     return !!this.args.nationalityRequired;
   }
 
+  get isGeboorteFieldRequired() {
+    return !!this.args.geboorteRequired;
+  }
+
   @task
   *loadOrCreateRijksregister() {
     let identificator;
@@ -125,7 +129,7 @@ export default class SharedPersoonCreatePersoonComponent extends Component {
       }
     });
 
-    if (!this.birthDate) {
+    if (!this.birthDate && this.isGeboorteFieldRequired) {
       errors.geboorte = 'geboortedatum is een vereist veld.';
     }
 

--- a/app/components/shared/persoon/create-persoon.js
+++ b/app/components/shared/persoon/create-persoon.js
@@ -113,7 +113,8 @@ export default class SharedPersoonCreatePersoonComponent extends Component {
 
   @task
   *save() {
-    // todo geboorte en identificator
+    // todo identificator
+
     let errors = {};
 
     if (this.isNationalityFieldRequired) requiredFields.push('nationaliteit');
@@ -123,6 +124,10 @@ export default class SharedPersoonCreatePersoonComponent extends Component {
         errors[field] = `${field} is een vereist veld.`;
       }
     });
+
+    if (!this.birthDate) {
+      errors.geboorte = 'geboortedatum is een vereist veld.';
+    }
 
     if (!this.isValidRijksregisternummer) {
       errors.rijksregisternummer = 'rijksregisternummer is niet geldig.';

--- a/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
+++ b/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
@@ -10,6 +10,7 @@ import {
   isValidPrimaryContact,
 } from 'frontend-loket/models/contact-punt';
 import { setExpectedEndDate } from 'frontend-loket/utils/eredienst-mandatenbeheer';
+import { isMandaatValid } from 'frontend-loket/models/worship-mandatee';
 
 export default class EredienstMandatenbeheerMandatarisEditController extends Controller {
   @service currentSession;
@@ -118,14 +119,22 @@ export default class EredienstMandatenbeheerMandatarisEditController extends Con
     } else {
       this.model.contacts = [];
     }
+    if (!this.model.start) {
+      this.model.errors.add('start', 'start is een vereist veld.');
+    }
+    if (
+      yield isMandaatValid(this.model) && this.model.start && this.model.isValid
+    ) {
+      yield this.model.save();
 
-    yield this.model.save();
-
-    try {
-      yield this.router.transitionTo('eredienst-mandatenbeheer.mandatarissen');
-    } catch (error) {
-      // I believe we're running into this issue: https://github.com/emberjs/ember.js/issues/20038
-      // A `TransitionAborted` error is thrown even though the transition is complete, so we hide the error.
+      try {
+        yield this.router.transitionTo(
+          'eredienst-mandatenbeheer.mandatarissen'
+        );
+      } catch (error) {
+        // I believe we're running into this issue: https://github.com/emberjs/ember.js/issues/20038
+        // A `TransitionAborted` error is thrown even though the transition is complete, so we hide the error.
+      }
     }
   }
 

--- a/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
+++ b/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
@@ -120,7 +120,7 @@ export default class EredienstMandatenbeheerMandatarisEditController extends Con
       this.model.contacts = [];
     }
     if (!this.model.start) {
-      this.model.errors.add('start', 'start is een vereist veld.');
+      this.model.errors.add('start', 'startdatum is een vereist veld.');
     }
     if ((yield validateMandaat(this.model)) && this.model.isValid) {
       yield this.model.save();

--- a/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
+++ b/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
@@ -122,11 +122,7 @@ export default class EredienstMandatenbeheerMandatarisEditController extends Con
     if (!this.model.start) {
       this.model.errors.add('start', 'start is een vereist veld.');
     }
-    if (
-      (yield validateMandaat(this.model)) &&
-      this.model.start &&
-      this.model.isValid
-    ) {
+    if ((yield validateMandaat(this.model)) && this.model.isValid) {
       yield this.model.save();
 
       try {

--- a/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
+++ b/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
@@ -10,7 +10,7 @@ import {
   isValidPrimaryContact,
 } from 'frontend-loket/models/contact-punt';
 import { setExpectedEndDate } from 'frontend-loket/utils/eredienst-mandatenbeheer';
-import { isMandaatValid } from 'frontend-loket/models/worship-mandatee';
+import { validateMandaat } from 'frontend-loket/models/worship-mandatee';
 
 export default class EredienstMandatenbeheerMandatarisEditController extends Controller {
   @service currentSession;
@@ -123,7 +123,9 @@ export default class EredienstMandatenbeheerMandatarisEditController extends Con
       this.model.errors.add('start', 'start is een vereist veld.');
     }
     if (
-      yield isMandaatValid(this.model) && this.model.start && this.model.isValid
+      (yield validateMandaat(this.model)) &&
+      this.model.start &&
+      this.model.isValid
     ) {
       yield this.model.save();
 

--- a/app/controllers/eredienst-mandatenbeheer/new.js
+++ b/app/controllers/eredienst-mandatenbeheer/new.js
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { dropTask } from 'ember-concurrency';
-import { isMandaatSelected } from 'frontend-loket/models/worship-mandatee';
+import { isMandaatValid } from 'frontend-loket/models/worship-mandatee';
 import { setExpectedEndDate } from 'frontend-loket/utils/eredienst-mandatenbeheer';
 
 export default class EredienstMandatenbeheerNewController extends Controller {
@@ -50,14 +50,19 @@ export default class EredienstMandatenbeheerNewController extends Controller {
     event.preventDefault();
 
     let { worshipMandatee } = this.model;
-    if (yield isMandaatSelected(worshipMandatee)) {
+    if (!worshipMandatee.start) {
+      worshipMandatee.errors.add('start', 'start is een vereist veld.');
+    }
+    if (
+      yield isMandaatValid(worshipMandatee) &&
+        worshipMandatee.start &&
+        worshipMandatee.isValid
+    ) {
       yield worshipMandatee.save();
       this.router.transitionTo(
         'eredienst-mandatenbeheer.mandataris.edit',
         worshipMandatee.id
       );
-    } else {
-      worshipMandatee.errors.add('bekleedt', 'Mandaat is een vereist veld.');
     }
   }
 }

--- a/app/controllers/eredienst-mandatenbeheer/new.js
+++ b/app/controllers/eredienst-mandatenbeheer/new.js
@@ -53,11 +53,7 @@ export default class EredienstMandatenbeheerNewController extends Controller {
     if (!worshipMandatee.start) {
       worshipMandatee.errors.add('start', 'start is een vereist veld.');
     }
-    if (
-      (yield validateMandaat(worshipMandatee)) &&
-      worshipMandatee.start &&
-      worshipMandatee.isValid
-    ) {
+    if ((yield validateMandaat(worshipMandatee)) && worshipMandatee.isValid) {
       yield worshipMandatee.save();
       this.router.transitionTo(
         'eredienst-mandatenbeheer.mandataris.edit',

--- a/app/controllers/eredienst-mandatenbeheer/new.js
+++ b/app/controllers/eredienst-mandatenbeheer/new.js
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { dropTask } from 'ember-concurrency';
-import { isMandaatValid } from 'frontend-loket/models/worship-mandatee';
+import { validateMandaat } from 'frontend-loket/models/worship-mandatee';
 import { setExpectedEndDate } from 'frontend-loket/utils/eredienst-mandatenbeheer';
 
 export default class EredienstMandatenbeheerNewController extends Controller {
@@ -54,9 +54,9 @@ export default class EredienstMandatenbeheerNewController extends Controller {
       worshipMandatee.errors.add('start', 'start is een vereist veld.');
     }
     if (
-      yield isMandaatValid(worshipMandatee) &&
-        worshipMandatee.start &&
-        worshipMandatee.isValid
+      (yield validateMandaat(worshipMandatee)) &&
+      worshipMandatee.start &&
+      worshipMandatee.isValid
     ) {
       yield worshipMandatee.save();
       this.router.transitionTo(

--- a/app/controllers/eredienst-mandatenbeheer/new.js
+++ b/app/controllers/eredienst-mandatenbeheer/new.js
@@ -51,7 +51,7 @@ export default class EredienstMandatenbeheerNewController extends Controller {
 
     let { worshipMandatee } = this.model;
     if (!worshipMandatee.start) {
-      worshipMandatee.errors.add('start', 'start is een vereist veld.');
+      worshipMandatee.errors.add('start', 'startdatum is een vereist veld.');
     }
     if ((yield validateMandaat(worshipMandatee)) && worshipMandatee.isValid) {
       yield worshipMandatee.save();

--- a/app/controllers/worship-ministers-management/minister/edit.js
+++ b/app/controllers/worship-ministers-management/minister/edit.js
@@ -9,7 +9,7 @@ import {
   findPrimaryContactPoint,
   isValidPrimaryContact,
 } from 'frontend-loket/models/contact-punt';
-import { isFunctieValid } from 'frontend-loket/models/minister';
+import { validateFunctie } from 'frontend-loket/models/minister';
 
 export default class WorshipMinistersManagementMinisterEditController extends Controller {
   @service store;
@@ -122,9 +122,9 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
       minister.errors.add('agentStartDate', 'startdatum is een vereist veld.');
     }
     if (
-      yield isFunctieValid(minister) &&
-        minister.agentStartDate &&
-        minister.ministerPosition // this is a workaround when no functies are set
+      (yield validateFunctie(minister)) &&
+      minister.agentStartDate &&
+      minister.ministerPosition
     ) {
       yield minister.save();
 

--- a/app/controllers/worship-ministers-management/minister/edit.js
+++ b/app/controllers/worship-ministers-management/minister/edit.js
@@ -121,11 +121,7 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
     if (!minister.agentStartDate) {
       minister.errors.add('agentStartDate', 'startdatum is een vereist veld.');
     }
-    if (
-      (yield validateFunctie(minister)) &&
-      minister.agentStartDate &&
-      minister.ministerPosition
-    ) {
+    if ((yield validateFunctie(minister)) && minister.isValid) {
       yield minister.save();
 
       try {

--- a/app/controllers/worship-ministers-management/minister/edit.js
+++ b/app/controllers/worship-ministers-management/minister/edit.js
@@ -121,8 +121,12 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
     if (!minister.agentStartDate) {
       minister.errors.add('agentStartDate', 'startdatum is een vereist veld.');
     }
-    if (yield isFunctieValid(minister)) {
-      yield this.model.save();
+    if (
+      yield isFunctieValid(minister) &&
+        minister.agentStartDate &&
+        minister.ministerPosition // this is a workaround when no functies are set
+    ) {
+      yield minister.save();
 
       try {
         yield this.router.transitionTo('worship-ministers-management');

--- a/app/controllers/worship-ministers-management/minister/edit.js
+++ b/app/controllers/worship-ministers-management/minister/edit.js
@@ -9,6 +9,7 @@ import {
   findPrimaryContactPoint,
   isValidPrimaryContact,
 } from 'frontend-loket/models/contact-punt';
+import { isFunctieValid } from 'frontend-loket/models/minister';
 
 export default class WorshipMinistersManagementMinisterEditController extends Controller {
   @service store;
@@ -21,6 +22,13 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
 
   get isEditingContactPoint() {
     return Boolean(this.editingContact);
+  }
+
+  @action
+  handleFunctieChange(functie) {
+    const { minister } = this.model;
+    minister.ministerPosition = functie;
+    minister.errors.remove('ministerPosition');
   }
 
   @action
@@ -110,13 +118,18 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
       minister.contacts = [];
     }
 
-    yield minister.save();
+    if (!minister.agentStartDate) {
+      minister.errors.add('agentStartDate', 'startdatum is een vereist veld.');
+    }
+    if (yield isFunctieValid(minister)) {
+      yield this.model.save();
 
-    try {
-      yield this.router.transitionTo('worship-ministers-management');
-    } catch (error) {
-      // I believe we're running into this issue: https://github.com/emberjs/ember.js/issues/20038
-      // A `TransitionAborted` error is thrown even though the transition is complete, so we hide the error.
+      try {
+        yield this.router.transitionTo('worship-ministers-management');
+      } catch (error) {
+        // I believe we're running into this issue: https://github.com/emberjs/ember.js/issues/20038
+        // A `TransitionAborted` error is thrown even though the transition is complete, so we hide the error.
+      }
     }
   }
 

--- a/app/controllers/worship-ministers-management/new.js
+++ b/app/controllers/worship-ministers-management/new.js
@@ -55,11 +55,7 @@ export default class WorshipMinistersManagementNewController extends Controller 
         'startdatum is een vereist veld.'
       );
     }
-    if (
-      (yield validateFunctie(worshipMinister)) &&
-      worshipMinister.agentStartDate &&
-      worshipMinister.isValid
-    ) {
+    if ((yield validateFunctie(worshipMinister)) && worshipMinister.isValid) {
       yield worshipMinister.save();
       this.router.transitionTo(
         'worship-ministers-management.minister.edit',

--- a/app/controllers/worship-ministers-management/new.js
+++ b/app/controllers/worship-ministers-management/new.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { dropTask } from 'ember-concurrency';
+import { isFunctieValid } from 'frontend-loket/models/minister';
 
 export default class WorshipMinistersManagementNewController extends Controller {
   @service router;
@@ -64,17 +65,5 @@ export default class WorshipMinistersManagementNewController extends Controller 
         worshipMinister.id
       );
     }
-  }
-}
-
-async function isFunctieValid(worshipMinister) {
-  let functie = await worshipMinister.ministerPosition;
-  if (!functie) {
-    worshipMinister.errors.add(
-      'ministerPosition',
-      'Functienaam is een vereist veld.'
-    );
-  } else {
-    return functie.isValid;
   }
 }

--- a/app/controllers/worship-ministers-management/new.js
+++ b/app/controllers/worship-ministers-management/new.js
@@ -52,12 +52,14 @@ export default class WorshipMinistersManagementNewController extends Controller 
     if (!worshipMinister.agentStartDate) {
       worshipMinister.errors.add(
         'agentStartDate',
-        'Startdatum is een vereist veld.'
+        'startdatum is een vereist veld.'
       );
     }
 
     if (
-      yield isFunctieValid(worshipMinister) && worshipMinister.agentStartDate
+      yield isFunctieValid(worshipMinister) &&
+        worshipMinister.agentStartDate &&
+        worshipMinister.isValid
     ) {
       yield worshipMinister.save();
       this.router.transitionTo(

--- a/app/controllers/worship-ministers-management/new.js
+++ b/app/controllers/worship-ministers-management/new.js
@@ -27,6 +27,13 @@ export default class WorshipMinistersManagementNewController extends Controller 
   }
 
   @action
+  handleFunctieChange(functie) {
+    const { worshipMinister } = this.model;
+    worshipMinister.ministerPosition = functie;
+    worshipMinister.errors.remove('ministerPosition');
+  }
+
+  @action
   handleDateChange(type, isoDate, date) {
     this.model.worshipMinister[type] = date;
   }
@@ -41,11 +48,33 @@ export default class WorshipMinistersManagementNewController extends Controller 
     event.preventDefault();
 
     let { worshipMinister } = this.model;
-    yield worshipMinister.save();
+    if (!worshipMinister.agentStartDate) {
+      worshipMinister.errors.add(
+        'agentStartDate',
+        'Startdatum is een vereist veld.'
+      );
+    }
 
-    this.router.transitionTo(
-      'worship-ministers-management.minister.edit',
-      worshipMinister.id
+    if (
+      yield isFunctieValid(worshipMinister) && worshipMinister.agentStartDate
+    ) {
+      yield worshipMinister.save();
+      this.router.transitionTo(
+        'worship-ministers-management.minister.edit',
+        worshipMinister.id
+      );
+    }
+  }
+}
+
+async function isFunctieValid(worshipMinister) {
+  let functie = await worshipMinister.ministerPosition;
+  if (!functie) {
+    worshipMinister.errors.add(
+      'ministerPosition',
+      'Functienaam is een vereist veld.'
     );
+  } else {
+    return functie.isValid;
   }
 }

--- a/app/controllers/worship-ministers-management/new.js
+++ b/app/controllers/worship-ministers-management/new.js
@@ -3,7 +3,7 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { dropTask } from 'ember-concurrency';
-import { isFunctieValid } from 'frontend-loket/models/minister';
+import { validateFunctie } from 'frontend-loket/models/minister';
 
 export default class WorshipMinistersManagementNewController extends Controller {
   @service router;
@@ -55,11 +55,10 @@ export default class WorshipMinistersManagementNewController extends Controller 
         'startdatum is een vereist veld.'
       );
     }
-
     if (
-      yield isFunctieValid(worshipMinister) &&
-        worshipMinister.agentStartDate &&
-        worshipMinister.isValid
+      (yield validateFunctie(worshipMinister)) &&
+      worshipMinister.agentStartDate &&
+      worshipMinister.isValid
     ) {
       yield worshipMinister.save();
       this.router.transitionTo(

--- a/app/models/minister.js
+++ b/app/models/minister.js
@@ -9,10 +9,10 @@ export default class MinisterModel extends AgentInPosition {
   @hasMany('minister-condition', { inverse: null }) conditions;
 }
 
-export async function isFunctieValid(worshipMinister) {
+export async function validateFunctie(worshipMinister) {
   let functie = await worshipMinister.ministerPosition;
-
-  if (!functie) {
+  let isFunctie = Boolean(functie);
+  if (!isFunctie) {
     // TODO: This works around a problem in Ember Data where adding an error without the record being in a dirty state triggers an exception.
     // Ember Data doesn't consider relationship changes a "dirty" change, so this causes issues if the adres is cleared.
     // This workaround uses `.send` but that is a private API which is no longer present in Ember Data 4.x
@@ -24,7 +24,6 @@ export async function isFunctieValid(worshipMinister) {
       'ministerPosition',
       'functienaam is een vereist veld.'
     );
-  } else {
-    return functie.isValid;
   }
+  return isFunctie;
 }

--- a/app/models/minister.js
+++ b/app/models/minister.js
@@ -8,3 +8,23 @@ export default class MinisterModel extends AgentInPosition {
   @belongsTo('financing-code', { inverse: null }) financing;
   @hasMany('minister-condition', { inverse: null }) conditions;
 }
+
+export async function isFunctieValid(worshipMinister) {
+  let functie = await worshipMinister.ministerPosition;
+
+  if (!functie) {
+    // TODO: This works around a problem in Ember Data where adding an error without the record being in a dirty state triggers an exception.
+    // Ember Data doesn't consider relationship changes a "dirty" change, so this causes issues if the adres is cleared.
+    // This workaround uses `.send` but that is a private API which is no longer present in Ember Data 4.x
+    // The bug is fixed in Ember Data 4.6 so we need to update to that version instead of 4.4 LTS
+    // More information in the Discord: https://discord.com/channels/480462759797063690/1016327513900847134
+    // Same old issue where they use this workaround: https://stackoverflow.com/questions/27698496/attempted-to-handle-event-becameinvalid-while-in-state-root-loaded-saved
+    worshipMinister.send?.('becomeDirty');
+    worshipMinister.errors.add(
+      'ministerPosition',
+      'functienaam is een vereist veld.'
+    );
+  } else {
+    return functie.isValid;
+  }
+}

--- a/app/models/worship-mandatee.js
+++ b/app/models/worship-mandatee.js
@@ -7,11 +7,11 @@ export default class WorshipMandateeModel extends Mandataris {
   @attr reasonStopped;
 }
 
-export async function isMandaatValid(worshipMandatee) {
+export async function validateMandaat(worshipMandatee) {
   let mandate = await worshipMandatee.bekleedt;
-  if (!mandate) {
+  let isMandate = Boolean(mandate);
+  if (!isMandate) {
     worshipMandatee.errors.add('bekleedt', 'mandaat is een vereist veld.');
-  } else {
-    return mandate.isValid;
   }
+  return isMandate;
 }

--- a/app/models/worship-mandatee.js
+++ b/app/models/worship-mandatee.js
@@ -7,7 +7,11 @@ export default class WorshipMandateeModel extends Mandataris {
   @attr reasonStopped;
 }
 
-export async function isMandaatSelected(worshipMandatee) {
+export async function isMandaatValid(worshipMandatee) {
   let mandate = await worshipMandatee.bekleedt;
-  return Boolean(mandate);
+  if (!mandate) {
+    worshipMandatee.errors.add('bekleedt', 'mandaat is een vereist veld.');
+  } else {
+    return mandate.isValid;
+  }
 }

--- a/app/templates/eredienst-mandatenbeheer/mandataris/edit.hbs
+++ b/app/templates/eredienst-mandatenbeheer/mandataris/edit.hbs
@@ -5,12 +5,12 @@
     <div>
       <AuHeading @skin="2">Bewerk mandataris</AuHeading>
       <p class="au-u-h3">
-        {{this.model.isBestuurlijkeAliasVan.gebruikteVoornaam}}
-        {{this.model.isBestuurlijkeAliasVan.achternaam~}}
+        {{@model.isBestuurlijkeAliasVan.gebruikteVoornaam}}
+        {{@model.isBestuurlijkeAliasVan.achternaam~}}
 
-        {{~#if this.model.bekleedt~}}
+        {{~#if @model.bekleedt~}}
           ,
-          {{this.model.bekleedt.bestuursfunctie.label}}
+          {{@model.bekleedt.bestuursfunctie.label}}
         {{/if}}
       </p>
     </div>
@@ -38,36 +38,66 @@
 <AuBodyContainer @scroll={{true}}>
   <div class="au-u-2-3@medium au-o-box">
     <div class="au-u-margin-bottom-small">
-      <AuLabel for="mandaat">Mandaat</AuLabel>
+      {{#let (if @model.errors.bekleedt true false) as |showError|}}
+      <AuLabel for="mandaat"
+        @required={{true}}
+        @error={{showError}}
+        >
+        Mandaat
+      </AuLabel>
       <Mandatenbeheer::MandaatBestuursorganenSelector
         @bestuursorganen={{this.bestuursorganen}}
-        @mandaat={{this.model.bekleedt}}
+        @mandaat={{@model.bekleedt}}
         @onSelect={{this.setMandaat}}
+        @error={{showError}}
       />
+      {{#if showError}}
+        <AuHelpText @error="true">
+          {{#each @model.errors.bekleedt as |errors|}}
+            {{errors.message}}
+          {{/each}}
+        </AuHelpText>
+      {{/if}}
+      {{/let}}
     </div>
     <div class="au-o-grid au-o-grid--tiny au-u-margin-bottom-small">
       <div class="au-o-grid__item au-u-1-2">
-        <AuLabel for="mandate-correction-start-date">Start</AuLabel>
+      {{#let (if @model.errors.start true false) as |showError|}}
+        <AuLabel for="mandate-correction-start-date"
+        @required={{true}}
+        @error={{showError}}
+        >
+        Start
+        </AuLabel>
         <AuDatePicker
-          @value={{this.model.start}}
+          @value={{@model.start}}
           @onChange={{fn this.handleDateChange "start"}}
+          @error={{showError}}
           @id="mandate-correction-start-date"
         />
+        {{#if showError}}
+        <AuHelpText @error="true">
+          {{#each @model.errors.start as |errors|}}
+            {{errors.message}}
+          {{/each}}
+        </AuHelpText>
+      {{/if}}
+      {{/let}}
       </div>
       <div class="au-o-grid__item au-u-1-2">
         <AuLabel for="mandate-correction-end-date">Einde</AuLabel>
         <AuDatePicker
-          @value={{this.model.einde}}
+          @value={{@model.einde}}
           @onChange={{fn this.handleDateChange "einde"}}
           @id="mandate-correction-end-date"
         />
       </div>
     </div>
-    {{#if this.model.bekleedt}}
+    {{#if @model.bekleedt}}
     <div class="au-u-margin-bottom-small">
       <AuLabel for="mandate-expected-end-date">Geplande einddatum</AuLabel>
       <AuInput
-        @value={{if this.model.expectedEndDate (moment-format this.model.expectedEndDate 'DD.MM.YYYY') 'N/A'}}
+        @value={{if @model.expectedEndDate (moment-format @model.expectedEndDate 'DD.MM.YYYY') 'N/A'}}
         @disabled={{true}}
         @id="mandate-expected-end-date"
       />

--- a/app/templates/eredienst-mandatenbeheer/new-person.hbs
+++ b/app/templates/eredienst-mandatenbeheer/new-person.hbs
@@ -6,6 +6,7 @@
 
 <Shared::Persoon::CreatePersoon
   @nationalityRequired={{true}}
+  @geboorteRequired={{true}}
   @onCreate={{this.onCreate}}
   @onCancel={{this.onCancel}}
 />

--- a/app/templates/eredienst-mandatenbeheer/new.hbs
+++ b/app/templates/eredienst-mandatenbeheer/new.hbs
@@ -59,7 +59,12 @@
     <div class="au-u-2-3@medium au-o-box">
       <div class="au-u-margin-bottom-small">
         {{#let (if @model.worshipMandatee.errors.bekleedt true false) as |showError|}}
-        <AuLabel for="mandaat" @error={{showError}} @required={{true}}>Mandaat</AuLabel>
+        <AuLabel for="mandaat"
+          @error={{showError}}
+          @required={{true}}
+          >
+          Mandaat
+        </AuLabel>
         <Mandatenbeheer::MandaatBestuursorganenSelector
           @bestuursorganen={{@model.bestuursorganen}}
           @mandaat={{@model.worshipMandatee.bekleedt}}
@@ -78,12 +83,27 @@
 
       <div class="au-o-grid au-o-grid--tiny au-u-margin-bottom-small">
         <div class="au-o-grid__item au-u-1-2">
-          <AuLabel for="mandate-start-date">Start</AuLabel>
+        {{#let (if @model.worshipMandatee.errors.start true false) as |showError|}}
+          <AuLabel for="mandate-start-date"
+            @error={{showError}}
+            @required={{true}}
+            >
+            Start
+          </AuLabel>
           <AuDatePicker
             @value={{@model.worshipMandatee.start}}
             @onChange={{fn this.handleDateChange "start"}}
+            @error={{showError}}
             @id="mandate-start-date"
           />
+          {{#if showError}}
+          <AuHelpText @error={{true}}>
+            {{#each @model.worshipMandatee.errors.start as |errors|}}
+              {{errors.message}}
+            {{/each}}
+          </AuHelpText>
+        {{/if}}
+        {{/let}}
         </div>
 
         <div class="au-o-grid__item au-u-1-2">

--- a/app/templates/worship-ministers-management/minister/edit.hbs
+++ b/app/templates/worship-ministers-management/minister/edit.hbs
@@ -46,24 +46,52 @@
 <AuBodyContainer @scroll={{true}}>
   <div class="au-u-2-3@medium au-o-box">
     <div class="au-u-margin-bottom-small">
-      <AuLabel for="worship-minister-function">Functienaam</AuLabel>
+      {{#let (if @model.minister.errors.ministerPosition true false) as |showError|}}
+      <AuLabel for="worship-minister-function"
+        @required={{true}}
+        @error={{showError}}
+        >
+        Functienaam
+      </AuLabel>
       <WorshipMinistersManagement::PositionSelect
         @worshipService={{@model.currentWorshipService}}
         @selected={{@model.minister.ministerPosition}}
-        @onChange={{fn (mut @model.minister.ministerPosition)}}
+        @onChange={{this.handleFunctieChange}}
+        @error={{showError}}
         id="worship-minister-position-select"
       />
+      {{#if showError}}
+        <AuHelpText @error="true">
+          {{#each @model.minister.errors.ministerPosition as |errors|}}
+            {{errors.message}}
+          {{/each}}
+        </AuHelpText>
+      {{/if}}
+      {{/let}}
     </div>
     <div class="au-o-grid au-o-grid--tiny au-u-margin-bottom-small">
       <div class="au-o-grid__item au-u-1-2">
-        <AuLabel for="worship-minister-correction-start-date">
+        {{#let (if @model.minister.errors.agentStartDate true false) as |showError|}}
+        <AuLabel for="worship-minister-correction-start-date"
+          @required={{true}}
+          @error={{showError}}
+          >
           Startdatum
         </AuLabel>
         <AuDatePicker
           @value={{@model.minister.agentStartDate}}
           @onChange={{fn this.handleDateChange "agentStartDate"}}
+          @error={{showError}}
           @id="worship-minister-correction-start-date"
         />
+        {{#if showError}}
+          <AuHelpText @error="true">
+            {{#each @model.minister.errors.agentStartDate as |errors|}}
+            {{errors.message}}
+            {{/each}}
+          </AuHelpText>
+        {{/if}}
+      {{/let}}
       </div>
       <div class="au-o-grid__item au-u-1-2">
         <AuLabel for="worship-minister-correction-end-date">Eindedatum</AuLabel>

--- a/app/templates/worship-ministers-management/new-person.hbs
+++ b/app/templates/worship-ministers-management/new-person.hbs
@@ -8,6 +8,7 @@
 
 <Shared::Persoon::CreatePersoon
   @nationalityRequired={{true}}
+  @geboorteRequired={{true}}
   @onCreate={{this.onCreate}}
   @onCancel={{this.onCancel}}
 />

--- a/app/templates/worship-ministers-management/new.hbs
+++ b/app/templates/worship-ministers-management/new.hbs
@@ -51,23 +51,53 @@
   >
     <div class="au-u-2-3@medium au-o-box">
       <div class="au-u-margin-bottom-small">
-        <AuLabel for="worship-minister-position-select">Functienaam</AuLabel>
+        {{#let (if @model.worshipMinister.errors.ministerPosition true false) as |showError|}}
+        <AuLabel for="worship-minister-position-select"
+          @required={{true}}
+          @error={{showError}}
+          >
+          Functienaam
+        </AuLabel>
         <WorshipMinistersManagement::PositionSelect
           @worshipService={{@model.currentWorshipService}}
           @selected={{@model.worshipMinister.ministerPosition}}
-          @onChange={{fn (mut @model.worshipMinister.ministerPosition)}}
+          @onChange={{this.handleFunctieChange}}
+          @error={{showError}}
           id="worship-minister-position-select"
         />
+        {{#if showError}}
+          <AuHelpText @error="true">
+            {{#each @model.worshipMinister.errors.ministerPosition as |errors|}}
+              {{errors.message}}
+            {{/each}}
+          </AuHelpText>
+        {{/if}}
+        {{/let}}
       </div>
 
       <div class="au-o-grid au-o-grid--tiny au-u-margin-bottom-small">
         <div class="au-o-grid__item au-u-1-2">
-          <AuLabel for="worship-minister-start-date">Startdatum</AuLabel>
+          {{#let (if @model.worshipMinister.errors.agentStartDate true false) as |showError|}}
+          <AuLabel for="worship-minister-start-date"
+            @required={{true}}
+            @error={{showError}}
+            >
+            Startdatum
+          </AuLabel>
           <AuDatePicker
             @value={{@model.worshipMinister.agentStartDate}}
             @onChange={{fn this.handleDateChange "agentStartDate"}}
+            @error={{showError}}
             @id="worship-minister-start-date"
           />
+        {{#if showError}}
+          <AuHelpText @error="true">
+            {{#each @model.worshipMinister.errors.agentStartDate as |errors|}}
+              {{errors.message}}
+            {{/each}}
+          </AuHelpText>
+        {{/if}}
+        {{/let}}
         </div>
 
         <div class="au-o-grid__item au-u-1-2">


### PR DESCRIPTION
DL-4291

This address the changes requested from QA testing :

- adding the field `geboorte` as required for the `create-persoon` component, also handling error if the field is empty. (Does this field is also mandatory on other modules ?)
- adding `startDatum` & `Functienaam` as required for the New page in `bedienarenbeheer`, same for error handling.

Note : Thinking about the `Rijksregisternummer`, since it does display the birth date at the beginning. Will this be tested in the future to compare/check if the **date from the Rijksregisternummer** = **geboorteDatum** ?

Does fields must be mandatory too on `Edit` page ? if so, this also needs to be added in `eredienst-mandatenbeheer`.


