### PR TITLE
Removing `userManualLink` for now in eredienst-mandatenbeheer and bedienarenbeheer

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -73,7 +73,7 @@
             @isAvailable={{this.currentSession.canAccessWorshipMinisterManagement}}
             @icon="user"
             @extraInformationLink="https://lokaalbestuur.vlaanderen.be/erediensten"
-            @userManualLink="https://loket.lokaalbestuur.vlaanderen.be/handleiding/#bedienarenbeheer"
+            {{!-- TODO: Add userManualLink link when it will be available --}}
           >
             <:title>Bedienarenbeheer</:title>
             <:description>Hou de bedienaren binnen de erediensten bij.</:description>
@@ -88,8 +88,8 @@
           <LoketModuleCard
             @isAvailable={{this.currentSession.canAccessEredienstMandatenbeheer}}
             @icon="users-four-of-four"
-            @extraInformationLink="TODO"
-            @userManualLink="TODO"
+            @extraInformationLink="https://lokaalbestuur.vlaanderen.be/erediensten"
+            {{!-- TODO: Add userManualLink link when it will be available --}}
           >
             <:title>Eredienst mandatenbeheer</:title>
             <:description>Hou de mandaten binnen de erediensten bij.</:description>

--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -112,7 +112,7 @@
                   <c.footer>
                     <p>
                       <a class="au-c-button" href="https://lokaalbestuur.vlaanderen.be/erediensten" target="_blank" rel="noopener noreferrer">Meer informatie</a>
-                      <a class="au-c-button au-c-button--secondary" href="https://loket.lokaalbestuur.vlaanderen.be/handleiding/#bedienarenbeheer" target="_blank" rel="noopener noreferrer">Handleiding</a>
+                      {{!-- TODO: Add userManualLink link when it will be available --}}
                     </p>
                   </c.footer>
                 </AuCard>
@@ -129,6 +129,12 @@
                   <c.content>
                     <p class="au-u-margin-top-tiny">Hou de mandaten binnen de erediensten bij.</p>
                   </c.content>
+                  <c.footer>
+                    <p>
+                      <a class="au-c-button" href="https://lokaalbestuur.vlaanderen.be/erediensten" target="_blank" rel="noopener noreferrer">Meer informatie</a>
+                      {{!-- TODO: Add userManualLink link when it will be available --}}
+                    </p>
+                  </c.footer>
                 </AuCard>
               </div>
             {{/if}}


### PR DESCRIPTION
DL-4292

The user manual for eredienst-mandatenbeheer and bedienarenbeheer is unavailable yet. We simply remove the URL's for now until we have the link.

Note : Does the more information link need to be removed too ? 