### PR TITLE
Update to Appuniversum v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.69.1",
       "license": "MIT",
       "devDependencies": {
-        "@appuniversum/ember-appuniversum": "^1.10.0",
+        "@appuniversum/ember-appuniversum": "^2.0.0",
         "@codemirror/basic-setup": "^0.20.0",
         "@codemirror/lang-html": "^6.0.0",
         "@codemirror/lang-xml": "^6.0.0",
@@ -20,7 +20,7 @@
         "@lblod/ember-acmidm-login": "^1.4.0",
         "@lblod/ember-mock-login": "^0.7.0",
         "@lblod/ember-rdfa-editor": "^0.63.4",
-        "@lblod/ember-submission-form-fields": "^2.2.0",
+        "@lblod/ember-submission-form-fields": "^2.3.0",
         "@lblod/submission-form-helpers": "^2.1.0",
         "babel-eslint": "^10.1.0",
         "broccoli-asset-rev": "^3.0.0",
@@ -116,22 +116,22 @@
       }
     },
     "node_modules/@appuniversum/ember-appuniversum": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-1.10.0.tgz",
-      "integrity": "sha512-f0qPB4mv2NF0g2aIF6+cVNJA6/jAPpR9K92ctfVbDd3gEMONLgg08jG4di7Qwftvfaxei4g8w4FO5eiYAxH66g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-2.0.0.tgz",
+      "integrity": "sha512-1vg8b0+W5/VH9VpsC/LUiKE8DoZ1Ou5ck1VTJrwbfWBq/Ew8PJneWbRDBfULrxoXI3R7aJJdkk2qbpPVUej3WQ==",
       "dev": true,
       "dependencies": {
         "@duetds/date-picker": "^1.4.0",
         "@embroider/macros": "^1.9.0",
-        "@glimmer/component": "^1.1.1",
-        "@glimmer/tracking": "^1.1.1",
+        "@glimmer/component": "^1.1.2",
+        "@glimmer/tracking": "^1.1.2",
         "@zestia/ember-auto-focus": "^4.2.0",
         "date-fns": "^2.28.0",
         "ember-auto-import": "^2.4.1",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-htmlbars": "^6.0.1",
         "ember-data-table": "^2.1.0",
-        "ember-file-upload": "^4.0.1",
+        "ember-file-upload": "^7.0.3",
         "ember-focus-trap": "^1.0.1",
         "ember-inputmask5": "^4.0.2",
         "ember-modifier": "^3.2.7",
@@ -140,7 +140,7 @@
         "tracked-toolbox": "^1.2.3"
       },
       "engines": {
-        "node": "12.* || 14.* || >= 16"
+        "node": "14.* || >= 16"
       },
       "optionalDependencies": {
         "ember-concurrency": "2.x",
@@ -5449,9 +5449,9 @@
       }
     },
     "node_modules/@lblod/ember-submission-form-fields": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.2.0.tgz",
-      "integrity": "sha512-4TGyqdw3lWm9kPXRiG9fB7Yoytb7IlywZ0YorFUwWLb9Gi+Dt+J2jh8kIX9RxNrbqHHHUF2IVWMsFjvdYIz2Xw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.3.0.tgz",
+      "integrity": "sha512-QjE5oDPFvLKXSYtnvgJUV8jWYZ8LWVagWBOKMmb4VL9g4TI4fs+kJLuXCQCfN+5gqBja9m8T26kDCtfDthUIaA==",
       "dev": true,
       "dependencies": {
         "@lblod/submission-form-helpers": "^2.0.1",
@@ -5470,7 +5470,7 @@
         "node": "14.* || >= 16"
       },
       "peerDependencies": {
-        "@appuniversum/ember-appuniversum": "^1.0.9",
+        "@appuniversum/ember-appuniversum": "^1.10.0 || ^2.0.0",
         "ember-data": "^3.16.0 || ^4.0.0",
         "ember-power-select": "^4.0.0 || ^5.0.0 || ^6.0.0"
       }
@@ -18303,238 +18303,35 @@
       }
     },
     "node_modules/ember-file-upload": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ember-file-upload/-/ember-file-upload-4.0.3.tgz",
-      "integrity": "sha512-7IDNGolb9GkcIkQh0W30tL03v+1aOvJkCJ+kRm+0AZ0IbvkZD5T/v9jFwGDRchsMp/C3E8LqN3q8PkGi4BapYw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ember-file-upload/-/ember-file-upload-7.1.0.tgz",
+      "integrity": "sha512-6bfRfjWqdHceNoxAY4PIKV5UQnn3GOi4p6Lq5QNAzPJ3MVNRNUqLevIg2VNXjipfnYz0iftGb6V7VP8CiTD18w==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.13.15",
-        "ember-cli-babel": "^7.26.3",
-        "ember-cli-htmlbars": "^5.7.1"
+        "@ember/test-helpers": "^2.4.2",
+        "@ember/test-waiters": "^3.0.0",
+        "@embroider/addon-shim": "^1.5.0",
+        "@embroider/macros": "^1.0.0",
+        "@glimmer/component": "^1.0.4",
+        "@glimmer/tracking": "^1.0.4",
+        "ember-auto-import": "^2.0.0",
+        "ember-modifier": "^3.2.7",
+        "tracked-built-ins": "^3.0.0"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
-      }
-    },
-    "node_modules/ember-file-upload/node_modules/async-disk-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "heimdalljs": "^0.2.3",
-        "istextorbinary": "^2.5.1",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^3.0.0",
-        "rsvp": "^4.8.5",
-        "username-sync": "^1.0.2"
+        "node": "14.* || 16.* || >= 18"
       },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-file-upload/node_modules/broccoli-persistent-filter": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
-      "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
-      "dev": true,
-      "dependencies": {
-        "async-disk-cache": "^2.0.0",
-        "async-promise-queue": "^1.0.3",
-        "broccoli-plugin": "^4.0.3",
-        "fs-tree-diff": "^2.0.0",
-        "hash-for-dep": "^1.5.0",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "promise-map-series": "^0.2.1",
-        "rimraf": "^3.0.0",
-        "symlink-or-copy": "^1.0.1",
-        "sync-disk-cache": "^2.0.0"
+      "peerDependencies": {
+        "ember-cli-mirage": "*",
+        "miragejs": "*"
       },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-file-upload/node_modules/broccoli-plugin": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-      "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-node-api": "^1.7.0",
-        "broccoli-output-wrapper": "^3.2.5",
-        "fs-merger": "^3.2.1",
-        "promise-map-series": "^0.3.0",
-        "quick-temp": "^0.1.8",
-        "rimraf": "^3.0.2",
-        "symlink-or-copy": "^1.3.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-file-upload/node_modules/broccoli-plugin/node_modules/promise-map-series": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-      "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-      "dev": true,
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-file-upload/node_modules/editions": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-      "dev": true,
-      "dependencies": {
-        "errlop": "^2.0.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/ember-file-upload/node_modules/editions/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/ember-file-upload/node_modules/ember-cli-htmlbars": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-      "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-      "dev": true,
-      "dependencies": {
-        "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-        "broccoli-debug": "^0.6.5",
-        "broccoli-persistent-filter": "^3.1.2",
-        "broccoli-plugin": "^4.0.3",
-        "common-tags": "^1.8.0",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-version-checker": "^5.1.2",
-        "fs-tree-diff": "^2.0.1",
-        "hash-for-dep": "^1.5.1",
-        "heimdalljs-logger": "^0.1.10",
-        "json-stable-stringify": "^1.0.1",
-        "semver": "^7.3.4",
-        "silent-error": "^1.1.1",
-        "strip-bom": "^4.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-file-upload/node_modules/fs-tree-diff": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-      "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-      "dev": true,
-      "dependencies": {
-        "@types/symlink-or-copy": "^1.2.0",
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-file-upload/node_modules/istextorbinary": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-      "dev": true,
-      "dependencies": {
-        "binaryextensions": "^2.1.2",
-        "editions": "^2.2.0",
-        "textextensions": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/ember-file-upload/node_modules/minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/ember-file-upload/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/ember-file-upload/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/ember-file-upload/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-file-upload/node_modules/strip-bom": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ember-file-upload/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
+      "peerDependenciesMeta": {
+        "ember-cli-mirage": {
+          "optional": true
+        },
+        "miragejs": {
+          "optional": true
+        }
       }
     },
     "node_modules/ember-focus-trap": {
@@ -39318,15 +39115,15 @@
       }
     },
     "@appuniversum/ember-appuniversum": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-1.10.0.tgz",
-      "integrity": "sha512-f0qPB4mv2NF0g2aIF6+cVNJA6/jAPpR9K92ctfVbDd3gEMONLgg08jG4di7Qwftvfaxei4g8w4FO5eiYAxH66g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-2.0.0.tgz",
+      "integrity": "sha512-1vg8b0+W5/VH9VpsC/LUiKE8DoZ1Ou5ck1VTJrwbfWBq/Ew8PJneWbRDBfULrxoXI3R7aJJdkk2qbpPVUej3WQ==",
       "dev": true,
       "requires": {
         "@duetds/date-picker": "^1.4.0",
         "@embroider/macros": "^1.0.0",
-        "@glimmer/component": "^1.1.1",
-        "@glimmer/tracking": "^1.1.1",
+        "@glimmer/component": "^1.1.2",
+        "@glimmer/tracking": "^1.1.2",
         "@zestia/ember-auto-focus": "^4.2.0",
         "date-fns": "^2.28.0",
         "ember-auto-import": "^2.4.1",
@@ -39334,7 +39131,7 @@
         "ember-cli-htmlbars": "^6.0.1",
         "ember-concurrency": "2.x",
         "ember-data-table": "^2.1.0",
-        "ember-file-upload": "^4.0.1",
+        "ember-file-upload": "^7.0.3",
         "ember-focus-trap": "^1.0.1",
         "ember-inputmask5": "^4.0.2",
         "ember-modifier": "^3.2.7",
@@ -43380,9 +43177,9 @@
       }
     },
     "@lblod/ember-submission-form-fields": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.2.0.tgz",
-      "integrity": "sha512-4TGyqdw3lWm9kPXRiG9fB7Yoytb7IlywZ0YorFUwWLb9Gi+Dt+J2jh8kIX9RxNrbqHHHUF2IVWMsFjvdYIz2Xw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.3.0.tgz",
+      "integrity": "sha512-QjE5oDPFvLKXSYtnvgJUV8jWYZ8LWVagWBOKMmb4VL9g4TI4fs+kJLuXCQCfN+5gqBja9m8T26kDCtfDthUIaA==",
       "dev": true,
       "requires": {
         "@lblod/submission-form-helpers": "^2.0.1",
@@ -54045,187 +53842,20 @@
       }
     },
     "ember-file-upload": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ember-file-upload/-/ember-file-upload-4.0.3.tgz",
-      "integrity": "sha512-7IDNGolb9GkcIkQh0W30tL03v+1aOvJkCJ+kRm+0AZ0IbvkZD5T/v9jFwGDRchsMp/C3E8LqN3q8PkGi4BapYw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ember-file-upload/-/ember-file-upload-7.1.0.tgz",
+      "integrity": "sha512-6bfRfjWqdHceNoxAY4PIKV5UQnn3GOi4p6Lq5QNAzPJ3MVNRNUqLevIg2VNXjipfnYz0iftGb6V7VP8CiTD18w==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.13.15",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^5.7.1"
-      },
-      "dependencies": {
-        "async-disk-cache": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-          "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "heimdalljs": "^0.2.3",
-            "istextorbinary": "^2.5.1",
-            "mkdirp": "^0.5.0",
-            "rimraf": "^3.0.0",
-            "rsvp": "^4.8.5",
-            "username-sync": "^1.0.2"
-          }
-        },
-        "broccoli-persistent-filter": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
-          "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
-          "dev": true,
-          "requires": {
-            "async-disk-cache": "^2.0.0",
-            "async-promise-queue": "^1.0.3",
-            "broccoli-plugin": "^4.0.3",
-            "fs-tree-diff": "^2.0.0",
-            "hash-for-dep": "^1.5.0",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "promise-map-series": "^0.2.1",
-            "rimraf": "^3.0.0",
-            "symlink-or-copy": "^1.0.1",
-            "sync-disk-cache": "^2.0.0"
-          }
-        },
-        "broccoli-plugin": {
-          "version": "4.0.7",
-          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-          "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-          "dev": true,
-          "requires": {
-            "broccoli-node-api": "^1.7.0",
-            "broccoli-output-wrapper": "^3.2.5",
-            "fs-merger": "^3.2.1",
-            "promise-map-series": "^0.3.0",
-            "quick-temp": "^0.1.8",
-            "rimraf": "^3.0.2",
-            "symlink-or-copy": "^1.3.1"
-          },
-          "dependencies": {
-            "promise-map-series": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-              "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-              "dev": true
-            }
-          }
-        },
-        "editions": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-          "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-          "dev": true,
-          "requires": {
-            "errlop": "^2.0.0",
-            "semver": "^6.3.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-              "dev": true
-            }
-          }
-        },
-        "ember-cli-htmlbars": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-          "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-          "dev": true,
-          "requires": {
-            "@ember/edition-utils": "^1.2.0",
-            "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-            "broccoli-debug": "^0.6.5",
-            "broccoli-persistent-filter": "^3.1.2",
-            "broccoli-plugin": "^4.0.3",
-            "common-tags": "^1.8.0",
-            "ember-cli-babel-plugin-helpers": "^1.1.1",
-            "ember-cli-version-checker": "^5.1.2",
-            "fs-tree-diff": "^2.0.1",
-            "hash-for-dep": "^1.5.1",
-            "heimdalljs-logger": "^0.1.10",
-            "json-stable-stringify": "^1.0.1",
-            "semver": "^7.3.4",
-            "silent-error": "^1.1.1",
-            "strip-bom": "^4.0.0",
-            "walk-sync": "^2.2.0"
-          }
-        },
-        "fs-tree-diff": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-          "dev": true,
-          "requires": {
-            "@types/symlink-or-copy": "^1.2.0",
-            "heimdalljs-logger": "^0.1.7",
-            "object-assign": "^4.1.0",
-            "path-posix": "^1.0.0",
-            "symlink-or-copy": "^1.1.8"
-          }
-        },
-        "istextorbinary": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-          "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-          "dev": true,
-          "requires": {
-            "binaryextensions": "^2.1.2",
-            "editions": "^2.2.0",
-            "textextensions": "^2.5.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-          "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.6"
-          }
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "rsvp": {
-          "version": "4.8.5",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
-        },
-        "strip-bom": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-          "dev": true
-        },
-        "walk-sync": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0",
-            "minimatch": "^3.0.4"
-          }
-        }
+        "@ember/test-helpers": "^2.4.2",
+        "@ember/test-waiters": "^3.0.0",
+        "@embroider/addon-shim": "^1.5.0",
+        "@embroider/macros": "^1.0.0",
+        "@glimmer/component": "^1.0.4",
+        "@glimmer/tracking": "^1.0.4",
+        "ember-auto-import": "^2.0.0",
+        "ember-modifier": "^3.2.7",
+        "tracked-built-ins": "^3.0.0"
       }
     },
     "ember-focus-trap": {

--- a/package.json
+++ b/package.json
@@ -27,13 +27,17 @@
     "test:ember": "ember test"
   },
   "overrides": {
+    "@appuniversum/ember-appuniversum": "^2.0.0",
     "@embroider/macros": "^1.0.0",
     "@embroider/util": "^1.0.0",
     "ember-cli-babel": "$ember-cli-babel",
     "moment": "^2.29.1"
   },
+  "overridesNotes": {
+    "appuniversum": "ember-rdfa-editor and ember-acmidm-login bring in a v1 version. We can remove the override once that is resolved."
+  },
   "devDependencies": {
-    "@appuniversum/ember-appuniversum": "^1.10.0",
+    "@appuniversum/ember-appuniversum": "^2.0.0",
     "@codemirror/basic-setup": "^0.20.0",
     "@codemirror/lang-html": "^6.0.0",
     "@codemirror/lang-xml": "^6.0.0",
@@ -44,7 +48,7 @@
     "@lblod/ember-acmidm-login": "^1.4.0",
     "@lblod/ember-mock-login": "^0.7.0",
     "@lblod/ember-rdfa-editor": "^0.63.4",
-    "@lblod/ember-submission-form-fields": "^2.2.0",
+    "@lblod/ember-submission-form-fields": "^2.3.0",
     "@lblod/submission-form-helpers": "^2.1.0",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
Some dependencies still depend on v1 so we use overrides to force v2 everywhere. Once that is resolved we can remove the override again.