### PR TITLE
[Worship-modules] Fixing secondaryContactPoint is null error

### DIFF
--- a/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
+++ b/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
@@ -135,9 +135,6 @@ export default class EredienstMandatenbeheerMandatarisEditController extends Con
       if ((yield isValidPrimaryContact(contactPoint)) && this.model.isValid) {
         if (secondaryContactPoint.telefoon) {
           yield secondaryContactPoint.save();
-        } else {
-          // The secondary contact point is empty so we can remove it if it was ever persisted before
-          yield secondaryContactPoint.destroyRecord();
         }
 
         if (adres?.isNew || adres?.hasDirtyAttributes) {
@@ -196,6 +193,14 @@ export default class EredienstMandatenbeheerMandatarisEditController extends Con
       this.model.contacts.length > 0 &&
       this.model.isValid
     ) {
+      let secondaryContactPoint = yield this.selectedContact
+        .secondaryContactPoint;
+      if (secondaryContactPoint !== null) {
+        if (!secondaryContactPoint.telefoon) {
+          // The secondary contact point is empty so we can remove it if it was ever persisted before
+          yield secondaryContactPoint.destroyRecord();
+        }
+      }
       yield this.model.save();
 
       try {

--- a/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
+++ b/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
@@ -139,6 +139,9 @@ export default class EredienstMandatenbeheerMandatarisEditController extends Con
       ) {
         if (secondaryContactPoint.telefoon) {
           yield secondaryContactPoint.save();
+        } else {
+          // The secondary contact point is empty so we can remove it if it was ever persisted before
+          yield secondaryContactPoint.destroyRecord();
         }
 
         if (adres?.isNew || adres?.hasDirtyAttributes) {
@@ -193,14 +196,6 @@ export default class EredienstMandatenbeheerMandatarisEditController extends Con
       this.model.contacts.length > 0 &&
       this.model.isValid
     ) {
-      let secondaryContactPoint = yield this.selectedContact
-        .secondaryContactPoint;
-      if (secondaryContactPoint !== null) {
-        if (!secondaryContactPoint.telefoon) {
-          // The secondary contact point is empty so we can remove it if it was ever persisted before
-          yield secondaryContactPoint.destroyRecord();
-        }
-      }
       yield this.model.save();
 
       try {

--- a/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
+++ b/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
@@ -132,18 +132,18 @@ export default class EredienstMandatenbeheerMandatarisEditController extends Con
         yield isValidAdres(adres);
       }
 
-      if ((yield isValidPrimaryContact(contactPoint)) && this.model.isValid) {
+      if (
+        (yield isValidPrimaryContact(contactPoint)) &&
+        this.model.isValid &&
+        adres.isValid
+      ) {
         if (secondaryContactPoint.telefoon) {
           yield secondaryContactPoint.save();
         }
 
         if (adres?.isNew || adres?.hasDirtyAttributes) {
-          if (adres.isValid) {
-            adres.volledigAdres = combineFullAddress(adres);
-            yield adres.save();
-          } else {
-            return;
-          }
+          adres.volledigAdres = combineFullAddress(adres);
+          yield adres.save();
         }
 
         if (contactPoint.isNew) {

--- a/app/controllers/eredienst-mandatenbeheer/new.js
+++ b/app/controllers/eredienst-mandatenbeheer/new.js
@@ -168,15 +168,12 @@ export default class EredienstMandatenbeheerNewController extends Controller {
 
       if (
         (yield isValidPrimaryContact(contactPoint)) &&
-        worshipMandatee.isValid
+        worshipMandatee.isValid &&
+        adres.isValid
       ) {
         if (adres?.isNew || adres?.hasDirtyAttributes) {
-          if (adres.isValid) {
-            adres.volledigAdres = combineFullAddress(adres);
-            yield adres.save();
-          } else {
-            return;
-          }
+          adres.volledigAdres = combineFullAddress(adres);
+          yield adres.save();
         }
 
         if (contactPoint.isNew) {

--- a/app/controllers/eredienst-mandatenbeheer/new.js
+++ b/app/controllers/eredienst-mandatenbeheer/new.js
@@ -183,6 +183,9 @@ export default class EredienstMandatenbeheerNewController extends Controller {
 
         if (secondaryContactPoint.telefoon) {
           yield secondaryContactPoint.save();
+        } else {
+          // The secondary contact point is empty so we can remove it if it was ever persisted before
+          yield secondaryContactPoint.destroyRecord();
         }
       } else {
         return;
@@ -213,15 +216,6 @@ export default class EredienstMandatenbeheerNewController extends Controller {
       worshipMandatee.contacts.length > 0 &&
       this.selectedContact.isValid
     ) {
-      let secondaryContactPoint = yield this.selectedContact
-        .secondaryContactPoint;
-      if (secondaryContactPoint !== null) {
-        if (!secondaryContactPoint.telefoon) {
-          // The secondary contact point is empty so we can remove it if it was ever persisted before
-          yield secondaryContactPoint.destroyRecord();
-        }
-      }
-
       yield this.selectedContact.save();
       yield worshipMandatee.save();
 

--- a/app/controllers/worship-ministers-management/minister/edit.js
+++ b/app/controllers/worship-ministers-management/minister/edit.js
@@ -142,6 +142,9 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
       ) {
         if (secondaryContactPoint.telefoon) {
           yield secondaryContactPoint.save();
+        } else {
+          // The secondary contact point is empty so we can remove it if it was ever persisted before
+          yield secondaryContactPoint.destroyRecord();
         }
 
         if (adres?.isNew || adres?.hasDirtyAttributes) {
@@ -196,14 +199,6 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
       minister.isValid &&
       minister.contacts.length > 0
     ) {
-      let secondaryContactPoint = yield this.selectedContact
-        .secondaryContactPoint;
-      if (secondaryContactPoint !== null) {
-        if (!secondaryContactPoint.telefoon) {
-          // The secondary contact point is empty so we can remove it if it was ever persisted before
-          yield secondaryContactPoint.destroyRecord();
-        }
-      }
       yield minister.save();
 
       try {

--- a/app/controllers/worship-ministers-management/minister/edit.js
+++ b/app/controllers/worship-ministers-management/minister/edit.js
@@ -138,10 +138,8 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
       if ((yield isValidPrimaryContact(contactPoint)) && minister.isValid) {
         if (secondaryContactPoint.telefoon) {
           yield secondaryContactPoint.save();
-        } else {
-          // The secondary contact point is empty so we can remove it if it was ever persisted before
-          yield secondaryContactPoint.destroyRecord();
         }
+
         if (adres?.isNew || adres?.hasDirtyAttributes) {
           if (adres.isValid) {
             adres.volledigAdres = combineFullAddress(adres);
@@ -198,6 +196,14 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
       minister.isValid &&
       minister.contacts.length > 0
     ) {
+      let secondaryContactPoint = yield this.selectedContact
+        .secondaryContactPoint;
+      if (secondaryContactPoint !== null) {
+        if (!secondaryContactPoint.telefoon) {
+          // The secondary contact point is empty so we can remove it if it was ever persisted before
+          yield secondaryContactPoint.destroyRecord();
+        }
+      }
       yield minister.save();
 
       try {

--- a/app/controllers/worship-ministers-management/minister/edit.js
+++ b/app/controllers/worship-ministers-management/minister/edit.js
@@ -135,18 +135,18 @@ export default class WorshipMinistersManagementMinisterEditController extends Co
         yield isValidAdres(adres);
       }
 
-      if ((yield isValidPrimaryContact(contactPoint)) && minister.isValid) {
+      if (
+        (yield isValidPrimaryContact(contactPoint)) &&
+        minister.isValid &&
+        adres.isValid
+      ) {
         if (secondaryContactPoint.telefoon) {
           yield secondaryContactPoint.save();
         }
 
         if (adres?.isNew || adres?.hasDirtyAttributes) {
-          if (adres.isValid) {
-            adres.volledigAdres = combineFullAddress(adres);
-            yield adres.save();
-          } else {
-            return;
-          }
+          adres.volledigAdres = combineFullAddress(adres);
+          yield adres.save();
         }
 
         if (contactPoint.isNew) {

--- a/app/controllers/worship-ministers-management/new.js
+++ b/app/controllers/worship-ministers-management/new.js
@@ -189,6 +189,9 @@ export default class WorshipMinistersManagementNewController extends Controller 
 
         if (secondaryContactPoint.telefoon) {
           yield secondaryContactPoint.save();
+        } else {
+          // The secondary contact point is empty so we can remove it if it was ever persisted before
+          yield secondaryContactPoint.destroyRecord();
         }
       } else {
         return;
@@ -220,14 +223,6 @@ export default class WorshipMinistersManagementNewController extends Controller 
       worshipMinister.contacts.length > 0 &&
       this.selectedContact.isValid
     ) {
-      let secondaryContactPoint = yield this.selectedContact
-        .secondaryContactPoint;
-      if (secondaryContactPoint !== null) {
-        if (!secondaryContactPoint.telefoon) {
-          // The secondary contact point is empty so we can remove it if it was ever persisted before
-          yield secondaryContactPoint.destroyRecord();
-        }
-      }
       yield this.selectedContact.save();
       yield worshipMinister.save();
       this.router.transitionTo('worship-ministers-management');

--- a/app/controllers/worship-ministers-management/new.js
+++ b/app/controllers/worship-ministers-management/new.js
@@ -174,15 +174,12 @@ export default class WorshipMinistersManagementNewController extends Controller 
       // in this case the contact point information and address should be valid
       if (
         (yield isValidPrimaryContact(contactPoint)) &&
-        worshipMinister.isValid
+        worshipMinister.isValid &&
+        adres.isValid
       ) {
         if (adres?.isNew || adres?.hasDirtyAttributes) {
-          if (adres.isValid) {
-            adres.volledigAdres = combineFullAddress(adres);
-            yield adres.save();
-          } else {
-            return;
-          }
+          adres.volledigAdres = combineFullAddress(adres);
+          yield adres.save();
         }
 
         if (contactPoint.isNew) {


### PR DESCRIPTION
DL-4733

**Context :**
If we try to validate an empty address with no secondary phone number. The secondary phone number record is deleted _(this prevents the record to be saved empty in the database)_, but if we try again with an address it throws an error because it’s looking for that secondary contact point _(Secondary phone number)_ to be destroyed again when the secondary phone number is missing.

**Solved :**
By moving the "destroyRecord" logic in the final validation we make sure that the record is deleted once.