### PR TITLE
Hide unavailable modules

### DIFF
--- a/app/components/loket-module-card.hbs
+++ b/app/components/loket-module-card.hbs
@@ -1,3 +1,4 @@
+{{#if @isAvailable}}
 <AuCard @flex="true" ...attributes as |c|>
   {{#if (has-block "title")}}
     <c.header @badgeSkin="brand" @badgeIcon={{@icon}}>
@@ -12,21 +13,9 @@
         {{yield to="description"}}
       </p>
     {{/if}}
-
-    {{#if @isAvailable}}
       <p data-test-loket-module-card="link">
         {{yield to="link"}}
       </p>
-    {{else}}
-      <AuAlert
-        @title="Geen toegang."
-        @skin="info"
-        @size="tiny"
-        data-test-loket-module-card="not-available"
-      >
-        Neem contact op met uw interne beheerder om toegang te verkrijgen.
-      </AuAlert>
-    {{/if}}
   </c.content>
   {{#if (or @extraInformationLink @userManualLink)}}
     <c.footer>
@@ -54,3 +43,4 @@
     </c.footer>
   {{/if}}
 </AuCard>
+{{/if}}

--- a/app/components/loket-module-card.hbs
+++ b/app/components/loket-module-card.hbs
@@ -1,4 +1,3 @@
-{{#if @isAvailable}}
 <AuCard @flex="true" ...attributes as |c|>
   {{#if (has-block "title")}}
     <c.header @badgeSkin="brand" @badgeIcon={{@icon}}>
@@ -43,4 +42,3 @@
     </c.footer>
   {{/if}}
 </AuCard>
-{{/if}}

--- a/app/components/shared/bread-crumb.js
+++ b/app/components/shared/bread-crumb.js
@@ -202,13 +202,13 @@ export default class SharedBreadCrumbComponent extends Component {
     },
     {
       route: 'eredienst-mandatenbeheer.mandatarissen',
-      crumbs: [{ label: 'Eredienst mandatenbeheer' }],
+      crumbs: [{ label: 'Mandatenbeheer' }],
     },
     {
       route: 'eredienst-mandatenbeheer.mandataris.edit',
       crumbs: [
         {
-          label: 'Eredienst mandatenbeheer',
+          label: 'Mandatenbeheer',
           link: 'eredienst-mandatenbeheer.mandatarissen',
         },
         { label: 'Bewerk mandataris' },
@@ -218,7 +218,7 @@ export default class SharedBreadCrumbComponent extends Component {
       route: 'eredienst-mandatenbeheer.new',
       crumbs: [
         {
-          label: 'Eredienst mandatenbeheer',
+          label: 'Mandatenbeheer',
           link: 'eredienst-mandatenbeheer.mandatarissen',
         },
         { label: 'Voeg mandaat toe' },
@@ -228,7 +228,7 @@ export default class SharedBreadCrumbComponent extends Component {
       route: 'eredienst-mandatenbeheer.new-person',
       crumbs: [
         {
-          label: 'Eredienst mandatenbeheer',
+          label: 'Mandatenbeheer',
           link: 'eredienst-mandatenbeheer.mandatarissen',
         },
         { label: 'Voeg nieuwe persoon toe' },
@@ -238,7 +238,7 @@ export default class SharedBreadCrumbComponent extends Component {
       route: 'eredienst-mandatenbeheer.mandataris.contact-points.new',
       crumbs: [
         {
-          label: 'Eredienst mandatenbeheer',
+          label: 'Mandatenbeheer',
           link: 'eredienst-mandatenbeheer.mandatarissen',
         },
         {
@@ -252,7 +252,7 @@ export default class SharedBreadCrumbComponent extends Component {
       route: 'eredienst-mandatenbeheer.mandataris.contact-points.edit',
       crumbs: [
         {
-          label: 'Eredienst mandatenbeheer',
+          label: 'Mandatenbeheer',
           link: 'eredienst-mandatenbeheer.mandatarissen',
         },
         {

--- a/app/components/shared/compact-menu.hbs
+++ b/app/components/shared/compact-menu.hbs
@@ -52,7 +52,7 @@
   {{#if this.currentSession.canAccessEredienstMandatenbeheer}}
     <AuLink @route="eredienst-mandatenbeheer.mandatarissen" role="menuitem">
       <AuIcon @icon="users-four-of-four" @alignment="left" />
-      Eredienst<br> mandatenbeheer
+      Mandatenbeheer
     </AuLink>
   {{/if}}
   {{#if this.currentSession.canAccessPublicServices}}

--- a/app/components/shared/main-menu.hbs
+++ b/app/components/shared/main-menu.hbs
@@ -70,7 +70,7 @@
     {{#if this.currentSession.canAccessEredienstMandatenbeheer}}
       <AuNavigationLink @route="eredienst-mandatenbeheer.mandatarissen">
         <AuIcon @icon="users-four-of-four" @alignment="left" />
-        Eredienst mandatenbeheer
+        Mandatenbeheer
       </AuNavigationLink>
     {{/if}}
     {{#if this.currentSession.canAccessPublicServices}}

--- a/app/templates/eredienst-mandatenbeheer.hbs
+++ b/app/templates/eredienst-mandatenbeheer.hbs
@@ -1,2 +1,2 @@
-{{page-title "Eredienst mandatenbeheer"}}
+{{page-title "Mandatenbeheer"}}
 {{outlet}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -91,10 +91,10 @@
             @extraInformationLink="https://lokaalbestuur.vlaanderen.be/erediensten"
             {{!-- TODO: Add userManualLink link when it will be available --}}
           >
-            <:title>Eredienst mandatenbeheer</:title>
+            <:title>Mandatenbeheer</:title>
             <:description>Hou de mandaten binnen de erediensten bij.</:description>
             <:link>
-              <AuLink @route="eredienst-mandatenbeheer.mandatarissen" @skin="button">Ga naar eredienst mandatenbeheer</AuLink>
+              <AuLink @route="eredienst-mandatenbeheer.mandatarissen" @skin="button">Ga naar Mandatenbeheer</AuLink>
             </:link>
           </LoketModuleCard>
         </li>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -11,6 +11,7 @@
     <AuHeading @level="2" @skin="3" class="au-u-margin-bottom">Beschikbare modules</AuHeading>
 
     <ul class="au-o-grid au-o-grid--small">
+      {{#if this.currentSession.canAccessToezicht}}
       <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
           @isAvailable={{this.currentSession.canAccessToezicht}}
@@ -25,6 +26,8 @@
           </:link>
         </LoketModuleCard>
       </li>
+      {{/if}}
+      {{#if this.currentSession.canAccessBerichten}}
       <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
           @isAvailable={{this.currentSession.canAccessBerichten}}
@@ -39,6 +42,8 @@
           </:link>
         </LoketModuleCard>
       </li>
+      {{/if}}
+      {{#if this.currentSession.canAccessBbcdr}}
       <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
           @isAvailable={{this.currentSession.canAccessBbcdr}}
@@ -53,6 +58,8 @@
           </:link>
         </LoketModuleCard>
       </li>
+      {{/if}}
+      {{#if this.currentSession.canAccessMandaat}}
       <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
           @isAvailable={{this.currentSession.canAccessMandaat}}
@@ -67,7 +74,8 @@
           </:link>
         </LoketModuleCard>
       </li>
-      {{#if (is-feature-enabled "worship-minister-management")}}
+      {{/if}}
+      {{#if (or is-feature-enabled "worship-minister-management" this.currentSession.canAccessWorshipMinisterManagement)}}
         <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
           <LoketModuleCard
             @isAvailable={{this.currentSession.canAccessWorshipMinisterManagement}}
@@ -83,7 +91,7 @@
           </LoketModuleCard>
         </li>
       {{/if}}
-      {{#if (is-feature-enabled "eredienst-mandatenbeheer")}}
+      {{#if (or is-feature-enabled "eredienst-mandatenbeheer" this.currentSession.canAccessEredienstMandatenbeheer)}}
         <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
           <LoketModuleCard
             @isAvailable={{this.currentSession.canAccessEredienstMandatenbeheer}}
@@ -99,6 +107,7 @@
           </LoketModuleCard>
         </li>
       {{/if}}
+      {{#if this.currentSession.canAccessLeidinggevenden}}
       <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
           @isAvailable={{this.currentSession.canAccessLeidinggevenden}}
@@ -113,6 +122,8 @@
           </:link>
         </LoketModuleCard>
       </li>
+      {{/if}}
+      {{#if this.currentSession.canAccessPersoneelsbeheer}}
       <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
           @isAvailable={{this.currentSession.canAccessPersoneelsbeheer}}
@@ -126,6 +137,8 @@
           </:link>
         </LoketModuleCard>
       </li>
+      {{/if}}
+      {{#if this.currentSession.canAccessSubsidies}}
       <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
           @isAvailable={{this.currentSession.canAccessSubsidies}}
@@ -140,7 +153,8 @@
           </:link>
         </LoketModuleCard>
       </li>
-      {{#if (is-feature-enabled "public-services")}}
+      {{/if}}
+      {{#if (or is-feature-enabled "public-services" this.currentSession.canAccessPublicServices)}}
         <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
           @isAvailable={{this.currentSession.canAccessPublicServices}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -14,7 +14,6 @@
       {{#if this.currentSession.canAccessToezicht}}
       <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
-          @isAvailable={{this.currentSession.canAccessToezicht}}
           @icon="search-folder"
           @extraInformationLink="https://lokaalbestuur.vlaanderen.be/loket-lokaal-bestuur-module-toezicht"
           @userManualLink="https://loket.lokaalbestuur.vlaanderen.be/handleiding/#toezicht"
@@ -30,7 +29,6 @@
       {{#if this.currentSession.canAccessBerichten}}
       <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
-          @isAvailable={{this.currentSession.canAccessBerichten}}
           @icon="message"
           @extraInformationLink="https://lokaalbestuur.vlaanderen.be/loket-lokaal-bestuur-module-berichtencentrum"
           @userManualLink="https://loket.lokaalbestuur.vlaanderen.be/handleiding/#berichtencentrum"
@@ -46,7 +44,6 @@
       {{#if this.currentSession.canAccessBbcdr}}
       <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
-          @isAvailable={{this.currentSession.canAccessBbcdr}}
           @icon="document"
           @extraInformationLink="https://lokaalbestuur.vlaanderen.be/bbc-strategisch-en-financieel-beleid/digitale-rapportering"
           @userManualLink="https://loket.lokaalbestuur.vlaanderen.be/handleiding/#bbcdr"
@@ -62,7 +59,6 @@
       {{#if this.currentSession.canAccessMandaat}}
       <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
-          @isAvailable={{this.currentSession.canAccessMandaat}}
           @icon="user-fill"
           @extraInformationLink="https://lokaalbestuur.vlaanderen.be/mandatarissen/mandatendatabank"
           @userManualLink="https://loket.lokaalbestuur.vlaanderen.be/handleiding/#mandatenbeheer"
@@ -75,10 +71,9 @@
         </LoketModuleCard>
       </li>
       {{/if}}
-      {{#if (or is-feature-enabled "worship-minister-management" this.currentSession.canAccessWorshipMinisterManagement)}}
+      {{#if (and (is-feature-enabled "worship-minister-management") this.currentSession.canAccessWorshipMinisterManagement)}}
         <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
           <LoketModuleCard
-            @isAvailable={{this.currentSession.canAccessWorshipMinisterManagement}}
             @icon="user"
             @extraInformationLink="https://lokaalbestuur.vlaanderen.be/erediensten"
             {{!-- TODO: Add userManualLink link when it will be available --}}
@@ -91,10 +86,9 @@
           </LoketModuleCard>
         </li>
       {{/if}}
-      {{#if (or is-feature-enabled "eredienst-mandatenbeheer" this.currentSession.canAccessEredienstMandatenbeheer)}}
+      {{#if (and (is-feature-enabled "eredienst-mandatenbeheer") this.currentSession.canAccessEredienstMandatenbeheer)}}
         <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
           <LoketModuleCard
-            @isAvailable={{this.currentSession.canAccessEredienstMandatenbeheer}}
             @icon="users-four-of-four"
             @extraInformationLink="https://lokaalbestuur.vlaanderen.be/erediensten"
             {{!-- TODO: Add userManualLink link when it will be available --}}
@@ -110,7 +104,6 @@
       {{#if this.currentSession.canAccessLeidinggevenden}}
       <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
-          @isAvailable={{this.currentSession.canAccessLeidinggevenden}}
           @icon="user-popup"
           @extraInformationLink="https://lokaalbestuur.vlaanderen.be/personeel/databank-leidinggevenden"
           @userManualLink="https://loket.lokaalbestuur.vlaanderen.be/handleiding/#leidinggevendenbeheer"
@@ -126,7 +119,6 @@
       {{#if this.currentSession.canAccessPersoneelsbeheer}}
       <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
-          @isAvailable={{this.currentSession.canAccessPersoneelsbeheer}}
           @icon="users"
           @userManualLink="https://loket.lokaalbestuur.vlaanderen.be/handleiding/#personeelsbeheer"
         >
@@ -141,7 +133,6 @@
       {{#if this.currentSession.canAccessSubsidies}}
       <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
-          @isAvailable={{this.currentSession.canAccessSubsidies}}
           @icon="documents"
           @extraInformationLink="https://lokaalbestuur.vlaanderen.be/loket-lokaal-bestuur-module-subsidies"
           @userManualLink="https://loket.lokaalbestuur.vlaanderen.be/handleiding/#subsidiebeheer"
@@ -154,10 +145,9 @@
         </LoketModuleCard>
       </li>
       {{/if}}
-      {{#if (or is-feature-enabled "public-services" this.currentSession.canAccessPublicServices)}}
+      {{#if (and (is-feature-enabled "public-services") this.currentSession.canAccessPublicServices)}}
         <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
-          @isAvailable={{this.currentSession.canAccessPublicServices}}
           @icon="unordered-list"
           {{! TODO: Add the needed documentation links }}
         >

--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -123,7 +123,7 @@
                 <AuCard @textCenter="true" as |c|>
                   <c.header @badgeSkin="brand" @badgeIcon="user-fill">
                     <AuHeading @level="3" @skin="4">
-                      Eredienst mandatenbeheer
+                      Mandatenbeheer
                     </AuHeading>
                   </c.header>
                   <c.content>

--- a/tests/integration/components/loket-module-card-test.js
+++ b/tests/integration/components/loket-module-card-test.js
@@ -7,7 +7,6 @@ const LOKET_MODULE_CARD = {
   TITLE: '[data-test-loket-module-card="title"]',
   DESCRIPTION: '[data-test-loket-module-card="description"]',
   LINK: '[data-test-loket-module-card="link"]',
-  NOT_AVAILABLE: '[data-test-loket-module-card="not-available"]',
   EXTRA_INFORMATION_LINK:
     '[data-test-loket-module-card="extra-information-link"]',
   USER_MANUAL_LINK: '[data-test-loket-module-card="user-manual-link"]',
@@ -58,26 +57,9 @@ module('Integration | Component | loket-module-card', function (hooks) {
     assert.dom(LOKET_MODULE_CARD.DESCRIPTION).doesNotExist();
   });
 
-  test("it shows a message if the module isn't available", async function (assert) {
-    this.isAvailable = false;
-
-    await render(hbs`
-      <LoketModuleCard
-        @isAvailable={{this.isAvailable}}
-      />
-    `);
-
-    assert.dom(LOKET_MODULE_CARD.NOT_AVAILABLE).exists();
-
-    this.set('isAvailable', true);
-    assert.dom(LOKET_MODULE_CARD.NOT_AVAILABLE).doesNotExist();
-  });
-
   test('it has a block to render the module link', async function (assert) {
     await render(hbs`
-      <LoketModuleCard
-        @isAvailable={{true}}
-      >
+      <LoketModuleCard>
         <:link>
           Foo
         </:link>
@@ -121,53 +103,5 @@ module('Integration | Component | loket-module-card', function (hooks) {
     assert
       .dom(LOKET_MODULE_CARD.USER_MANUAL_LINK)
       .hasAttribute('href', 'https://user-manual.test');
-  });
-
-  test("it doesn't show the link content if the module isn't available", async function (assert) {
-    this.isAvailable = true;
-
-    await render(hbs`
-      <LoketModuleCard
-        @isAvailable={{this.isAvailable}}
-        @extraInformationLink="https://extra-information.test"
-        @userManualLink="https://user-manual.test"
-      >
-        <:title>Foo</:title>
-        <:description>Bar</:description>
-        <:link>
-          Baz
-        </:link>
-      </LoketModuleCard>
-    `);
-
-    assert.dom(LOKET_MODULE_CARD.LINK).hasText('Baz');
-    assert.dom(LOKET_MODULE_CARD.TITLE).hasText('Foo');
-    assert.dom(LOKET_MODULE_CARD.DESCRIPTION).hasText('Bar');
-
-    this.set('isAvailable', false);
-    assert.dom(LOKET_MODULE_CARD.LINK).doesNotExist();
-
-    assert
-      .dom(LOKET_MODULE_CARD.TITLE)
-      .hasText('Foo', "it also shows the title if the module isn't available");
-
-    assert
-      .dom(LOKET_MODULE_CARD.DESCRIPTION)
-      .hasText(
-        'Bar',
-        "it also shows the description if the module isn't available"
-      );
-
-    assert
-      .dom(LOKET_MODULE_CARD.EXTRA_INFORMATION_LINK)
-      .exists(
-        "it also shows the extra information link if the module isn't available"
-      );
-
-    assert
-      .dom(LOKET_MODULE_CARD.USER_MANUAL_LINK)
-      .exists(
-        "it also shows the user manual link if the module isn't available"
-      );
   });
 });


### PR DESCRIPTION
DL-4376

- hiding all unavailable modules

- renaming the `eredienst mandatenbeheer` module to just `mandatenbeheer`.