### PR TITLE
Small improvements to the "report incorrect person data" flow

### DIFF
--- a/app/components/shared/persoon/persoon-search-result.js
+++ b/app/components/shared/persoon/persoon-search-result.js
@@ -19,7 +19,7 @@ export default class SharedPersoonPersoonSearchResultComponent extends Component
 
   get mailContent() {
     let mail = 'LoketLokaalBestuur@vlaanderen.be';
-    let administrativeUnitName = this.currentSession.group.naam;
+    let administrativeUnitName = `${this.currentSession.groupClassification.label} ${this.currentSession.group.naam}`;
     let subject = encodeURIComponent('Melden van onvolledige of foutieve data');
     // The indentation is intentional, otherwise the email would display white space in the front
     // TODO: look for some de-indent solution since we could use it in other places as well
@@ -28,6 +28,7 @@ Beste Loket team,
 
 Ik zie foutieve data bij/wens een ander probleem te melden:
 Bestuur: ${administrativeUnitName}
+Persoon: ${this.args.persoon.gebruikteVoornaam} ${this.args.persoon.achternaam}
 Foute data: [Vul details aan]
 Correctie: [Vul details aan]`);
 


### PR DESCRIPTION
Small improvements for the work we merged in #258.

- add the classification name of the administrative unit
- add the person name

![image](https://user-images.githubusercontent.com/3533236/212697136-99a961cd-6ca2-414e-bc6b-57dd05164129.png)
