### PR TITLE
Add a "Conceptual public service" details page

### DIFF
--- a/app/components/public-services/concept-details-page.hbs
+++ b/app/components/public-services/concept-details-page.hbs
@@ -1,0 +1,36 @@
+<AuBodyContainer @scroll={{true}}>
+  {{#if this.loadForm.isRunning}}
+    <div class="au-o-box">
+      <p class="au-u-h4 au-u-medium" aria-hidden="true">
+        Formulier aan het laden
+      </p>
+      <AuLoader @padding="small" />
+    </div>
+  {{else if this.loadForm.last.isError}}
+    <div class="au-o-box">
+      <AuAlert
+        @title="Onverwachte fout"
+        @skin="error"
+        @icon="circle-x"
+        @size="small"
+        class="au-u-max-width-small"
+      >
+        <p>
+          Er ging iets fout bij het laden van het formulier, gelieve de helpdesk
+          te contacteren.
+        </p>
+      </AuAlert>
+    </div>
+  {{else}}
+    <form class="au-c-rdf-form {{@tabName}}">
+      <RdfForm
+        @groupClass="au-o-grid__item"
+        @form={{this.form}}
+        @graphs={{this.graphs}}
+        @sourceNode={{this.sourceNode}}
+        @formStore={{this.formStore}}
+        @show={{true}}
+      />
+    </form>
+  {{/if}}
+</AuBodyContainer>

--- a/app/components/public-services/concept-details-page.js
+++ b/app/components/public-services/concept-details-page.js
@@ -1,0 +1,58 @@
+import { guidFor } from '@ember/object/internals';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import { ForkingStore } from '@lblod/ember-submission-form-fields';
+import { NamedNode } from 'rdflib';
+import { task } from 'ember-concurrency';
+import { FORM, RDF } from 'frontend-loket/rdf/namespaces';
+
+const FORM_GRAPHS = {
+  formGraph: new NamedNode('http://data.lblod.info/form'),
+  metaGraph: new NamedNode('http://data.lblod.info/metagraph'),
+  sourceGraph: new NamedNode(`http://data.lblod.info/sourcegraph`),
+};
+
+export default class PublicServicesDetailsPageComponent extends Component {
+  @service router;
+  @service store;
+
+  id = guidFor(this);
+  form;
+  formStore;
+  graphs = FORM_GRAPHS;
+
+  constructor() {
+    super(...arguments);
+    this.loadForm.perform();
+    this.sourceNode = new NamedNode(this.args.concept.uri);
+  }
+
+  @task
+  *loadForm() {
+    const {
+      form: formTtl,
+      meta: metaTtl,
+      source: sourceTtl,
+    } = yield fetchFormGraphs(this.args.concept.id, this.args.formId);
+
+    let formStore = new ForkingStore();
+    formStore.parse(formTtl, FORM_GRAPHS.formGraph, 'text/turtle');
+    formStore.parse(metaTtl, FORM_GRAPHS.metaGraph, 'text/turtle');
+    formStore.parse(sourceTtl, FORM_GRAPHS.sourceGraph, 'text/turtle');
+
+    let form = formStore.any(
+      undefined,
+      RDF('type'),
+      FORM('Form'),
+      FORM_GRAPHS.formGraph
+    );
+
+    this.form = form;
+    this.formStore = formStore;
+  }
+}
+
+async function fetchFormGraphs(serviceId, formId) {
+  let response = await fetch(`/lpdc-management/${serviceId}/form/${formId}`);
+  return await response.json();
+}

--- a/app/components/shared/bread-crumb.js
+++ b/app/components/shared/bread-crumb.js
@@ -325,12 +325,29 @@ export default class SharedBreadCrumbComponent extends Component {
       ],
     },
     {
-      route: 'public-services.details.translations',
+      route: 'public-services.concept-details',
       crumbs: [
         { label: 'Producten- en dienstencatalogus', link: 'public-services' },
         // TODO: this should be the name of the service, but the breadcrumbs system doesn't support that
-        { label: 'Details' },
-        { label: 'Engelse vertalingen' },
+        { label: 'Concept details' },
+      ],
+    },
+    {
+      route: 'public-services.concept-details.content',
+      crumbs: [
+        { label: 'Producten- en dienstencatalogus', link: 'public-services' },
+        // TODO: this should be the name of the service, but the breadcrumbs system doesn't support that
+        { label: 'Concept details' },
+        { label: 'Inhoud' },
+      ],
+    },
+    {
+      route: 'public-services.concept-details.properties',
+      crumbs: [
+        { label: 'Producten- en dienstencatalogus', link: 'public-services' },
+        // TODO: this should be the name of the service, but the breadcrumbs system doesn't support that
+        { label: 'Concept details' },
+        { label: 'Eigenschappen' },
       ],
     },
   ];

--- a/app/router.js
+++ b/app/router.js
@@ -109,6 +109,14 @@ Router.map(function () {
           this.route('content', { path: '/inhoud' });
           this.route('properties', { path: '/eigenschappen' });
         });
+        this.route(
+          'concept-details',
+          { path: '/concept/:conceptId' },
+          function () {
+            this.route('content', { path: '/inhoud' });
+            this.route('properties', { path: '/eigenschappen' });
+          }
+        );
       }
     );
   }

--- a/app/routes/public-services.js
+++ b/app/routes/public-services.js
@@ -1,15 +1,42 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { registerFormFields } from '@lblod/ember-submission-form-fields';
+import TagSelector from 'frontend-loket/components/public-services/rdf-form-fields/tag-selector';
+import ConceptSelector from 'frontend-loket/components/rdf-form-fields/concept-selector';
+import RichTextEditor from 'frontend-loket/components/rdf-form-fields/rich-text-editor';
 
 export default class PublicServicesRoute extends Route {
   @service currentSession;
   @service session;
   @service router;
 
+  constructor() {
+    super(...arguments);
+
+    this.registerCustomFormFields();
+  }
+
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
 
     if (!this.currentSession.canAccessPublicServices)
       this.router.transitionTo('index');
+  }
+
+  registerCustomFormFields() {
+    registerFormFields([
+      {
+        displayType: 'http://lblod.data.gift/display-types/richText',
+        edit: RichTextEditor,
+      },
+      {
+        displayType: 'http://lblod.data.gift/display-types/conceptSelector',
+        edit: ConceptSelector,
+      },
+      {
+        displayType: 'http://lblod.data.gift/display-types/tagSelector',
+        edit: TagSelector,
+      },
+    ]);
   }
 }

--- a/app/routes/public-services/concept-details.js
+++ b/app/routes/public-services/concept-details.js
@@ -9,7 +9,6 @@ export default class PublicServicesConceptDetailsRoute extends Route {
       'conceptual-public-service',
       conceptId,
       {
-        reload: true,
         include: 'type,status',
       }
     );

--- a/app/routes/public-services/concept-details.js
+++ b/app/routes/public-services/concept-details.js
@@ -1,0 +1,21 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class PublicServicesConceptDetailsRoute extends Route {
+  @service store;
+
+  async model({ conceptId }) {
+    let concept = await this.store.findRecord(
+      'conceptual-public-service',
+      conceptId,
+      {
+        reload: true,
+        include: 'type,status',
+      }
+    );
+
+    return {
+      concept,
+    };
+  }
+}

--- a/app/routes/public-services/concept-details/content.js
+++ b/app/routes/public-services/concept-details/content.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class PublicServicesConceptDetailsContentRoute extends Route {
+  model() {
+    return this.modelFor('public-services.concept-details');
+  }
+}

--- a/app/routes/public-services/concept-details/index.js
+++ b/app/routes/public-services/concept-details/index.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class PublicServicesConceptDetailsIndexRoute extends Route {
+  @service router;
+
+  beforeModel() {
+    this.router.replaceWith('public-services.concept-details.content');
+  }
+}

--- a/app/routes/public-services/concept-details/properties.js
+++ b/app/routes/public-services/concept-details/properties.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class PublicServicesConceptDetailsPropertiesRoute extends Route {
+  model() {
+    return this.modelFor('public-services.concept-details');
+  }
+}

--- a/app/routes/public-services/details.js
+++ b/app/routes/public-services/details.js
@@ -1,19 +1,9 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import { registerFormFields } from '@lblod/ember-submission-form-fields';
-import TagSelector from 'frontend-loket/components/public-services/rdf-form-fields/tag-selector';
-import ConceptSelector from 'frontend-loket/components/rdf-form-fields/concept-selector';
-import RichTextEditor from 'frontend-loket/components/rdf-form-fields/rich-text-editor';
 import { loadPublicServiceDetails } from 'frontend-loket/utils/public-services';
 
 export default class PublicServicesDetailsRoute extends Route {
   @service store;
-
-  constructor() {
-    super(...arguments);
-
-    this.registerCustomFormFields();
-  }
 
   async model({ serviceId }) {
     const publicService = await loadPublicServiceDetails(this.store, serviceId);
@@ -25,22 +15,5 @@ export default class PublicServicesDetailsRoute extends Route {
       publicService,
       readOnly,
     };
-  }
-
-  registerCustomFormFields() {
-    registerFormFields([
-      {
-        displayType: 'http://lblod.data.gift/display-types/richText',
-        edit: RichTextEditor,
-      },
-      {
-        displayType: 'http://lblod.data.gift/display-types/conceptSelector',
-        edit: ConceptSelector,
-      },
-      {
-        displayType: 'http://lblod.data.gift/display-types/tagSelector',
-        edit: TagSelector,
-      },
-    ]);
   }
 }

--- a/app/templates/public-services/concept-details.hbs
+++ b/app/templates/public-services/concept-details.hbs
@@ -1,0 +1,23 @@
+{{page-title "Concept: " @model.concept.nameNl}}
+
+<AuToolbar @size="large" as |Group|>
+  <Group>
+    <AuHeading @skin="2">
+      {{! template-lint-disable no-triple-curlies}}
+      Concept: {{{@model.concept.nameNl}}}
+    </AuHeading>
+  </Group>
+</AuToolbar>
+
+<AuTabs as |Tab|>
+  <Tab>
+    <AuLink @route="public-services.concept-details.content">Inhoud</AuLink>
+  </Tab>
+  <Tab>
+    <AuLink @route="public-services.concept-details.properties">Eigenschappen</AuLink>
+  </Tab>
+</AuTabs>
+
+<AuBodyContainer>
+  {{outlet}}
+</AuBodyContainer>

--- a/app/templates/public-services/concept-details/content.hbs
+++ b/app/templates/public-services/concept-details/content.hbs
@@ -1,0 +1,7 @@
+{{page-title "Inhoud"}}
+
+<PublicServices::ConceptDetailsPage
+  @concept={{@model.concept}}
+  @formId="cd0b5eba-33c1-45d9-aed9-75194c3728d3"
+  @tabName="au-c-rdf-form--content"
+/>

--- a/app/templates/public-services/concept-details/properties.hbs
+++ b/app/templates/public-services/concept-details/properties.hbs
@@ -1,0 +1,7 @@
+{{page-title "Eigenschappen"}}
+
+<PublicServices::ConceptDetailsPage
+  @concept={{@model.concept}}
+  @formId="149a7247-0294-44a5-a281-0a4d3782b4fd"
+  @tabName="au-c-rdf-form--properties"
+/>


### PR DESCRIPTION
~~This depends on this PR to render the forms: https://github.com/lblod/lpdc-management-service/pull/21~~ This is now included in the development branch of the backend so just running that should be enough.

The only way to get to the page for now is by manually typing it in the url (or do some inspector trickery, but typing will be easier). You can find the uuid of a concept by going to the "add new product" page and looking in the data tab of the inspector.