### PR TITLE
Old tables don't have a version number.

### DIFF
--- a/app/components/rdf-form-fields/climate-subsidy-costs-table.js
+++ b/app/components/rdf-form-fields/climate-subsidy-costs-table.js
@@ -133,7 +133,7 @@ export default class RdfFormFieldsClimateSubsidyCostsTableComponent extends Inpu
       LBLOD_SUBSIDIE('lekp'),
       undefined,
       metaGraph
-    )[0].object.value;
+    )[0]?.object?.value || '1.0';
 
     this.drawingRight = drawingRight;
     this.restitutionToDestribute = drawingRight;


### PR DESCRIPTION
We assume if not provided, this is version 1.0