### PR TITLE
[Eredienst mandatenbeheer] mandate edition flow changes

### DIFF
--- a/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
+++ b/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
@@ -87,12 +87,18 @@ export default class EredienstMandatenbeheerMandatarisEditController extends Con
 
   @dropTask
   *save() {
+    if (!this.model.start) {
+      this.model.errors.add('start', 'startdatum is een vereist veld.');
+    }
+
+    yield validateMandaat(this.model);
+
     if (this.isEditingContactPoint) {
       let contactPoint = this.editingContact;
       let secondaryContactPoint = yield contactPoint.secondaryContactPoint;
       let adres = yield contactPoint.adres;
 
-      if (yield isValidPrimaryContact(contactPoint)) {
+      if ((yield isValidPrimaryContact(contactPoint)) && this.model.isValid) {
         if (secondaryContactPoint.telefoon) {
           yield secondaryContactPoint.save();
         } else {
@@ -128,12 +134,14 @@ export default class EredienstMandatenbeheerMandatarisEditController extends Con
         );
       }
     } else {
-      this.model.contacts = [];
+      return;
     }
-    if (!this.model.start) {
-      this.model.errors.add('start', 'startdatum is een vereist veld.');
-    }
-    if ((yield validateMandaat(this.model)) && this.model.isValid) {
+
+    if (
+      this.selectedContact.isValid &&
+      this.model.contacts.length > 0 &&
+      this.model.isValid
+    ) {
       yield this.model.save();
 
       try {

--- a/app/templates/eredienst-mandatenbeheer/mandataris/edit.hbs
+++ b/app/templates/eredienst-mandatenbeheer/mandataris/edit.hbs
@@ -126,11 +126,11 @@
       @onEditContact={{this.setEditingContact}}
       @onEditContactCancel={{this.handleEditContactCancel}}
       @onContactSelectionChange={{this.handleContactSelectionChange}}
+      @isRequired={{true}}
     />
 
     {{#if (and this.editingContact (not this.editingContact.isValid))}}
       <AuAlert
-        @title={{this.title}}
         @skin="error"
         @icon="cross"
         @size="small"


### PR DESCRIPTION
DL-4494

This prevents the form to be saved when the contact point is unselected, also the contact form is required.
`worship-mandatee` contacts relationship can't be empty & `worship-mandatee` must be valid to save a contact point.