### PR TITLE
[Bedienarenbeheer] Show an error message if no contact info is provided when creating or editing position

### DIFF
--- a/app/controllers/worship-ministers-management/minister/edit.js
+++ b/app/controllers/worship-ministers-management/minister/edit.js
@@ -51,6 +51,7 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
   @action
   handleContactSelectionChange(contact, isSelected) {
     if (isSelected) {
+      this.model.minister.errors.remove('contacts');
       this.selectedContact = contact;
     } else {
       this.selectedContact = null;
@@ -59,6 +60,8 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
 
   @action
   addNewContact() {
+    this.model.minister.errors.remove('contacts');
+
     let primaryContactPoint = createPrimaryContactPoint(this.store);
     let secondaryContactPoint = createSecondaryContactPoint(this.store);
 
@@ -88,6 +91,7 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
   @dropTask
   *save() {
     let { minister, contacts } = this.model;
+    minister.errors.remove('contacts');
 
     if (!minister.agentStartDate) {
       minister.errors.add('agentStartDate', 'startdatum is een vereist veld.');
@@ -96,8 +100,6 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
     yield validateFunctie(minister);
 
     if (this.isEditingContactPoint) {
-      minister.errors.remove('contacts');
-
       let contactPoint = this.editingContact;
       let secondaryContactPoint = yield contactPoint.secondaryContactPoint;
       let adres = yield contactPoint.adres;
@@ -122,23 +124,9 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
       } else {
         return;
       }
-    } else if (contacts.length === 0) {
-      // TODO: This works around a problem in Ember Data where adding an error without the record being in a dirty state triggers an exception.
-      // Ember Data doesn't consider relationship changes a "dirty" change, so this causes issues if the adres is cleared.
-      // This workaround uses `.send` but that is a private API which is no longer present in Ember Data 4.x
-      // The bug is fixed in Ember Data 4.6 so we need to update to that version instead of 4.4 LTS
-      // More information in the Discord: https://discord.com/channels/480462759797063690/1016327513900847134
-      // Same old issue where they use this workaround: https://stackoverflow.com/questions/27698496/attempted-to-handle-event-becameinvalid-while-in-state-root-loaded-saved
-      minister.send?.('becomeDirty');
-      minister.errors.add(
-        'contacts',
-        'Klik op "Contactgegevens toevoegen" om contactgegevens in te vullen'
-      );
     }
 
     if (this.selectedContact) {
-      minister.errors.remove('contacts');
-
       let primaryContactPoint = findPrimaryContactPoint(
         yield minister.contacts
       );
@@ -150,7 +138,7 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
           Boolean
         );
       }
-    } else if (contacts.length > 0) {
+    } else {
       // TODO: This works around a problem in Ember Data where adding an error without the record being in a dirty state triggers an exception.
       // Ember Data doesn't consider relationship changes a "dirty" change, so this causes issues if the adres is cleared.
       // This workaround uses `.send` but that is a private API which is no longer present in Ember Data 4.x
@@ -160,10 +148,12 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
       minister.send?.('becomeDirty');
       minister.errors.add(
         'contacts',
-        'Selecteer een van de bestaande contactgegevens.'
+        `Klik op "Contactgegevens toevoegen" om contactgegevens in te vullen${
+          contacts.length > 0
+            ? ' of selecteer een van de bestaande contactgegevens.'
+            : '.'
+        }`
       );
-      return;
-    } else {
       return;
     }
 

--- a/app/controllers/worship-ministers-management/new.js
+++ b/app/controllers/worship-ministers-management/new.js
@@ -80,6 +80,7 @@ export default class WorshipMinistersManagementNewController extends Controller 
   @action
   handleContactSelectionChange(contact, isSelected) {
     if (isSelected) {
+      this.model.worshipMinister.errors.remove('contacts');
       this.selectedContact = contact;
     } else {
       this.selectedContact = null;
@@ -88,6 +89,8 @@ export default class WorshipMinistersManagementNewController extends Controller 
 
   @action
   addNewContact() {
+    this.model.worshipMinister.errors.remove('contacts');
+
     let primaryContactPoint = createPrimaryContactPoint(this.store);
     let secondaryContactPoint = createSecondaryContactPoint(this.store);
 
@@ -119,6 +122,7 @@ export default class WorshipMinistersManagementNewController extends Controller 
     event.preventDefault();
 
     let { worshipMinister, contacts } = this.model;
+    worshipMinister.errors.remove('contacts');
 
     // validate the minister record
     if (!worshipMinister.agentStartDate) {
@@ -132,8 +136,6 @@ export default class WorshipMinistersManagementNewController extends Controller 
     // validate the worship minister contacts which has 2 valid branches:
     // the user is editing a new contact:
     if (this.isEditingContactPoint) {
-      worshipMinister.errors.remove('contacts');
-
       let contactPoint = this.editingContact;
       let secondaryContactPoint = yield contactPoint.secondaryContactPoint;
       let adres = yield contactPoint.adres;
@@ -158,27 +160,24 @@ export default class WorshipMinistersManagementNewController extends Controller 
       } else {
         return;
       }
-    } else if (contacts.length === 0) {
-      worshipMinister.errors.add(
-        'contacts',
-        'Klik op "Contactgegevens toevoegen" om contactgegevens in te vullen'
-      );
     }
 
     // the user has selected an already existing contact pair
     if (this.selectedContact) {
-      worshipMinister.errors.remove('contacts');
       let secondaryContact = yield this.selectedContact.secondaryContactPoint;
       worshipMinister.contacts = [
         this.selectedContact,
         secondaryContact,
       ].filter(Boolean);
-    } else if (contacts.length > 0) {
+    } else {
       worshipMinister.errors.add(
         'contacts',
-        'Selecteer een van de bestaande contactgegevens.'
+        `Klik op "Contactgegevens toevoegen" om contactgegevens in te vullen${
+          contacts.length > 0
+            ? ' of selecteer een van de bestaande contactgegevens.'
+            : '.'
+        }`
       );
-    } else {
       return;
     }
 

--- a/app/controllers/worship-ministers-management/new.js
+++ b/app/controllers/worship-ministers-management/new.js
@@ -118,7 +118,7 @@ export default class WorshipMinistersManagementNewController extends Controller 
   *createWorshipMinister(event) {
     event.preventDefault();
 
-    let { worshipMinister } = this.model;
+    let { worshipMinister, contacts } = this.model;
 
     // validate the minister record
     if (!worshipMinister.agentStartDate) {
@@ -132,6 +132,8 @@ export default class WorshipMinistersManagementNewController extends Controller 
     // validate the worship minister contacts which has 2 valid branches:
     // the user is editing a new contact:
     if (this.isEditingContactPoint) {
+      worshipMinister.errors.remove('contacts');
+
       let contactPoint = this.editingContact;
       let secondaryContactPoint = yield contactPoint.secondaryContactPoint;
       let adres = yield contactPoint.adres;
@@ -156,15 +158,26 @@ export default class WorshipMinistersManagementNewController extends Controller 
       } else {
         return;
       }
+    } else if (contacts.length === 0) {
+      worshipMinister.errors.add(
+        'contacts',
+        'Klik op "Contactgegevens toevoegen" om contactgegevens in te vullen'
+      );
     }
 
     // the user has selected an already existing contact pair
     if (this.selectedContact) {
+      worshipMinister.errors.remove('contacts');
       let secondaryContact = yield this.selectedContact.secondaryContactPoint;
       worshipMinister.contacts = [
         this.selectedContact,
         secondaryContact,
       ].filter(Boolean);
+    } else if (contacts.length > 0) {
+      worshipMinister.errors.add(
+        'contacts',
+        'Selecteer een van de bestaande contactgegevens.'
+      );
     } else {
       return;
     }

--- a/app/templates/worship-ministers-management/minister/edit.hbs
+++ b/app/templates/worship-ministers-management/minister/edit.hbs
@@ -141,19 +141,22 @@
         </p>
       </AuAlert>
     {{/if}}
-    {{#let (if this.selectedContact true false) as |isSelected|}}
-      {{#unless (or this.isEditingContactPoint isSelected)}}
-        <AuAlert
-          @skin="error"
-          @icon="cross"
-          @size="small"
-          class="au-u-margin-top-small"
-        >
-          <p>
-            Contactgegevens zijn verplicht. Klik op "Contactgegevens" om contactgegevens in te vullen of selecteer een bestaande contactgegevens.
-          </p>
-        </AuAlert>
-      {{/unless}}
-      {{/let}}
+    {{#let (if @model.minister.errors.contacts true false) as |hasErrors|}}
+    {{#if hasErrors}}
+      <AuAlert
+        @skin="error"
+        @icon="cross"
+        @size="small"
+        class="au-u-margin-top-small"
+      >
+        <p>
+          Contactgegevens zijn verplicht.
+          {{#each @model.minister.errors.contacts as |error|}}
+            {{error.message}}
+          {{/each}}
+        </p>
+      </AuAlert>
+    {{/if}}
+    {{/let}}
   </div>
 </AuBodyContainer>

--- a/app/templates/worship-ministers-management/minister/edit.hbs
+++ b/app/templates/worship-ministers-management/minister/edit.hbs
@@ -141,5 +141,19 @@
         </p>
       </AuAlert>
     {{/if}}
+    {{#let (if this.selectedContact true false) as |isSelected|}}
+      {{#unless (or this.isEditingContactPoint isSelected)}}
+        <AuAlert
+          @skin="error"
+          @icon="cross"
+          @size="small"
+          class="au-u-margin-top-small"
+        >
+          <p>
+            Contactgegevens zijn verplicht. Klik op "Contactgegevens" om contactgegevens in te vullen of selecteer een bestaande contactgegevens.
+          </p>
+        </AuAlert>
+      {{/unless}}
+      {{/let}}
   </div>
 </AuBodyContainer>

--- a/app/templates/worship-ministers-management/new.hbs
+++ b/app/templates/worship-ministers-management/new.hbs
@@ -147,6 +147,20 @@
           </p>
         </AuAlert>
       {{/if}}
+      {{#let (if this.selectedContact true false) as |isSelected|}}
+      {{#unless (or this.isEditingContactPoint isSelected)}}
+        <AuAlert
+          @skin="error"
+          @icon="cross"
+          @size="small"
+          class="au-u-margin-top-small"
+        >
+          <p>
+            Contactgegevens zijn verplicht. Klik op "Contactgegevens" om contactgegevens in te vullen of selecteer een bestaande contactgegevens.
+          </p>
+        </AuAlert>
+      {{/unless}}
+      {{/let}}
     </div>
   </form>
 {{/if}}

--- a/app/templates/worship-ministers-management/new.hbs
+++ b/app/templates/worship-ministers-management/new.hbs
@@ -147,8 +147,8 @@
           </p>
         </AuAlert>
       {{/if}}
-      {{#let (if this.selectedContact true false) as |isSelected|}}
-      {{#unless (or this.isEditingContactPoint isSelected)}}
+      {{#let (if @model.worshipMinister.errors.contacts true false) as |hasErrors|}}
+      {{#if hasErrors}}
         <AuAlert
           @skin="error"
           @icon="cross"
@@ -156,11 +156,14 @@
           class="au-u-margin-top-small"
         >
           <p>
-            Contactgegevens zijn verplicht. Klik op "Contactgegevens" om contactgegevens in te vullen of selecteer een bestaande contactgegevens.
+            Contactgegevens zijn verplicht.
+            {{#each @model.worshipMinister.errors.contacts as |error|}}
+              {{error.message}}
+            {{/each}}
           </p>
         </AuAlert>
-      {{/unless}}
-      {{/let}}
+        {{/if}}
+        {{/let}}
     </div>
   </form>
 {{/if}}


### PR DESCRIPTION
DL-4463

This shows an error message when the required contact information is missing or unselected.