### PR TITLE
Shouldn't select and save an endDate that is less or equal than the starting date

### DIFF
--- a/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
+++ b/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
@@ -34,11 +34,14 @@ export default class EredienstMandatenbeheerMandatarisEditController extends Con
   @action
   handleDateChange(attributeName, isoDate, date) {
     this.model[attributeName] = date;
-    if (this.model.einde <= this.model.start) {
-      this.model.errors.add(
-        'einde',
-        'De einddatum moet na de startdatum liggen'
-      );
+    let { start, einde } = this.model;
+    if (einde instanceof Date && start instanceof Date) {
+      if (einde <= start) {
+        this.model.errors.add(
+          'einde',
+          'De einddatum moet na de startdatum liggen'
+        );
+      }
     }
   }
 

--- a/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
+++ b/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
@@ -41,6 +41,8 @@ export default class EredienstMandatenbeheerMandatarisEditController extends Con
           'einde',
           'De einddatum moet na de startdatum liggen'
         );
+      } else {
+        this.model.errors.remove('einde');
       }
     }
   }

--- a/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
+++ b/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
@@ -34,6 +34,12 @@ export default class EredienstMandatenbeheerMandatarisEditController extends Con
   @action
   handleDateChange(attributeName, isoDate, date) {
     this.model[attributeName] = date;
+    if (this.model.einde <= this.model.start) {
+      this.model.errors.add(
+        'einde',
+        'De einddatum moet groter zijn dan de begindatum'
+      );
+    }
   }
 
   @action
@@ -118,7 +124,9 @@ export default class EredienstMandatenbeheerMandatarisEditController extends Con
     } else {
       this.model.contacts = [];
     }
-
+    if (this.model.errors.has('einde')) {
+      return;
+    }
     yield this.model.save();
 
     try {

--- a/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
+++ b/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
@@ -37,7 +37,7 @@ export default class EredienstMandatenbeheerMandatarisEditController extends Con
     if (this.model.einde <= this.model.start) {
       this.model.errors.add(
         'einde',
-        'De einddatum moet groter zijn dan de begindatum'
+        'De einddatum moet na de startdatum liggen'
       );
     }
   }

--- a/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
+++ b/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
@@ -124,7 +124,7 @@ export default class EredienstMandatenbeheerMandatarisEditController extends Con
     } else {
       this.model.contacts = [];
     }
-    if (this.model.errors.has('einde')) {
+    if (!this.model.isValid) {
       return;
     }
     yield this.model.save();

--- a/app/controllers/eredienst-mandatenbeheer/new.js
+++ b/app/controllers/eredienst-mandatenbeheer/new.js
@@ -44,11 +44,14 @@ export default class EredienstMandatenbeheerNewController extends Controller {
   handleDateChange(type, isoDate, date) {
     const { worshipMandatee } = this.model;
     worshipMandatee[type] = date;
-    if (worshipMandatee.einde <= worshipMandatee.start) {
-      worshipMandatee.errors.add(
-        'einde',
-        'De einddatum moet na de startdatum liggen'
-      );
+    let { einde, start } = worshipMandatee;
+    if (einde instanceof Date && start instanceof Date) {
+      if (einde <= start) {
+        worshipMandatee.errors.add(
+          'einde',
+          'De einddatum moet na de startdatum liggen'
+        );
+      }
     }
   }
 

--- a/app/controllers/eredienst-mandatenbeheer/new.js
+++ b/app/controllers/eredienst-mandatenbeheer/new.js
@@ -57,7 +57,7 @@ export default class EredienstMandatenbeheerNewController extends Controller {
     event.preventDefault();
 
     let { worshipMandatee } = this.model;
-    if (worshipMandatee.errors.has('einde')) {
+    if (!worshipMandatee.isValid) {
       return;
     }
     if (yield isMandaatSelected(worshipMandatee)) {

--- a/app/controllers/eredienst-mandatenbeheer/new.js
+++ b/app/controllers/eredienst-mandatenbeheer/new.js
@@ -47,7 +47,7 @@ export default class EredienstMandatenbeheerNewController extends Controller {
     if (worshipMandatee.einde <= worshipMandatee.start) {
       worshipMandatee.errors.add(
         'einde',
-        'De einddatum moet groter zijn dan de begindatum'
+        'De einddatum moet na de startdatum liggen'
       );
     }
   }

--- a/app/controllers/eredienst-mandatenbeheer/new.js
+++ b/app/controllers/eredienst-mandatenbeheer/new.js
@@ -42,7 +42,14 @@ export default class EredienstMandatenbeheerNewController extends Controller {
 
   @action
   handleDateChange(type, isoDate, date) {
-    this.model.worshipMandatee[type] = date;
+    const { worshipMandatee } = this.model;
+    worshipMandatee[type] = date;
+    if (worshipMandatee.einde <= worshipMandatee.start) {
+      worshipMandatee.errors.add(
+        'einde',
+        'De einddatum moet groter zijn dan de begindatum'
+      );
+    }
   }
 
   @dropTask
@@ -50,6 +57,9 @@ export default class EredienstMandatenbeheerNewController extends Controller {
     event.preventDefault();
 
     let { worshipMandatee } = this.model;
+    if (worshipMandatee.errors.has('einde')) {
+      return;
+    }
     if (yield isMandaatSelected(worshipMandatee)) {
       yield worshipMandatee.save();
       this.router.transitionTo(

--- a/app/controllers/eredienst-mandatenbeheer/new.js
+++ b/app/controllers/eredienst-mandatenbeheer/new.js
@@ -51,6 +51,8 @@ export default class EredienstMandatenbeheerNewController extends Controller {
           'einde',
           'De einddatum moet na de startdatum liggen'
         );
+      } else {
+        worshipMandatee.errors.remove('einde');
       }
     }
   }

--- a/app/controllers/worship-ministers-management/minister/edit.js
+++ b/app/controllers/worship-ministers-management/minister/edit.js
@@ -25,7 +25,14 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
 
   @action
   handleDateChange(attributeName, isoDate, date) {
-    this.model.minister[attributeName] = date;
+    const { minister } = this.model;
+    minister[attributeName] = date;
+    if (minister.agentEndDate <= minister.agentStartDate) {
+      minister.errors.add(
+        'agentEndDate',
+        'De einddatum moet groter zijn dan de begindatum'
+      );
+    }
   }
 
   @action
@@ -108,6 +115,9 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
       }
     } else {
       minister.contacts = [];
+    }
+    if (minister.errors.has('agentEndDate')) {
+      return;
     }
 
     yield minister.save();

--- a/app/controllers/worship-ministers-management/minister/edit.js
+++ b/app/controllers/worship-ministers-management/minister/edit.js
@@ -27,11 +27,14 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
   handleDateChange(attributeName, isoDate, date) {
     const { minister } = this.model;
     minister[attributeName] = date;
-    if (minister.agentEndDate <= minister.agentStartDate) {
-      minister.errors.add(
-        'agentEndDate',
-        'De einddatum moet na de startdatum liggen'
-      );
+    let { agentStartDate, agentEndDate } = minister;
+    if (agentEndDate instanceof Date && agentStartDate instanceof Date) {
+      if (agentEndDate <= agentStartDate) {
+        minister.errors.add(
+          'agentEndDate',
+          'De einddatum moet na de startdatum liggen'
+        );
+      }
     }
   }
 

--- a/app/controllers/worship-ministers-management/minister/edit.js
+++ b/app/controllers/worship-ministers-management/minister/edit.js
@@ -30,7 +30,7 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
     if (minister.agentEndDate <= minister.agentStartDate) {
       minister.errors.add(
         'agentEndDate',
-        'De einddatum moet groter zijn dan de begindatum'
+        'De einddatum moet na de startdatum liggen'
       );
     }
   }

--- a/app/controllers/worship-ministers-management/minister/edit.js
+++ b/app/controllers/worship-ministers-management/minister/edit.js
@@ -34,6 +34,8 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
           'agentEndDate',
           'De einddatum moet na de startdatum liggen'
         );
+      } else {
+        minister.errors.remove('agentEndDate');
       }
     }
   }

--- a/app/controllers/worship-ministers-management/minister/edit.js
+++ b/app/controllers/worship-ministers-management/minister/edit.js
@@ -116,7 +116,7 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
     } else {
       minister.contacts = [];
     }
-    if (minister.errors.has('agentEndDate')) {
+    if (!minister.isValid) {
       return;
     }
 

--- a/app/controllers/worship-ministers-management/new.js
+++ b/app/controllers/worship-ministers-management/new.js
@@ -30,11 +30,14 @@ export default class WorshipMinistersManagementNewController extends Controller 
   async handleDateChange(type, isoDate, date) {
     const { worshipMinister } = this.model;
     worshipMinister[type] = date;
-    if (worshipMinister.agentEndDate <= worshipMinister.agentStartDate) {
-      worshipMinister.errors.add(
-        'agentEndDate',
-        'De einddatum moet na de startdatum liggen'
-      );
+    let { agentStartDate, agentEndDate } = worshipMinister;
+    if (agentEndDate instanceof Date && agentStartDate instanceof Date) {
+      if (agentEndDate <= agentStartDate) {
+        worshipMinister.errors.add(
+          'agentEndDate',
+          'De einddatum moet na de startdatum liggen'
+        );
+      }
     }
   }
 

--- a/app/controllers/worship-ministers-management/new.js
+++ b/app/controllers/worship-ministers-management/new.js
@@ -37,6 +37,8 @@ export default class WorshipMinistersManagementNewController extends Controller 
           'agentEndDate',
           'De einddatum moet na de startdatum liggen'
         );
+      } else {
+        worshipMinister.errors.remove('agentEndDate');
       }
     }
   }

--- a/app/controllers/worship-ministers-management/new.js
+++ b/app/controllers/worship-ministers-management/new.js
@@ -33,7 +33,7 @@ export default class WorshipMinistersManagementNewController extends Controller 
     if (worshipMinister.agentEndDate <= worshipMinister.agentStartDate) {
       worshipMinister.errors.add(
         'agentEndDate',
-        'De einddatum moet groter zijn dan de begindatum'
+        'De einddatum moet na de startdatum liggen'
       );
     }
   }

--- a/app/controllers/worship-ministers-management/new.js
+++ b/app/controllers/worship-ministers-management/new.js
@@ -27,8 +27,15 @@ export default class WorshipMinistersManagementNewController extends Controller 
   }
 
   @action
-  handleDateChange(type, isoDate, date) {
-    this.model.worshipMinister[type] = date;
+  async handleDateChange(type, isoDate, date) {
+    const { worshipMinister } = this.model;
+    worshipMinister[type] = date;
+    if (worshipMinister.agentEndDate <= worshipMinister.agentStartDate) {
+      worshipMinister.errors.add(
+        'agentEndDate',
+        'De einddatum moet groter zijn dan de begindatum'
+      );
+    }
   }
 
   @action
@@ -41,6 +48,9 @@ export default class WorshipMinistersManagementNewController extends Controller 
     event.preventDefault();
 
     let { worshipMinister } = this.model;
+    if (worshipMinister.errors.has('agentEndDate')) {
+      return;
+    }
     yield worshipMinister.save();
 
     this.router.transitionTo(

--- a/app/controllers/worship-ministers-management/new.js
+++ b/app/controllers/worship-ministers-management/new.js
@@ -48,7 +48,7 @@ export default class WorshipMinistersManagementNewController extends Controller 
     event.preventDefault();
 
     let { worshipMinister } = this.model;
-    if (worshipMinister.errors.has('agentEndDate')) {
+    if (!worshipMinister.isValid) {
       return;
     }
     yield worshipMinister.save();

--- a/app/templates/eredienst-mandatenbeheer/mandataris/edit.hbs
+++ b/app/templates/eredienst-mandatenbeheer/mandataris/edit.hbs
@@ -55,12 +55,22 @@
         />
       </div>
       <div class="au-o-grid__item au-u-1-2">
-        <AuLabel for="mandate-correction-end-date">Einde</AuLabel>
+        {{#let (if this.model.errors.einde true false) as |showError|}}
+        <AuLabel for="mandate-correction-end-date" @error={{showError}}>Einde</AuLabel>
         <AuDatePicker
           @value={{this.model.einde}}
           @onChange={{fn this.handleDateChange "einde"}}
+          @error={{showError}}
           @id="mandate-correction-end-date"
         />
+        {{#if showError}}
+          <AuHelpText @error={{true}}>
+            {{#each this.model.errors.einde as |errors|}}
+              {{errors.message}}
+            {{/each}}
+          </AuHelpText>
+        {{/if}}
+        {{/let}}
       </div>
     </div>
     {{#if this.model.bekleedt}}

--- a/app/templates/eredienst-mandatenbeheer/new.hbs
+++ b/app/templates/eredienst-mandatenbeheer/new.hbs
@@ -87,12 +87,22 @@
         </div>
 
         <div class="au-o-grid__item au-u-1-2">
-          <AuLabel for="mandate-end-date">Einde</AuLabel>
+          {{#let (if @model.worshipMandatee.errors.einde true false) as |showError|}}
+          <AuLabel for="mandate-end-date" @error={{showError}}>Einde</AuLabel>
           <AuDatePicker
             @value={{@model.worshipMandatee.einde}}
             @onChange={{fn this.handleDateChange "einde"}}
+            @error={{showError}}
             @id="mandate-end-date"
           />
+          {{#if showError}}
+          <AuHelpText @error={{true}}>
+            {{#each @model.worshipMandatee.errors.einde as |errors|}}
+              {{errors.message}}
+            {{/each}}
+          </AuHelpText>
+          {{/if}}
+          {{/let}}
         </div>
       </div>
 

--- a/app/templates/worship-ministers-management/minister/edit.hbs
+++ b/app/templates/worship-ministers-management/minister/edit.hbs
@@ -67,7 +67,7 @@
       </div>
       <div class="au-o-grid__item au-u-1-2">
         {{#let (if @model.minister.errors.agentEndDate true false) as |showError|}}
-        <AuLabel for="worship-minister-correction-end-date" @error={{showError}}>Eindedatum</AuLabel>
+        <AuLabel for="worship-minister-correction-end-date" @error={{showError}}>Einddatum</AuLabel>
         <AuDatePicker
           @value={{@model.minister.agentEndDate}}
           @onChange={{fn this.handleDateChange "agentEndDate"}}

--- a/app/templates/worship-ministers-management/minister/edit.hbs
+++ b/app/templates/worship-ministers-management/minister/edit.hbs
@@ -66,12 +66,22 @@
         />
       </div>
       <div class="au-o-grid__item au-u-1-2">
-        <AuLabel for="worship-minister-correction-end-date">Eindedatum</AuLabel>
+        {{#let (if @model.minister.errors.agentEndDate true false) as |showError|}}
+        <AuLabel for="worship-minister-correction-end-date" @error={{showError}}>Eindedatum</AuLabel>
         <AuDatePicker
           @value={{@model.minister.agentEndDate}}
           @onChange={{fn this.handleDateChange "agentEndDate"}}
+          @error={{showError}}
           @id="worship-minister-correction-end-date"
         />
+        {{#if showError}}
+          <AuHelpText @error={{true}}>
+            {{#each @model.minister.errors.agentEndDate as |errors|}}
+              {{errors.message}}
+            {{/each}}
+          </AuHelpText>
+          {{/if}}
+          {{/let}}
       </div>
     </div>
   </div>

--- a/app/templates/worship-ministers-management/new.hbs
+++ b/app/templates/worship-ministers-management/new.hbs
@@ -71,12 +71,22 @@
         </div>
 
         <div class="au-o-grid__item au-u-1-2">
-          <AuLabel for="worship-minister-end-date">Eindedatum</AuLabel>
+          {{#let (if @model.worshipMinister.errors.agentEndDate true false) as |showError|}}
+          <AuLabel for="worship-minister-end-date" @error={{showError}}>Eindedatum</AuLabel>
           <AuDatePicker
             @value={{@model.worshipMinister.agentEndDate}}
             @onChange={{fn this.handleDateChange "agentEndDate"}}
+            @error={{showError}}
             @id="worship-minister-end-date"
           />
+          {{#if showError}}
+          <AuHelpText @error={{true}}>
+            {{#each @model.worshipMinister.errors.agentEndDate as |errors|}}
+              {{errors.message}}
+            {{/each}}
+          </AuHelpText>
+          {{/if}}
+          {{/let}}
         </div>
       </div>
 

--- a/app/templates/worship-ministers-management/new.hbs
+++ b/app/templates/worship-ministers-management/new.hbs
@@ -72,7 +72,7 @@
 
         <div class="au-o-grid__item au-u-1-2">
           {{#let (if @model.worshipMinister.errors.agentEndDate true false) as |showError|}}
-          <AuLabel for="worship-minister-end-date" @error={{showError}}>Eindedatum</AuLabel>
+          <AuLabel for="worship-minister-end-date" @error={{showError}}>Einddatum</AuLabel>
           <AuDatePicker
             @value={{@model.worshipMinister.agentEndDate}}
             @onChange={{fn this.handleDateChange "agentEndDate"}}


### PR DESCRIPTION
DL-4375

This prevent to save the record if the ending date is less or equal than the starting date for `eredienst-mandatenbeheer` and `bedienarenbeheer`. Sending an error to the user if it's the case.