### PR TITLE
Eredienst mandatenbeheer / bedienarenbeheer: Person creation prefill data

### DIFF
--- a/app/components/shared/persoon/create-persoon.js
+++ b/app/components/shared/persoon/create-persoon.js
@@ -18,10 +18,10 @@ export default class SharedPersoonCreatePersoonComponent extends Component {
   @service store;
 
   @tracked geslacht;
-  @tracked voornaam;
-  @tracked familienaam;
+  @tracked voornaam = this.args.prefilledValues.voornaam;
+  @tracked familienaam = this.args.prefilledValues.familienaam;
   @tracked roepnaam;
-  @tracked rijksregisternummer;
+  @tracked rijksregisternummer = this.args.prefilledValues.rijksregisternummer;
   @tracked nationaliteit;
   @tracked birthDate;
   @tracked errors;

--- a/app/components/shared/persoon/persoon-search-form.hbs
+++ b/app/components/shared/persoon/persoon-search-form.hbs
@@ -42,8 +42,11 @@
           @icon="search"
           @iconAlignment="left"
           @value={{this.identificator}}
+          @mask="99.99.99-999.99"
+          @maskPlaceholder="_"
+          @onChange={{(fn (mut this.identificator))}}
           id="mandataris-rijksregisternummer"
-          placeholder="Rijksregisternummer"
+          placeholder="00.00.00-000.00"
           {{on "input" (perform this.search)}}
         />
       </div>

--- a/app/components/shared/persoon/persoon-search-form.hbs
+++ b/app/components/shared/persoon/persoon-search-form.hbs
@@ -79,7 +79,7 @@
           <AuAlert @title="Komt het zoekresultaat niet overeen met wat u zocht?" @skin="info" @size="tiny" class="au-u-margin-top-small">
             <p>
               Kijk uw zoekopdracht na of
-              <AuButton @skin="tertiary" {{on 'click' @onCreateNewPerson}} class="au-c-link">
+              <AuButton @skin="tertiary" {{on 'click' (fn @onCreateNewPerson this.queryParams)}} class="au-c-link">
                 <AuIcon @icon="add" @alignment="left" />
                 voeg een nieuwe persoon toe
               </AuButton>.
@@ -89,7 +89,7 @@
           <AuAlert @title='"{{this.searchTerms}}" bestaat mogelijk nog niet.' @skin="info" @size="tiny">
             <p>
               Kijk uw zoekopdracht na of
-              <AuButton @skin="tertiary" {{on 'click' @onCreateNewPerson}} class="au-c-link">
+              <AuButton @skin="tertiary" {{on 'click' (fn @onCreateNewPerson this.queryParams)}} class="au-c-link">
                 <AuIcon @icon="add" @alignment="left" />
                 voeg een nieuwe persoon toe
               </AuButton>.
@@ -100,7 +100,7 @@
         <AuContent>
           <p class="au-c-text-info">
             Zoek een reeds gekende persoon in de databank van het loket op naam of op rijksregisternummer,<br>of
-            <AuButton @skin="tertiary" {{on 'click' @onCreateNewPerson}}>
+            <AuButton @skin="tertiary" {{on 'click' (fn @onCreateNewPerson this.queryParams)}}>
               <AuIcon @icon="add" @alignment="left" />
               voeg een nieuwe persoon toe
             </AuButton>.

--- a/app/controllers/eredienst-mandatenbeheer/new-person.js
+++ b/app/controllers/eredienst-mandatenbeheer/new-person.js
@@ -1,9 +1,23 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 
 export default class EredienstMandatenbeheerNewPersonController extends Controller {
   @service() router;
+
+  queryParams = ['firstName', 'lastName', 'rijksregisternummer'];
+  @tracked firstName = '';
+  @tracked lastName = '';
+  @tracked rijksregisternummer = '';
+
+  get personPrefilledValues() {
+    return {
+      voornaam: this.firstName,
+      familienaam: this.lastName,
+      rijksregisternummer: this.rijksregisternummer,
+    };
+  }
 
   @action
   onCreate(person) {

--- a/app/controllers/eredienst-mandatenbeheer/new.js
+++ b/app/controllers/eredienst-mandatenbeheer/new.js
@@ -23,8 +23,23 @@ export default class EredienstMandatenbeheerNewController extends Controller {
   }
 
   @action
-  createNewPerson() {
-    this.router.transitionTo('eredienst-mandatenbeheer.new-person');
+  createNewPerson(queryParams) {
+    if (queryParams.filter) {
+      const {
+        achternaam,
+        'gebruikte-voornaam': gebruikteVoornaam,
+        identificator,
+      } = queryParams.filter;
+      this.router.transitionTo('eredienst-mandatenbeheer.new-person', {
+        queryParams: {
+          firstName: gebruikteVoornaam,
+          lastName: achternaam,
+          rijksregisternummer: identificator,
+        },
+      });
+    } else {
+      this.router.transitionTo('eredienst-mandatenbeheer.new-person');
+    }
   }
 
   @action

--- a/app/controllers/worship-ministers-management/new-person.js
+++ b/app/controllers/worship-ministers-management/new-person.js
@@ -1,8 +1,22 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 export default class WorshipMinistersManagementNewPersonController extends Controller {
   @service() router;
+
+  queryParams = ['firstName', 'lastName', 'rijksregisternummer'];
+  @tracked firstName = '';
+  @tracked lastName = '';
+  @tracked rijksregisternummer = '';
+
+  get personPrefilledValues() {
+    return {
+      voornaam: this.firstName,
+      familienaam: this.lastName,
+      rijksregisternummer: this.rijksregisternummer,
+    };
+  }
 
   @action
   onCreate(person) {

--- a/app/controllers/worship-ministers-management/new.js
+++ b/app/controllers/worship-ministers-management/new.js
@@ -23,8 +23,23 @@ export default class WorshipMinistersManagementNewController extends Controller 
   }
 
   @action
-  createNewPerson() {
-    this.router.transitionTo('worship-ministers-management.new-person');
+  createNewPerson(queryParams) {
+    if (queryParams.filter) {
+      const {
+        achternaam,
+        'gebruikte-voornaam': gebruikteVoornaam,
+        identificator,
+      } = queryParams.filter;
+      this.router.transitionTo('eredienst-mandatenbeheer.new-person', {
+        queryParams: {
+          firstName: gebruikteVoornaam,
+          lastName: achternaam,
+          rijksregisternummer: identificator,
+        },
+      });
+    } else {
+      this.router.transitionTo('eredienst-mandatenbeheer.new-person');
+    }
   }
 
   @action

--- a/app/routes/eredienst-mandatenbeheer/new-person.js
+++ b/app/routes/eredienst-mandatenbeheer/new-person.js
@@ -1,3 +1,15 @@
 import Route from '@ember/routing/route';
 
-export default class EredienstMandatenbeheerNewPersonRoute extends Route {}
+export default class EredienstMandatenbeheerNewPersonRoute extends Route {
+  queryParams = {
+    firstName: {
+      refreshModel: true,
+    },
+    lastName: {
+      refreshModel: true,
+    },
+    rijksregisternummer: {
+      refreshModel: true,
+    },
+  };
+}

--- a/app/routes/worship-ministers-management/new-person.js
+++ b/app/routes/worship-ministers-management/new-person.js
@@ -1,3 +1,15 @@
 import Route from '@ember/routing/route';
 
-export default class WorshipMinistersManagementNewPersonRoute extends Route {}
+export default class WorshipMinistersManagementNewPersonRoute extends Route {
+  queryParams = {
+    firstName: {
+      refreshModel: true,
+    },
+    lastName: {
+      refreshModel: true,
+    },
+    rijksregisternummer: {
+      refreshModel: true,
+    },
+  };
+}

--- a/app/templates/eredienst-mandatenbeheer/new-person.hbs
+++ b/app/templates/eredienst-mandatenbeheer/new-person.hbs
@@ -5,6 +5,7 @@
 </AuToolbar>
 
 <Shared::Persoon::CreatePersoon
+  @prefilledValues={{this.personPrefilledValues}}
   @nationalityRequired={{true}}
   @geboorteRequired={{true}}
   @onCreate={{this.onCreate}}

--- a/app/templates/worship-ministers-management/new-person.hbs
+++ b/app/templates/worship-ministers-management/new-person.hbs
@@ -7,6 +7,7 @@
 </AuToolbar>
 
 <Shared::Persoon::CreatePersoon
+  @prefilledValues={{this.personPrefilledValues}}
   @nationalityRequired={{true}}
   @geboorteRequired={{true}}
   @onCreate={{this.onCreate}}


### PR DESCRIPTION
DL-4384

This prefill seach data from `/new` route in `/new-person` route for the following inputs : 
- first name
- last name
- rrn

The `rrn` input was also modified to be consistent with the `create-persoon` component.