### PR TITLE
Update to ember-template-lint v5

### DIFF
--- a/app/templates/mock-login.hbs
+++ b/app/templates/mock-login.hbs
@@ -23,6 +23,8 @@
                   <p>
                   {{account.gebruiker.voornaam}} {{account.gebruiker.achternaam}}
                   </p>
+                  {{! TODO: The solution in the lint rule docs doesn't work here. We need to find a different solution.}}
+                  {{! template-lint-disable no-array-prototype-extensions}}
                   {{#if (await account.gebruiker.bestuurseenheden.firstObject.alternatieveNaam)}}
                   <AuHr/>
                   <p>

--- a/app/templates/subsidy/applications/index.hbs
+++ b/app/templates/subsidy/applications/index.hbs
@@ -48,6 +48,8 @@
         <td>
           {{consumption.subsidyMeasureOffer.title}}
 
+          {{! TODO: The solution in the lint rule docs doesn't work here. We need to find a different solution.}}
+          {{! template-lint-disable no-array-prototype-extensions}}
           {{#if consumption.subsidyApplicationForms.firstObject.projectName}}
             <AuHelpText @skin="secondary" class="au-u-margin-top-none">
               {{consumption.subsidyApplicationForms.firstObject.projectName}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "ember-router-service-refresh-polyfill": "^1.0.1",
         "ember-simple-auth": "^4.2.1",
         "ember-source": "~3.28.8",
-        "ember-template-lint": "^4.0.0",
+        "ember-template-lint": "^5.3.1",
         "ember-test-selectors": "^6.0.0",
         "ember-truth-helpers": "^3.0.0",
         "ember-unique-id-helper-polyfill": "^1.2.0",
@@ -23538,24 +23538,25 @@
       }
     },
     "node_modules/ember-template-lint": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-4.18.1.tgz",
-      "integrity": "sha512-YATwZ1zENT5wfW41/W+wz36gJVFlR8FdSXrWhoJbg89r1goTtkLNG7jhU+/jF11sXOcq0KqvK4TOQsfwPDW8Ug==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-5.3.1.tgz",
+      "integrity": "sha512-c1eqYkjMjbZ2Hxfsv49bQcNCfRd2gDjoQv9t48BOb8/l94ygzf8YQN6uzQcIW/zvtVEugh04yGm8moxd7UR4vQ==",
       "dev": true,
       "dependencies": {
         "@lint-todo/utils": "^13.0.3",
         "aria-query": "^5.0.2",
-        "chalk": "^4.1.2",
-        "ci-info": "^3.4.0",
+        "chalk": "^5.2.0",
+        "ci-info": "^3.7.0",
         "date-fns": "^2.29.2",
-        "ember-template-imports": "^3.2.0",
+        "ember-template-imports": "^3.4.0",
         "ember-template-recast": "^6.1.3",
+        "eslint-formatter-kakoune": "^1.0.0",
         "find-up": "^6.3.0",
         "fuse.js": "^6.5.3",
         "get-stdin": "^9.0.0",
-        "globby": "^13.1.2",
+        "globby": "^13.1.3",
         "is-glob": "^4.0.3",
-        "language-tags": "^1.0.5",
+        "language-tags": "^1.0.7",
         "micromatch": "^4.0.5",
         "resolve": "^1.22.1",
         "v8-compile-cache": "^2.3.0",
@@ -23565,16 +23566,59 @@
         "ember-template-lint": "bin/ember-template-lint.js"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^14.18.0 || ^16.0.0 || >= 18.0.0"
+      }
+    },
+    "node_modules/ember-template-lint/node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ember-template-lint/node_modules/chalk": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/ember-template-lint/node_modules/ci-info": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.6.1.tgz",
-      "integrity": "sha512-up5ggbaDqOqJ4UqLKZ2naVkyqSJQgJi5lwD6b6mM748ysrghDBX0bx/qJTUHzw7zu6Mq4gycviSF5hJnwceD8w==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
+      "integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ember-template-lint/node_modules/fast-glob": {
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
       }
     },
     "node_modules/ember-template-lint/node_modules/find-up": {
@@ -23591,6 +23635,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ember-template-lint/node_modules/globby": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
+      "integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
+      "dev": true,
+      "dependencies": {
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.11",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ember-template-lint/node_modules/ignore": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/ember-template-lint/node_modules/locate-path": {
@@ -23645,6 +23717,18 @@
       "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/ember-template-lint/node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ember-template-lint/node_modules/yocto-queue": {
@@ -24762,6 +24846,12 @@
       "peerDependencies": {
         "eslint": ">=7.0.0"
       }
+    },
+    "node_modules/eslint-formatter-kakoune": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-kakoune/-/eslint-formatter-kakoune-1.0.0.tgz",
+      "integrity": "sha512-Uk/TVLt6Nf6Xoz7C1iYuZjOSdJxe5aaauGRke8JhKeJwD66Y61/pY2FjtLP04Ooq9PwV34bzrkKkU2UZ5FtDRA==",
+      "dev": true
     },
     "node_modules/eslint-plugin-ember": {
       "version": "10.6.1",
@@ -29186,12 +29276,12 @@
       "dev": true
     },
     "node_modules/language-tags": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
-      "integrity": "sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.7.tgz",
+      "integrity": "sha512-bSytju1/657hFjgUzPAPqszxH62ouE8nQFoFaVlIQfne4wO/wXC9A4+m8jYve7YBBvi59eq0SUpcshvG8h5Usw==",
       "dev": true,
       "dependencies": {
-        "language-subtag-registry": "~0.3.2"
+        "language-subtag-registry": "^0.3.20"
       }
     },
     "node_modules/latest-version": {
@@ -58050,35 +58140,61 @@
       }
     },
     "ember-template-lint": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-4.18.1.tgz",
-      "integrity": "sha512-YATwZ1zENT5wfW41/W+wz36gJVFlR8FdSXrWhoJbg89r1goTtkLNG7jhU+/jF11sXOcq0KqvK4TOQsfwPDW8Ug==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-5.3.1.tgz",
+      "integrity": "sha512-c1eqYkjMjbZ2Hxfsv49bQcNCfRd2gDjoQv9t48BOb8/l94ygzf8YQN6uzQcIW/zvtVEugh04yGm8moxd7UR4vQ==",
       "dev": true,
       "requires": {
         "@lint-todo/utils": "^13.0.3",
         "aria-query": "^5.0.2",
-        "chalk": "^4.1.2",
-        "ci-info": "^3.4.0",
+        "chalk": "^5.2.0",
+        "ci-info": "^3.7.0",
         "date-fns": "^2.29.2",
-        "ember-template-imports": "^3.2.0",
+        "ember-template-imports": "^3.4.0",
         "ember-template-recast": "^6.1.3",
+        "eslint-formatter-kakoune": "^1.0.0",
         "find-up": "^6.3.0",
         "fuse.js": "^6.5.3",
         "get-stdin": "^9.0.0",
-        "globby": "^13.1.2",
+        "globby": "^13.1.3",
         "is-glob": "^4.0.3",
-        "language-tags": "^1.0.5",
+        "language-tags": "^1.0.7",
         "micromatch": "^4.0.5",
         "resolve": "^1.22.1",
         "v8-compile-cache": "^2.3.0",
         "yargs": "^17.5.1"
       },
       "dependencies": {
-        "ci-info": {
-          "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.6.1.tgz",
-          "integrity": "sha512-up5ggbaDqOqJ4UqLKZ2naVkyqSJQgJi5lwD6b6mM748ysrghDBX0bx/qJTUHzw7zu6Mq4gycviSF5hJnwceD8w==",
+        "@nodelib/fs.stat": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+          "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
           "dev": true
+        },
+        "chalk": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+          "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+          "dev": true
+        },
+        "ci-info": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
+          "integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==",
+          "dev": true
+        },
+        "fast-glob": {
+          "version": "3.2.12",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+          "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.2",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.4"
+          }
         },
         "find-up": {
           "version": "6.3.0",
@@ -58089,6 +58205,25 @@
             "locate-path": "^7.1.0",
             "path-exists": "^5.0.0"
           }
+        },
+        "globby": {
+          "version": "13.1.3",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
+          "integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
+          "dev": true,
+          "requires": {
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.11",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^4.0.0"
+          }
+        },
+        "ignore": {
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+          "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+          "dev": true
         },
         "locate-path": {
           "version": "7.1.1",
@@ -58121,6 +58256,12 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
           "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+          "dev": true
+        },
+        "slash": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
           "dev": true
         },
         "yocto-queue": {
@@ -59033,6 +59174,12 @@
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
       "dev": true,
       "requires": {}
+    },
+    "eslint-formatter-kakoune": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-kakoune/-/eslint-formatter-kakoune-1.0.0.tgz",
+      "integrity": "sha512-Uk/TVLt6Nf6Xoz7C1iYuZjOSdJxe5aaauGRke8JhKeJwD66Y61/pY2FjtLP04Ooq9PwV34bzrkKkU2UZ5FtDRA==",
+      "dev": true
     },
     "eslint-plugin-ember": {
       "version": "10.6.1",
@@ -62475,12 +62622,12 @@
       "dev": true
     },
     "language-tags": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
-      "integrity": "sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.7.tgz",
+      "integrity": "sha512-bSytju1/657hFjgUzPAPqszxH62ouE8nQFoFaVlIQfne4wO/wXC9A4+m8jYve7YBBvi59eq0SUpcshvG8h5Usw==",
       "dev": true,
       "requires": {
-        "language-subtag-registry": "~0.3.2"
+        "language-subtag-registry": "^0.3.20"
       }
     },
     "latest-version": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "ember-router-service-refresh-polyfill": "^1.0.1",
     "ember-simple-auth": "^4.2.1",
     "ember-source": "~3.28.8",
-    "ember-template-lint": "^4.0.0",
+    "ember-template-lint": "^5.3.1",
     "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.0.0",
     "ember-unique-id-helper-polyfill": "^1.2.0",

--- a/tests/integration/components/shared/document-status-pill-test.js
+++ b/tests/integration/components/shared/document-status-pill-test.js
@@ -34,7 +34,7 @@ module(
     });
 
     test('it does not display a label if no status is passed', async function (assert) {
-      await render(hbs`{{shared/document-status-pill}}`);
+      await render(hbs`<Shared::DocumentStatusPill />`);
 
       assert.dom('[data-test-loket=document-status-pill]').doesNotIncludeText();
     });


### PR DESCRIPTION
This is also part of the v4 blueprint, but since we're still stuck on v3 this will at least prevent us from introducing new code that will be deprecated.