### PR TITLE
Use the `DD-MM-YYYY` format where needed

### DIFF
--- a/app/components/mandatenbeheer/mandataris-summary.hbs
+++ b/app/components/mandatenbeheer/mandataris-summary.hbs
@@ -12,9 +12,9 @@
   <div class="au-o-grid__item">
     <AuContent>
       <p class="au-c-info-text">
-        {{moment-format this.start 'DD/MM/YYYY'}} —
+        {{moment-format this.start 'DD-MM-YYYY'}} —
         {{#if this.einde}}
-          {{moment-format this.einde 'DD/MM/YYYY'}}
+          {{moment-format this.einde 'DD-MM-YYYY'}}
         {{else}}
           heden
         {{/if}}

--- a/app/components/mandatenbeheer/mandataris-table.hbs
+++ b/app/components/mandatenbeheer/mandataris-table.hbs
@@ -41,8 +41,8 @@
         {{row.bekleedt.bestuursfunctie.label}}
       </td>
       {{#unless @displaySubset}}
-        <td class="au-u-visible-medium-up">{{moment-format row.start 'DD/MM/YYYY'}}</td>
-        <td class="au-u-visible-medium-up">{{moment-format row.einde 'DD/MM/YYYY'}}</td>
+        <td class="au-u-visible-medium-up">{{moment-format row.start 'DD-MM-YYYY'}}</td>
+        <td class="au-u-visible-medium-up">{{moment-format row.einde 'DD-MM-YYYY'}}</td>
       {{/unless}}
       <td><LinkTo @route={{@editRoute}} @model={{row.isBestuurlijkeAliasVan.id}} class="au-c-link"> Bewerk </LinkTo></td>
     </c.body>

--- a/app/templates/eredienst-mandatenbeheer/mandataris/details.hbs
+++ b/app/templates/eredienst-mandatenbeheer/mandataris/details.hbs
@@ -35,7 +35,7 @@
           Startdatum
         </dt>
         <dd>
-          {{moment-format @model.start "DD/MM/YYYY"}}
+          {{moment-format @model.start "DD-MM-YYYY"}}
         </dd>
       </div>
       <div class="au-o-grid__item au-u-1-2">
@@ -43,7 +43,7 @@
         <dd>
           <ValueWithPlaceholder @value={{@model.einde}}>
             <:value as |value|>
-              {{moment-format value "DD/MM/YYYY"}}
+              {{moment-format value "DD-MM-YYYY"}}
             </:value>
           </ValueWithPlaceholder>
         </dd>
@@ -55,7 +55,7 @@
         <dd>
           <ValueWithPlaceholder @value={{@model.expectedEndDate}}>
             <:value as |value|>
-              {{moment-format value "DD/MM/YYYY"}}
+              {{moment-format value "DD-MM-YYYY"}}
             </:value>
           </ValueWithPlaceholder>
         </dd>

--- a/app/templates/eredienst-mandatenbeheer/mandataris/edit.hbs
+++ b/app/templates/eredienst-mandatenbeheer/mandataris/edit.hbs
@@ -107,7 +107,7 @@
     <div class="au-u-margin-bottom-small">
       <AuLabel for="mandate-expected-end-date">Geplande einddatum</AuLabel>
       <AuInput
-        @value={{if @model.expectedEndDate (moment-format @model.expectedEndDate 'DD.MM.YYYY') 'N/A'}}
+        @value={{if @model.expectedEndDate (moment-format @model.expectedEndDate 'DD-MM-YYYY') 'N/A'}}
         @disabled={{true}}
         @id="mandate-expected-end-date"
       />

--- a/app/templates/eredienst-mandatenbeheer/mandatarissen.hbs
+++ b/app/templates/eredienst-mandatenbeheer/mandatarissen.hbs
@@ -113,11 +113,11 @@
         </td>
         <td class="au-u-visible-medium-up">{{moment-format
             row.start
-            "DD/MM/YYYY"
+            "DD-MM-YYYY"
           }}</td>
         <td class="au-u-visible-medium-up">{{moment-format
             row.einde
-            "DD/MM/YYYY"
+            "DD-MM-YYYY"
           }}</td>
         <td>
           {{#if this.currentSession.hasViewOnlyWorshipMandateesManagementData}}

--- a/app/templates/eredienst-mandatenbeheer/new.hbs
+++ b/app/templates/eredienst-mandatenbeheer/new.hbs
@@ -130,7 +130,7 @@
         <div class="au-u-margin-bottom-small">
           <AuLabel for="mandate-expected-end-date">Geplande einddatum</AuLabel>
           <AuInput
-            @value={{if @model.worshipMandatee.expectedEndDate (moment-format @model.worshipMandatee.expectedEndDate 'DD.MM.YYYY') 'N/A'}}
+            @value={{if @model.worshipMandatee.expectedEndDate (moment-format @model.worshipMandatee.expectedEndDate 'DD-MM-YYYY') 'N/A'}}
             @disabled={{true}}
             @id="mandate-expected-end-date"
           />

--- a/app/templates/public-services/details.hbs
+++ b/app/templates/public-services/details.hbs
@@ -23,7 +23,7 @@
         <:content>
           <ValueWithPlaceholder @value={{@model.publicService.created}}>
             <:value as |value|>
-              {{moment-format value "DD.MM.YYYY - HH:mm"}}
+              {{moment-format value "DD-MM-YYYY - HH:mm"}}
             </:value>
           </ValueWithPlaceholder>
         </:content>
@@ -33,7 +33,7 @@
         <:content>
           <ValueWithPlaceholder @value={{@model.publicService.modified}}>
             <:value as |value|>
-              {{moment-format value "DD.MM.YYYY - HH:mm"}}
+              {{moment-format value "DD-MM-YYYY - HH:mm"}}
             </:value>
           </ValueWithPlaceholder>
         </:content>
@@ -43,7 +43,7 @@
         <:content>
           <ValueWithPlaceholder @value={{@model.publicService.startDate}}>
             <:value as |value|>
-              {{moment-format value "DD.MM.YYYY"}}
+              {{moment-format value "DD-MM-YYYY"}}
             </:value>
           </ValueWithPlaceholder>
         </:content>
@@ -53,7 +53,7 @@
         <:content>
           <ValueWithPlaceholder @value={{@model.publicService.endDate}}>
             <:value as |value|>
-              {{moment-format value "DD.MM.YYYY"}}
+              {{moment-format value "DD-MM-YYYY"}}
             </:value>
           </ValueWithPlaceholder>
         </:content>

--- a/app/templates/supervision/submissions/index.hbs
+++ b/app/templates/supervision/submissions/index.hbs
@@ -32,8 +32,8 @@
       <td>
         <p class="au-c-info-text"> <Supervision::SubmissionType @formData={{row.formData}} /></p>
       </td>
-      <td class="au-u-visible-small-up">{{moment-format row.formData.sessionStartedAtTime "DD/MM/YYYY"}}</td>
-      <td class="au-u-visible-large-up">{{moment-format row.sentDate "DD/MM/YYYY"}}</td>
+      <td class="au-u-visible-small-up">{{moment-format row.formData.sessionStartedAtTime "DD-MM-YYYY"}}</td>
+      <td class="au-u-visible-large-up">{{moment-format row.sentDate "DD-MM-YYYY"}}</td>
       <td class="au-u-visible-medium-up">
         {{#if row.job.created }}
           Automatisch aangemaakt bij publicatie

--- a/app/templates/worship-ministers-management/index.hbs
+++ b/app/templates/worship-ministers-management/index.hbs
@@ -55,8 +55,8 @@
       <td>{{minister.ministerPosition.function.label}}</td>
       <td>{{minister.person.gebruikteVoornaam}}</td>
       <td>{{minister.person.achternaam}}</td>
-      <td>{{moment-format minister.agentStartDate "DD/MM/YYYY"}}</td>
-      <td>{{moment-format minister.agentEndDate "DD/MM/YYYY"}}</td>
+      <td>{{moment-format minister.agentStartDate "DD-MM-YYYY"}}</td>
+      <td>{{moment-format minister.agentEndDate "DD-MM-YYYY"}}</td>
       <td class="u-table-cell-fit-content">
         {{#if this.currentSession.hasViewOnlyWorshipMinistersManagementData}}
           <AuLink

--- a/app/templates/worship-ministers-management/minister/details.hbs
+++ b/app/templates/worship-ministers-management/minister/details.hbs
@@ -33,7 +33,7 @@
       <div class="au-o-grid__item au-u-1-2">
         <dt class="au-c-label">Startdatum</dt>
         <dd>
-          {{moment-format @model.agentStartDate "DD/MM/YYYY"}}
+          {{moment-format @model.agentStartDate "DD-MM-YYYY"}}
         </dd>
       </div>
       <div class="au-o-grid__item au-u-1-2">
@@ -41,7 +41,7 @@
         <dd>
           <ValueWithPlaceholder @value={{@model.agentEndDate}}>
             <:value as |value|>
-              {{moment-format value "DD/MM/YYYY"}}
+              {{moment-format value "DD-MM-YYYY"}}
             </:value>
           </ValueWithPlaceholder>
         </dd>


### PR DESCRIPTION
We officially switched to the `DD-MM-YYYY` format, but there were still some other formats in use. This should make them all consistent again.