### PR TITLE
[Eredienst-Mandatenbeheer] Add permanent alert to Mandatenbeheer

### DIFF
--- a/app/templates/eredienst-mandatenbeheer/mandatarissen.hbs
+++ b/app/templates/eredienst-mandatenbeheer/mandatarissen.hbs
@@ -35,6 +35,7 @@
     </Group>
   </AuToolbar>
 
+  <AuAlert @skin="warning" @icon="alert-triangle" @size="small">Gelieve Bestuursleden met mandaten Penningmeester, Secretaris of Voorzitter ook afzonderlijk als bestuurslid toe te voegen. Meer informatie over waarom deze als twee aparte posities gezien worden vindt u in de <AuLinkExternal href="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/mandatenbeheer#de-bestuursmandaten">handleiding</AuLinkExternal>.</AuAlert>
 
   <AuDataTable @content={{this.model}} @isLoading={{this.isLoading}} @noDataMessage="Geen mandatarissen gevonden"
    @sort={{this.sort}} @page={{this.page}} @size={{this.size}} as |t|>


### PR DESCRIPTION
DL-4638

This shows the following message inside a `AuAlert` component with an `AuLinkExternal` component for the handleiding link, "**Gelieve Bestuursleden met mandaten Penningmeester, Secretaris of Voorzitter ook afzonderlijk als bestuurslid toe te voegen. Meer informatie over waarom deze als twee aparte posities gezien worden vindt u in de** [handleiding](https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/mandatenbeheer#de-bestuursmandaten)." to explain the reasoning to the user.