### PR TITLE
Eredienst mandatenbeheer / bedienarenbeheer: startdatum and einddatum inconsistency fix

### DIFF
--- a/app/templates/eredienst-mandatenbeheer/mandataris/edit.hbs
+++ b/app/templates/eredienst-mandatenbeheer/mandataris/edit.hbs
@@ -47,7 +47,7 @@
     </div>
     <div class="au-o-grid au-o-grid--tiny au-u-margin-bottom-small">
       <div class="au-o-grid__item au-u-1-2">
-        <AuLabel for="mandate-correction-start-date">Start</AuLabel>
+        <AuLabel for="mandate-correction-start-date">Startdatum</AuLabel>
         <AuDatePicker
           @value={{this.model.start}}
           @onChange={{fn this.handleDateChange "start"}}
@@ -55,7 +55,7 @@
         />
       </div>
       <div class="au-o-grid__item au-u-1-2">
-        <AuLabel for="mandate-correction-end-date">Einde</AuLabel>
+        <AuLabel for="mandate-correction-end-date">Einddatum</AuLabel>
         <AuDatePicker
           @value={{this.model.einde}}
           @onChange={{fn this.handleDateChange "einde"}}

--- a/app/templates/eredienst-mandatenbeheer/mandatarissen.hbs
+++ b/app/templates/eredienst-mandatenbeheer/mandatarissen.hbs
@@ -44,8 +44,8 @@
         <AuDataTableThSortable @field='isBestuurlijkeAliasVan.gebruikteVoornaam' @currentSorting={{this.sort}} @label='Naam' class="au-u-visible-small-up" />
         <AuDataTableThSortable @field='isBestuurlijkeAliasVan.achternaam' @currentSorting={{this.sort}} @label='Familienaam'/>
         <AuDataTableThSortable @field='bekleedt.bestuursfunctie.label' @currentSorting={{this.sort}} @label='Mandaat' />
-        <AuDataTableThSortable @field='start' @currentSorting={{this.sort}} @label='Start mandaat' class="au-u-visible-medium-up" />
-        <AuDataTableThSortable @field='einde' @currentSorting={{this.sort}} @label='Einde mandaat' class="au-u-visible-medium-up" />
+        <AuDataTableThSortable @field='start' @currentSorting={{this.sort}} @label='Startdatum' class="au-u-visible-medium-up" />
+        <AuDataTableThSortable @field='einde' @currentSorting={{this.sort}} @label='Einddatum' class="au-u-visible-medium-up" />
         <th></th>
       </c.header>
       <c.body data-test-loket="mandatarissen-body" as |row|>

--- a/app/templates/eredienst-mandatenbeheer/new.hbs
+++ b/app/templates/eredienst-mandatenbeheer/new.hbs
@@ -78,7 +78,7 @@
 
       <div class="au-o-grid au-o-grid--tiny au-u-margin-bottom-small">
         <div class="au-o-grid__item au-u-1-2">
-          <AuLabel for="mandate-start-date">Start</AuLabel>
+          <AuLabel for="mandate-start-date">Startdatum</AuLabel>
           <AuDatePicker
             @value={{@model.worshipMandatee.start}}
             @onChange={{fn this.handleDateChange "start"}}
@@ -87,7 +87,7 @@
         </div>
 
         <div class="au-o-grid__item au-u-1-2">
-          <AuLabel for="mandate-end-date">Einde</AuLabel>
+          <AuLabel for="mandate-end-date">Einddatum</AuLabel>
           <AuDatePicker
             @value={{@model.worshipMandatee.einde}}
             @onChange={{fn this.handleDateChange "einde"}}

--- a/app/templates/worship-ministers-management/index.hbs
+++ b/app/templates/worship-ministers-management/index.hbs
@@ -44,7 +44,7 @@
       <AuDataTableThSortable
         @field="agentEndDate"
         @currentSorting={{this.sort}}
-        @label="Eindedatum"
+        @label="Einddatum"
       />
       <th class="u-table-cell-shrink-content">
         <span class="au-u-hidden-visually">Bedienaar bewerken</span>

--- a/app/templates/worship-ministers-management/minister/edit.hbs
+++ b/app/templates/worship-ministers-management/minister/edit.hbs
@@ -66,7 +66,7 @@
         />
       </div>
       <div class="au-o-grid__item au-u-1-2">
-        <AuLabel for="worship-minister-correction-end-date">Eindedatum</AuLabel>
+        <AuLabel for="worship-minister-correction-end-date">Einddatum</AuLabel>
         <AuDatePicker
           @value={{@model.minister.agentEndDate}}
           @onChange={{fn this.handleDateChange "agentEndDate"}}

--- a/app/templates/worship-ministers-management/new.hbs
+++ b/app/templates/worship-ministers-management/new.hbs
@@ -71,7 +71,7 @@
         </div>
 
         <div class="au-o-grid__item au-u-1-2">
-          <AuLabel for="worship-minister-end-date">Eindedatum</AuLabel>
+          <AuLabel for="worship-minister-end-date">Einddatum</AuLabel>
           <AuDatePicker
             @value={{@model.worshipMinister.agentEndDate}}
             @onChange={{fn this.handleDateChange "agentEndDate"}}


### PR DESCRIPTION
DL-4379
This makes the typo `startdatum` and `einddatum` consistent between the two modules `eredienst-mandatenbeheer` & `bedienarenbeheer`. 

Changes were made also in https://github.com/lblod/frontend-loket/pull/213 for error messages.