### PR TITLE
Add a mail link to the helpdesk on the person search pages

### DIFF
--- a/app/components/shared/persoon/persoon-search-result.hbs
+++ b/app/components/shared/persoon/persoon-search-result.hbs
@@ -16,5 +16,8 @@
   </div>
   <div class="au-o-grid__item au-u-2-5 au-u-1-5@medium au-u-text-right">
     <AuButton {{on 'click' this.select}}>Selecteer</AuButton>
+    <AuHelpText>
+      Zie je een fout in de data? <AuLinkExternal href={{this.mailContent}}>Meld het ons!</AuLinkExternal>
+    </AuHelpText>
   </div>
 </div>

--- a/app/components/shared/persoon/persoon-search-result.js
+++ b/app/components/shared/persoon/persoon-search-result.js
@@ -1,8 +1,10 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class SharedPersoonPersoonSearchResultComponent extends Component {
+  @service currentSession;
   @tracked showDetails = false;
 
   @action
@@ -13,5 +15,22 @@ export default class SharedPersoonPersoonSearchResultComponent extends Component
   @action
   toggleDetails() {
     this.showDetails = !this.showDetails;
+  }
+
+  get mailContent() {
+    let mail = 'LoketLokaalBestuur@vlaanderen.be';
+    let administrativeUnitName = this.currentSession.group.naam;
+    let subject = encodeURIComponent('Melden van onvolledige of foutieve data');
+    // The indentation is intentional, otherwise the email would display white space in the front
+    // TODO: look for some de-indent solution since we could use it in other places as well
+    let message = encodeURIComponent(`\
+Beste Loket team,
+
+Ik zie foutieve data bij/wens een ander probleem te melden:
+Bestuur: ${administrativeUnitName}
+Foute data: [Vul details aan]
+Correctie: [Vul details aan]`);
+
+    return `mailto:${mail}?subject=${subject}&body=${message}`;
   }
 }


### PR DESCRIPTION
This allows users to notify the helpdesk about data issues since the user can't correct this themselves.

The email looks like this in Apple mail:
![image](https://user-images.githubusercontent.com/3533236/212072465-e615b8d4-0edf-4550-a622-5796841f77f3.png)
