### PR TITLE
[Worship-Modules] Add link to Databank Erediensten

### DIFF
--- a/app/components/shared/compact-menu.hbs
+++ b/app/components/shared/compact-menu.hbs
@@ -60,7 +60,7 @@
       Producten- en dienstencatalogus
     </AuLink>
   {{/if}}
-  {{#if this.currentSession.canAccessToezicht}}
+  {{#if this.currentSession.canAccessWorshipDecisionsDb}}
     <AuLinkExternal
       @icon="link-external"
       @iconAlignment="left"

--- a/app/components/shared/compact-menu.hbs
+++ b/app/components/shared/compact-menu.hbs
@@ -64,7 +64,7 @@
     <AuLinkExternal
       @icon="link-external"
       @iconAlignment="left"
-      href={{this.currentSession.databankEredienstenUrl}}
+      href={{(worship-decisions-database-url)}}
       role="menuitem"
     >
       Databank Erediensten

--- a/app/components/shared/compact-menu.hbs
+++ b/app/components/shared/compact-menu.hbs
@@ -60,4 +60,14 @@
       Producten- en dienstencatalogus
     </AuLink>
   {{/if}}
+  {{#if this.currentSession.canAccessToezicht}}
+    <AuLinkExternal
+      @icon="link-external"
+      @iconAlignment="left"
+      href={{this.currentSession.databankEredienstenUrl}}
+      role="menuitem"
+    >
+      Databank Erediensten
+    </AuLinkExternal>
+  {{/if}}
 </AuDropdown>

--- a/app/components/shared/main-menu.hbs
+++ b/app/components/shared/main-menu.hbs
@@ -88,7 +88,6 @@
             @iconAlignment="left"
             class="au-c-list-navigation__link"
             href={{this.currentSession.databankEredienstenUrl}}
-            role="menuitem"
           >
             Databank Erediensten
           </AuLinkExternal>

--- a/app/components/shared/main-menu.hbs
+++ b/app/components/shared/main-menu.hbs
@@ -81,7 +81,7 @@
         </AuNavigationLink>
       </li>
     {{/if}}
-    {{#if this.currentSession.canAccessToezicht}}
+    {{#if this.currentSession.canAccessWorshipDecisionsDb}}
       <li class="au-c-list-navigation__item">
         <AuLinkExternal
             @icon="link-external"

--- a/app/components/shared/main-menu.hbs
+++ b/app/components/shared/main-menu.hbs
@@ -87,7 +87,7 @@
             @icon="link-external"
             @iconAlignment="left"
             class="au-c-list-navigation__link"
-            href={{this.currentSession.databankEredienstenUrl}}
+            href={{(worship-decisions-database-url)}}
           >
             Databank Erediensten
           </AuLinkExternal>

--- a/app/components/shared/main-menu.hbs
+++ b/app/components/shared/main-menu.hbs
@@ -81,5 +81,18 @@
         </AuNavigationLink>
       </li>
     {{/if}}
+    {{#if this.currentSession.canAccessToezicht}}
+      <li class="au-c-list-navigation__item">
+        <AuLinkExternal
+            @icon="link-external"
+            @iconAlignment="left"
+            class="au-c-list-navigation__link"
+            href={{this.currentSession.databankEredienstenUrl}}
+            role="menuitem"
+          >
+            Databank Erediensten
+          </AuLinkExternal>
+      </li>
+    {{/if}}
   </ul>
 </nav>

--- a/app/helpers/worship-decisions-database-url.js
+++ b/app/helpers/worship-decisions-database-url.js
@@ -1,0 +1,5 @@
+import config from 'frontend-loket/config/environment';
+
+export default function worshipDecisionsDatabaseUrl() {
+  return config.worshipDecisionsDatabaseUrl;
+}

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -2,6 +2,7 @@ import Service from '@ember/service';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import isFeatureEnabled from 'frontend-loket/helpers/is-feature-enabled';
+import ENV from 'frontend-loket/config/environment';
 
 const MODULE = {
   SUPERVISION: 'LoketLB-toezichtGebruiker',
@@ -47,6 +48,10 @@ export default class CurrentSessionService extends Service {
 
   canAccess(role) {
     return this.roles.includes(role);
+  }
+
+  get databankEredienstenUrl() {
+    return ENV.databankEredienstenUrl;
   }
 
   get canAccessToezicht() {

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -2,7 +2,7 @@ import Service from '@ember/service';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import isFeatureEnabled from 'frontend-loket/helpers/is-feature-enabled';
-import ENV from 'frontend-loket/config/environment';
+import config from 'frontend-loket/config/environment';
 
 const MODULE = {
   SUPERVISION: 'LoketLB-toezichtGebruiker',
@@ -50,8 +50,11 @@ export default class CurrentSessionService extends Service {
     return this.roles.includes(role);
   }
 
-  get databankEredienstenUrl() {
-    return ENV.databankEredienstenUrl;
+  get canAccessWorshipDecisionsDb() {
+    return (
+      this.canAccessToezicht &&
+      !config.worshipDecisionsDatabaseUrl.startsWith('{{')
+    );
   }
 
   get canAccessToezicht() {

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -173,7 +173,7 @@
             <:link>
               <AuLinkExternal
                 @skin="button"
-                href={{this.currentSession.databankEredienstenUrl}}
+                href={{(worship-decisions-database-url)}}
               >
                 Ga naar de databank erediensten (externe link)
               </AuLinkExternal>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -160,7 +160,7 @@
         </LoketModuleCard>
         </li>
       {{/if}}
-      {{#if this.currentSession.canAccessToezicht}}
+      {{#if this.currentSession.canAccessWorshipDecisionsDb}}
         <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
           <LoketModuleCard
             @icon="link-external"

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -160,6 +160,27 @@
         </LoketModuleCard>
         </li>
       {{/if}}
+      {{#if this.currentSession.canAccessToezicht}}
+        <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
+          <LoketModuleCard
+            @icon="link-external"
+            @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/databank-erediensten"
+          >
+            <:title>Databank Erediensten</:title>
+            <:description>Consulteer hier inzendingen van (centrale) besturen
+              van de eredienst, gemeente- en provincieoverheid en representatief
+              orgaan.</:description>
+            <:link>
+              <AuLinkExternal
+                @skin="button"
+                href={{this.currentSession.databankEredienstenUrl}}
+              >
+                Ga naar de databank erediensten (externe link)
+              </AuLinkExternal>
+            </:link>
+          </LoketModuleCard>
+        </li>
+      {{/if}}
     </ul>
   </div>
 </div>

--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -214,6 +214,28 @@
               </div>
             {{/if}}
 
+            {{#if this.currentSession.canAccessToezicht}}
+              <div class="au-o-grid__item au-u-1-2@small au-u-1-3@medium">
+                <AuCard @textCenter="true" as |c|>
+                  <c.header @badgeSkin="brand" @badgeIcon="link-external">
+                    <AuHeading @level="3" @skin="4">
+                      Databank Erediensten
+                    </AuHeading>
+                  </c.header>
+                  <c.content>
+                    <p class="au-u-margin-top-tiny">Consulteer hier inzendingen
+                      van (centrale) besturen van de eredienst, gemeente- en
+                      provincieoverheid en representatief orgaan.</p>
+                  </c.content>
+                  <c.footer>
+                    <p>
+                      <a class="au-c-button au-c-button--secondary" href="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/databank-erediensten" target="_blank" rel="noopener noreferrer">Handleiding</a>
+                    </p>
+                  </c.footer>
+                </AuCard>
+              </div>
+            {{/if}}
+
           </div>
         </div>
       </section>

--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -214,28 +214,6 @@
               </div>
             {{/if}}
 
-            {{#if this.currentSession.canAccessToezicht}}
-              <div class="au-o-grid__item au-u-1-2@small au-u-1-3@medium">
-                <AuCard @textCenter="true" as |c|>
-                  <c.header @badgeSkin="brand" @badgeIcon="link-external">
-                    <AuHeading @level="3" @skin="4">
-                      Databank Erediensten
-                    </AuHeading>
-                  </c.header>
-                  <c.content>
-                    <p class="au-u-margin-top-tiny">Consulteer hier inzendingen
-                      van (centrale) besturen van de eredienst, gemeente- en
-                      provincieoverheid en representatief orgaan.</p>
-                  </c.content>
-                  <c.footer>
-                    <p>
-                      <a class="au-c-button au-c-button--secondary" href="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/databank-erediensten" target="_blank" rel="noopener noreferrer">Handleiding</a>
-                    </p>
-                  </c.footer>
-                </AuCard>
-              </div>
-            {{/if}}
-
           </div>
         </div>
       </section>

--- a/config/environment.js
+++ b/config/environment.js
@@ -65,6 +65,9 @@ module.exports = function (environment) {
     ENV.features['eredienst-mandatenbeheer'] = true;
     ENV.features['public-services'] = true;
     ENV.features['worship-minister-management'] = true;
+
+    ENV.databankEredienstenUrl =
+      'https://dev.app-worship-decisions-database.abb-bfg.s.redpencil.io/login';
   }
 
   if (environment === 'test') {
@@ -82,6 +85,8 @@ module.exports = function (environment) {
 
   if (environment === 'production') {
     // here you can enable a production-specific feature
+    ENV.databankEredienstenUrl =
+      'https://databankerediensten.lokaalbestuur.vlaanderen.be/login';
   }
 
   if (process.env.DEPLOY_ENV === 'production') {

--- a/config/environment.js
+++ b/config/environment.js
@@ -66,8 +66,7 @@ module.exports = function (environment) {
     ENV.features['public-services'] = true;
     ENV.features['worship-minister-management'] = true;
 
-    ENV.databankEredienstenUrl =
-      'https://dev.app-worship-decisions-database.abb-bfg.s.redpencil.io/login';
+    ENV.worshipDecisionsDatabaseUrl = '{{WORSHIP_DECISIONS_DATABASE_URL}}';
   }
 
   if (environment === 'test') {
@@ -85,8 +84,7 @@ module.exports = function (environment) {
 
   if (environment === 'production') {
     // here you can enable a production-specific feature
-    ENV.databankEredienstenUrl =
-      'https://databankerediensten.lokaalbestuur.vlaanderen.be/login';
+    ENV.worshipDecisionsDatabaseUrl = '{{WORSHIP_DECISIONS_DATABASE_URL}}';
   }
 
   if (process.env.DEPLOY_ENV === 'production') {

--- a/config/environment.js
+++ b/config/environment.js
@@ -53,6 +53,7 @@ module.exports = function (environment) {
       'worship-minister-management':
         '{{FEATURE_WORSHIP_MINISTER_MANAGEMENT_ENABLED}}',
     },
+    worshipDecisionsDatabaseUrl: '{{WORSHIP_DECISIONS_DATABASE_URL}}',
   };
 
   if (environment === 'development') {
@@ -65,8 +66,6 @@ module.exports = function (environment) {
     ENV.features['eredienst-mandatenbeheer'] = true;
     ENV.features['public-services'] = true;
     ENV.features['worship-minister-management'] = true;
-
-    ENV.worshipDecisionsDatabaseUrl = '{{WORSHIP_DECISIONS_DATABASE_URL}}';
   }
 
   if (environment === 'test') {
@@ -84,7 +83,6 @@ module.exports = function (environment) {
 
   if (environment === 'production') {
     // here you can enable a production-specific feature
-    ENV.worshipDecisionsDatabaseUrl = '{{WORSHIP_DECISIONS_DATABASE_URL}}';
   }
 
   if (process.env.DEPLOY_ENV === 'production') {


### PR DESCRIPTION
DL-4240

Adding the right access link for databank Erediensten from the right environment.
Adding the module `databank Erediensten` to be only available for users who does have access to Toezicht.