### PR TITLE
[Bedienarenbeheer] bedienaar creation flow changes

### DIFF
--- a/app/components/contact-information-table.js
+++ b/app/components/contact-information-table.js
@@ -1,6 +1,30 @@
 import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
 
 export default class ContactInformationTableComponent extends Component {
+  @service router;
+  constructor() {
+    super(...arguments);
+    console.log('args', this.args);
+    console.log('selected contact', this.args.selectedContact);
+    console.log('contacts', this.args.contacts);
+    console.log(
+      'is selected',
+      this.args.contacts === this.args.selectedContact
+    );
+    // We check if there is a contact available for this person
+    // This is false on edit because the arg is unavailable
+    // We need to check only when not redirected to the edit page
+    if (
+      !this.args.hasContact &&
+      this.router.currentRouteName !==
+        'worship-ministers-management.minister.edit'
+    ) {
+      // If not contact we force the user to enter one
+      this.args.onAddNewContact();
+    }
+    // if there is an address we want to check it by default
+  }
   get isEditing() {
     return Boolean(this.args.editingContact);
   }

--- a/app/components/contact-information-table.js
+++ b/app/components/contact-information-table.js
@@ -5,25 +5,12 @@ export default class ContactInformationTableComponent extends Component {
   @service router;
   constructor() {
     super(...arguments);
-    console.log('args', this.args);
-    console.log('selected contact', this.args.selectedContact);
-    console.log('contacts', this.args.contacts);
-    console.log(
-      'is selected',
-      this.args.contacts === this.args.selectedContact
-    );
-    // We check if there is a contact available for this person
-    // This is false on edit because the arg is unavailable
-    // We need to check only when not redirected to the edit page
     if (
       !this.args.hasContact &&
-      this.router.currentRouteName !==
-        'worship-ministers-management.minister.edit'
+      !this.router.currentRouteName.includes('.edit')
     ) {
-      // If not contact we force the user to enter one
       this.args.onAddNewContact();
     }
-    // if there is an address we want to check it by default
   }
   get isEditing() {
     return Boolean(this.args.editingContact);

--- a/app/controllers/worship-ministers-management/new.js
+++ b/app/controllers/worship-ministers-management/new.js
@@ -3,6 +3,12 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { dropTask } from 'ember-concurrency';
+import {
+  createPrimaryContactPoint,
+  createSecondaryContactPoint,
+  findPrimaryContactPoint,
+  isValidPrimaryContact,
+} from 'frontend-loket/models/contact-punt';
 import { validateFunctie } from 'frontend-loket/models/minister';
 
 export default class WorshipMinistersManagementNewController extends Controller {
@@ -12,6 +18,21 @@ export default class WorshipMinistersManagementNewController extends Controller 
   queryParams = ['personId'];
 
   @tracked personId = '';
+  @tracked selectedContact;
+  @tracked editingContact;
+
+  originalContactAdres;
+
+  get hasContact() {
+    // console.log('model', this.model.contacts);
+    console.log('length', this.model?.contacts?.length);
+    console.log('hasContact', this.model?.contacts?.length !== 0);
+    return this.model?.contacts?.length !== 0;
+  }
+
+  get isEditingContactPoint() {
+    return Boolean(this.editingContact);
+  }
 
   get shouldSelectPerson() {
     return !this.model?.person;
@@ -60,18 +81,120 @@ export default class WorshipMinistersManagementNewController extends Controller 
     this.router.transitionTo('worship-ministers-management');
   }
 
+  @action
+  handleContactSelectionChange(contact, isSelected) {
+    if (isSelected) {
+      this.selectedContact = contact;
+    } else {
+      this.selectedContact = null;
+    }
+  }
+
+  @action
+  addNewContact() {
+    let primaryContactPoint = createPrimaryContactPoint(this.store);
+    let secondaryContactPoint = createSecondaryContactPoint(this.store);
+
+    primaryContactPoint.secondaryContactPoint = secondaryContactPoint;
+    this.editingContact = primaryContactPoint;
+  }
+
+  @action
+  async setEditingContact(contactPoint) {
+    let secondaryContactPoint = await contactPoint.secondaryContactPoint;
+
+    if (!secondaryContactPoint) {
+      secondaryContactPoint = createSecondaryContactPoint(this.store);
+
+      contactPoint.secondaryContactPoint = secondaryContactPoint;
+    }
+
+    this.originalContactAdres = await contactPoint.adres;
+    this.editingContact = contactPoint;
+  }
+
+  @action
+  async handleEditContactCancel() {
+    this.rollbackUnsavedContactChanges();
+  }
+
   @dropTask
   *createWorshipMinister(event) {
     event.preventDefault();
 
-    let { worshipMinister } = this.model;
+    let { worshipMinister, contacts } = this.model;
+    console.log('editing contact', this.isEditingContactPoint);
+    if (this.isEditingContactPoint) {
+      // This part might need some refactoring
+      if (!worshipMinister.agentStartDate) {
+        worshipMinister.errors.add(
+          'agentStartDate',
+          'startdatum is een vereist veld.'
+        );
+      }
+      yield validateFunctie(worshipMinister);
+      // refactoring part end
+      let contactPoint = this.editingContact;
+      console.log('contact point is new', contactPoint.isNew);
+      let secondaryContactPoint = yield contactPoint.secondaryContactPoint;
+      let adres = yield contactPoint.adres;
+
+      if (yield isValidPrimaryContact(contactPoint)) {
+        console.log('valid primary');
+        if (secondaryContactPoint.telefoon) {
+          yield secondaryContactPoint.save();
+        } else {
+          // The secondary contact point is empty so we can remove it if it was ever persisted before
+          yield secondaryContactPoint.destroyRecord();
+        }
+        if (adres?.isNew) {
+          yield adres.save();
+        }
+
+        if (contactPoint.isNew) {
+          // If we are adding a new contact point, it will always be the "selected" contact after it is saved
+          this.selectedContact = contactPoint;
+        }
+
+        // yield contactPoint.save();
+      } else {
+        return;
+      }
+    }
+
+    if (this.selectedContact) {
+      let primaryContactPoint = findPrimaryContactPoint(yield contacts);
+      console.log('selected contact', this.selectedContact.id);
+      // this pass the check but does not have any id
+      // So the filter is just returning false false
+      if (this.selectedContact.id !== primaryContactPoint?.id) {
+        console.log('test passed');
+        let secondaryContact = yield this.selectedContact.secondaryContactPoint;
+        console.log('secondaryContact', secondaryContact);
+        console.log('primary contact', this.selectedContact);
+
+        console.log(worshipMinister.contacts);
+        worshipMinister.contacts = [
+          this.selectedContact,
+          secondaryContact,
+        ].filter(Boolean);
+      }
+    } else {
+      console.log('no contacts');
+      worshipMinister.contacts = [];
+    }
     if (!worshipMinister.agentStartDate) {
       worshipMinister.errors.add(
         'agentStartDate',
         'startdatum is een vereist veld.'
       );
     }
-    if ((yield validateFunctie(worshipMinister)) && worshipMinister.isValid) {
+    if (
+      (yield validateFunctie(worshipMinister)) &&
+      worshipMinister.isValid &&
+      worshipMinister.contacts.length > 0
+    ) {
+      yield this.editingContact.save();
       yield worshipMinister.save();
       this.router.transitionTo(
         'worship-ministers-management.minister.edit',
@@ -79,6 +202,33 @@ export default class WorshipMinistersManagementNewController extends Controller 
       );
     } else {
       return;
+    }
+  }
+
+  rollbackUnsavedChanges() {
+    this.model?.worshipMinister?.rollbackAttributes();
+    this.rollbackUnsavedContactChanges();
+  }
+
+  async rollbackUnsavedContactChanges() {
+    if (this.isEditingContactPoint) {
+      let contactPoint = this.editingContact;
+      let secondaryContactPoint = await contactPoint.secondaryContactPoint;
+
+      let currentAdres = await contactPoint.adres;
+      if (currentAdres?.isNew) {
+        currentAdres.rollbackAttributes();
+      }
+
+      if (this.originalContactAdres) {
+        contactPoint.adres = this.originalContactAdres;
+        this.originalContactAdres = null;
+      }
+
+      secondaryContactPoint?.rollbackAttributes?.();
+      contactPoint.rollbackAttributes();
+
+      this.editingContact = null;
     }
   }
 }

--- a/app/routes/worship-ministers-management/new.js
+++ b/app/routes/worship-ministers-management/new.js
@@ -17,33 +17,26 @@ export default class WorshipMinisterManagementNewRoute extends Route {
 
   async model({ personId }) {
     if (personId) {
-      console.log('Router : step 3');
       let person = await this.store.findRecord('persoon', personId, {
         backgroundReload: false,
       });
 
       let worshipMinister = this.store.createRecord('minister');
       worshipMinister.person = person;
+
       let contacts = await this.store.query('contact-punt', {
         'filter[agents-in-position][person][:id:]': person.id,
         'filter[type]': CONTACT_TYPE.PRIMARY,
         include: 'adres,secondary-contact-point',
       });
+
       // Is there an other way to check without accessing private '.content' ?
-      if (contacts.content.length !== 0) {
+      if (contacts.content.length > 0) {
         // Pre-select existing contact for this person;
         worshipMinister.contacts = contacts;
+        let positionContacts = await worshipMinister.contacts;
+        this.selectedContact = findPrimaryContactPoint(positionContacts);
       }
-      console.log('Router : contacts is valid', contacts.isValid);
-      console.log('Router : contacts', contacts);
-
-      // Before model ?
-      let positionContacts = await worshipMinister.contacts; // useless since we create a new worship minister
-      console.log('Router : Position contacts', positionContacts);
-      // We create a positionContacts but empty since it's a new worship minister
-      this.selectedContact = findPrimaryContactPoint(positionContacts);
-
-      console.log('Router : findprimarycontact', this.selectedContact);
 
       return {
         worshipMinister,
@@ -52,7 +45,6 @@ export default class WorshipMinisterManagementNewRoute extends Route {
         contacts,
       };
     }
-    console.log('Router : step 1');
     return {};
   }
 

--- a/app/routes/worship-ministers-management/new.js
+++ b/app/routes/worship-ministers-management/new.js
@@ -1,5 +1,9 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import {
+  CONTACT_TYPE,
+  findPrimaryContactPoint,
+} from 'frontend-loket/models/contact-punt';
 
 export default class WorshipMinisterManagementNewRoute extends Route {
   @service currentSession;
@@ -13,25 +17,52 @@ export default class WorshipMinisterManagementNewRoute extends Route {
 
   async model({ personId }) {
     if (personId) {
+      console.log('step 3');
       let person = await this.store.findRecord('persoon', personId, {
         backgroundReload: false,
       });
 
       let worshipMinister = this.store.createRecord('minister');
       worshipMinister.person = person;
+      let contacts = await this.store.query('contact-punt', {
+        'filter[agents-in-position][person][:id:]': person.id,
+        'filter[type]': CONTACT_TYPE.PRIMARY,
+        include: 'adres,secondary-contact-point',
+      });
+
+      console.log('contacts', contacts);
+
+      // Before model ?
+      let positionContacts = await worshipMinister.contacts;
+      // We create a positionContacts but empty since it's a new worship minister
+      // When we found contacts for this person do we fill it ?
+      // if (worshipMinister.contacts.content) {
+      //   worshipMinister.contacts = contacts;
+      // }
+      this.selectedContact = findPrimaryContactPoint(positionContacts);
+
+      console.log('findprimarycontact', this.selectedContact);
 
       return {
         worshipMinister,
         currentWorshipService: this.currentSession.group,
         person,
+        contacts,
       };
     }
-
+    console.log('step 1');
     return {};
+  }
+
+  setupController(controller) {
+    super.setupController(...arguments);
+
+    controller.selectedContact = this.selectedContact;
   }
 
   resetController(controller, isExiting) {
     super.resetController(...arguments);
+    controller.rollbackUnsavedChanges();
 
     if (isExiting) {
       controller.personId = '';

--- a/app/routes/worship-ministers-management/new.js
+++ b/app/routes/worship-ministers-management/new.js
@@ -17,7 +17,7 @@ export default class WorshipMinisterManagementNewRoute extends Route {
 
   async model({ personId }) {
     if (personId) {
-      console.log('step 3');
+      console.log('Router : step 3');
       let person = await this.store.findRecord('persoon', personId, {
         backgroundReload: false,
       });
@@ -29,19 +29,21 @@ export default class WorshipMinisterManagementNewRoute extends Route {
         'filter[type]': CONTACT_TYPE.PRIMARY,
         include: 'adres,secondary-contact-point',
       });
-
-      console.log('contacts', contacts);
+      // Is there an other way to check without accessing private '.content' ?
+      if (contacts.content.length !== 0) {
+        // Pre-select existing contact for this person;
+        worshipMinister.contacts = contacts;
+      }
+      console.log('Router : contacts is valid', contacts.isValid);
+      console.log('Router : contacts', contacts);
 
       // Before model ?
-      let positionContacts = await worshipMinister.contacts;
+      let positionContacts = await worshipMinister.contacts; // useless since we create a new worship minister
+      console.log('Router : Position contacts', positionContacts);
       // We create a positionContacts but empty since it's a new worship minister
-      // When we found contacts for this person do we fill it ?
-      // if (worshipMinister.contacts.content) {
-      //   worshipMinister.contacts = contacts;
-      // }
       this.selectedContact = findPrimaryContactPoint(positionContacts);
 
-      console.log('findprimarycontact', this.selectedContact);
+      console.log('Router : findprimarycontact', this.selectedContact);
 
       return {
         worshipMinister,
@@ -50,7 +52,7 @@ export default class WorshipMinisterManagementNewRoute extends Route {
         contacts,
       };
     }
-    console.log('step 1');
+    console.log('Router : step 1');
     return {};
   }
 

--- a/app/templates/worship-ministers-management/new.hbs
+++ b/app/templates/worship-ministers-management/new.hbs
@@ -46,7 +46,7 @@
 {{else}}
   <form
     id="create-worship-minister"
-    class="au-c-body-container"
+    class="au-c-body-container--scroll"
     {{on "submit" (perform this.createWorshipMinister)}}
   >
     <div class="au-u-2-3@medium au-o-box">
@@ -120,11 +120,33 @@
         </div>
       </div>
 
-      <AuAlert @skin="info" @icon="info-circle" @size="small">
-        <p>
-          Klik op "Bedienaar toevoegen" om contactgegevens verder aan te vullen.
-        </p>
-      </AuAlert>
     </div>
+    <AuHr @size="small" />
+      <div class="au-o-box">
+        <ContactInformationTable
+          @contacts={{@model.contacts}}
+          @selectedContact={{this.selectedContact}}
+          @editingContact={{this.editingContact}}
+          @onAddNewContact={{this.addNewContact}}
+          @onEditContact={{this.setEditingContact}}
+          @onEditContactCancel={{this.handleEditContactCancel}}
+          @onContactSelectionChange={{this.handleContactSelectionChange}}
+          @hasContact={{this.hasContact}}
+        />
+        {{#if (and this.isEditingContactPoint (not this.editingContact.isValid))}}
+          <AuAlert
+            @title={{this.title}}
+            @skin="error"
+            @icon="cross"
+            @size="small"
+            class="au-u-margin-top-small"
+          >
+            <p>
+              Gelieve de velden "Adres", "E-mail" en "Primair telefoonnummer" in te
+              vullen.
+            </p>
+          </AuAlert>
+        {{/if}}
+      </div>
   </form>
 {{/if}}


### PR DESCRIPTION
DL-4382

This changes the flow of creation for a new worship minister.

Component `contact-information-table` is now in the `new.hbs` of `worship-ministers-management` as it's required for the user to fill the following contact information (**Adres**, **E-mail**, **Primair telefonnummer**).

Adding a new behavior for the component. 

When creating or selecting a person, if the person does not own a contact information the `contact-information-table` is in edit mode so the user can enter his contact information without clicking on `Contactgegevens toevoegen`.

For the case where the person already own a contact information it does pre-select the contact from his previous position.