### PR TITLE
[Eredienst mandatenbeheer] mandate creation flow changes

### DIFF
--- a/app/controllers/eredienst-mandatenbeheer/new.js
+++ b/app/controllers/eredienst-mandatenbeheer/new.js
@@ -3,6 +3,11 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { dropTask } from 'ember-concurrency';
+import {
+  createPrimaryContactPoint,
+  createSecondaryContactPoint,
+  isValidPrimaryContact,
+} from 'frontend-loket/models/contact-punt';
 import { validateMandaat } from 'frontend-loket/models/worship-mandatee';
 import { setExpectedEndDate } from 'frontend-loket/utils/eredienst-mandatenbeheer';
 
@@ -12,6 +17,18 @@ export default class EredienstMandatenbeheerNewController extends Controller {
 
   queryParams = ['personId'];
   @tracked personId = '';
+  @tracked selectedContact;
+  @tracked editingContact;
+
+  originalContactAdres;
+
+  get hasContact() {
+    return this.model?.contacts?.length > 0;
+  }
+
+  get isEditingContactPoint() {
+    return Boolean(this.editingContact);
+  }
 
   get shouldSelectPerson() {
     return !this.model?.person;
@@ -61,22 +78,145 @@ export default class EredienstMandatenbeheerNewController extends Controller {
     }
   }
 
+  @action
+  handleContactSelectionChange(contact, isSelected) {
+    if (isSelected) {
+      this.selectedContact = contact;
+    } else {
+      this.selectedContact = null;
+    }
+  }
+
+  @action
+  addNewContact() {
+    let primaryContactPoint = createPrimaryContactPoint(this.store);
+    let secondaryContactPoint = createSecondaryContactPoint(this.store);
+
+    primaryContactPoint.secondaryContactPoint = secondaryContactPoint;
+    this.editingContact = primaryContactPoint;
+  }
+
+  @action
+  async setEditingContact(contactPoint) {
+    let secondaryContactPoint = await contactPoint.secondaryContactPoint;
+
+    if (!secondaryContactPoint) {
+      secondaryContactPoint = createSecondaryContactPoint(this.store);
+
+      contactPoint.secondaryContactPoint = secondaryContactPoint;
+    }
+
+    this.originalContactAdres = await contactPoint.adres;
+    this.editingContact = contactPoint;
+  }
+
+  @action
+  async handleEditContactCancel() {
+    this.rollbackUnsavedContactChanges();
+  }
+
   @dropTask
   *createMandatee(event) {
     event.preventDefault();
 
     let { worshipMandatee } = this.model;
+
     if (!worshipMandatee.start) {
       worshipMandatee.errors.add('start', 'startdatum is een vereist veld.');
     }
-    if ((yield validateMandaat(worshipMandatee)) && worshipMandatee.isValid) {
-      yield worshipMandatee.save();
-      this.router.transitionTo(
-        'eredienst-mandatenbeheer.mandataris.edit',
-        worshipMandatee.id
-      );
+    yield validateMandaat(worshipMandatee);
+
+    if (this.isEditingContactPoint) {
+      let contactPoint = this.editingContact;
+      let secondaryContactPoint = yield contactPoint.secondaryContactPoint;
+      let adres = yield contactPoint.adres;
+
+      if (
+        (yield isValidPrimaryContact(contactPoint)) &&
+        worshipMandatee.isValid
+      ) {
+        if (adres?.isNew) {
+          yield adres.save();
+        }
+
+        if (contactPoint.isNew) {
+          // If we are adding a new contact point, it will always be the "selected" contact after it is saved
+          this.selectedContact = contactPoint;
+        }
+
+        if (secondaryContactPoint.telefoon) {
+          yield secondaryContactPoint.save();
+        }
+      } else {
+        return;
+      }
+    }
+
+    if (this.selectedContact) {
+      let secondaryContact = yield this.selectedContact.secondaryContactPoint;
+
+      worshipMandatee.contacts = [
+        this.selectedContact,
+        secondaryContact,
+      ].filter(Boolean);
     } else {
       return;
+    }
+
+    if (
+      worshipMandatee.isValid &&
+      worshipMandatee.contacts.length > 0 &&
+      this.selectedContact.isValid
+    ) {
+      let secondaryContactPoint = yield this.selectedContact
+        .secondaryContactPoint;
+      if (secondaryContactPoint !== null) {
+        if (!secondaryContactPoint.telefoon) {
+          // The secondary contact point is empty so we can remove it if it was ever persisted before
+          yield secondaryContactPoint.destroyRecord();
+        }
+      }
+
+      yield this.selectedContact.save();
+      yield worshipMandatee.save();
+
+      try {
+        yield this.router.transitionTo(
+          'eredienst-mandatenbeheer.mandatarissen'
+        );
+      } catch (error) {
+        // I believe we're running into this issue: https://github.com/emberjs/ember.js/issues/20038
+        // A `TransitionAborted` error is thrown even though the transition is complete, so we hide the error.
+      }
+    } else {
+      return;
+    }
+  }
+
+  rollbackUnsavedChanges() {
+    this.model?.worshipMandatee?.rollbackAttributes();
+    this.rollbackUnsavedContactChanges();
+  }
+
+  async rollbackUnsavedContactChanges() {
+    if (this.isEditingContactPoint) {
+      let contactPoint = this.editingContact;
+      let secondaryContactPoint = await contactPoint.secondaryContactPoint;
+
+      let currentAdres = await contactPoint.adres;
+      if (currentAdres?.isNew) {
+        currentAdres.rollbackAttributes();
+      }
+
+      if (this.originalContactAdres) {
+        contactPoint.adres = this.originalContactAdres;
+        this.originalContactAdres = null;
+      }
+
+      secondaryContactPoint?.rollbackAttributes?.();
+      contactPoint.rollbackAttributes();
+
+      this.editingContact = null;
     }
   }
 }

--- a/app/templates/eredienst-mandatenbeheer/new.hbs
+++ b/app/templates/eredienst-mandatenbeheer/new.hbs
@@ -53,7 +53,7 @@
 {{else}}
   <form
     id="create-mandatee"
-    class="au-c-body-container"
+    class="au-c-body-container--scroll"
     {{on "submit" (perform this.createMandatee)}}
   >
     <div class="au-u-2-3@medium au-o-box">
@@ -136,12 +136,33 @@
           />
         </div>
         {{/if}}
+    </div>
 
-      <AuAlert @skin="info" @icon="info-circle" @size="small">
-        <p>
-          Klik op "Mandaat toevoegen" om contactgegevens verder aan te vullen.
-        </p>
-      </AuAlert>
+    <AuHr @size="small" />
+    <div class="au-o-box">
+      <ContactInformationTable
+        @contacts={{@model.contacts}}
+        @selectedContact={{this.selectedContact}}
+        @editingContact={{this.editingContact}}
+        @onAddNewContact={{this.addNewContact}}
+        @onEditContact={{this.setEditingContact}}
+        @onEditContactCancel={{this.handleEditContactCancel}}
+        @onContactSelectionChange={{this.handleContactSelectionChange}}
+        @isRequired={{true}}
+      />
+      {{#if (and this.isEditingContactPoint (not this.editingContact.isValid))}}
+        <AuAlert
+          @skin="error"
+          @icon="cross"
+          @size="small"
+          class="au-u-margin-top-small"
+        >
+          <p>
+            Gelieve de velden "Adres", "E-mail" en "Primair telefoonnummer" in te
+            vullen.
+          </p>
+        </AuAlert>
+      {{/if}}
     </div>
   </form>
 {{/if}}


### PR DESCRIPTION
DL-4381

This changes the flow of creation for a new worship mandatee. 

Component `contact-information-table` is now in the new.hbs of worship-ministers-management as it's required for the user to fill the following contact information (**Adres, E-mail, Primair telefoonnummer**).

Adding a new behavior for the component.

When creating or selecting a person, if the person does not own a contact information the `contact-information-table` is in edit mode so the user can enter his contact information without clicking on `Contactgegevens toevoegen`.

For the case where the person already own a contact information it does pre-select the contact from his previous mandatee position.