### PR TITLE
Increase the datepicker width

### DIFF
--- a/app/styles/project/_c-rdf-forms.scss
+++ b/app/styles/project/_c-rdf-forms.scss
@@ -13,7 +13,7 @@
   }
 
   .au-c-datepicker {
-    max-width: 14rem;
+    max-width: 15rem;
   }
 
   .au-c-datepicker .duet-date__dialog {


### PR DESCRIPTION
The current width doesn't fit wider dates so the last letter gets cut off, (for example `30.09.2020`), so we simply increase the width.