### PR TITLE
LPDC: Implement the basic "change notification" system

### DIFF
--- a/app/components/public-services/details-page.hbs
+++ b/app/components/public-services/details-page.hbs
@@ -40,7 +40,7 @@
   {{/if}}
 </AuBodyContainer>
 
-<AuToolbar @border="top" @size="large" as |Group|>
+<AuToolbar @border="top" @size="medium" as |Group|>
   <Group>
     <AuButtonGroup>
       {{#if @readOnly}}

--- a/app/controllers/public-services/details.js
+++ b/app/controllers/public-services/details.js
@@ -1,0 +1,24 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { dropTask } from 'ember-concurrency';
+import { isConceptUpdated } from 'frontend-loket/models/public-service';
+
+export default class PublicServicesDetailsController extends Controller {
+  // We use a separate flag, otherwise the message would be hidden before the save was actually completed
+  @tracked reviewStatus;
+  isConceptUpdated = isConceptUpdated;
+
+  get showReviewRequiredMessage() {
+    return Boolean(this.reviewStatus);
+  }
+
+  @dropTask
+  *markAsReviewed() {
+    let { publicService } = this.model;
+    publicService.reviewStatus = null;
+
+    yield publicService.save();
+
+    this.reviewStatus = null;
+  }
+}

--- a/app/controllers/public-services/index.js
+++ b/app/controllers/public-services/index.js
@@ -1,12 +1,23 @@
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { restartableTask, timeout } from 'ember-concurrency';
+import { serviceNeedsReview } from 'frontend-loket/models/public-service';
 
 export default class PublicServicesIndexController extends Controller {
-  queryParams = ['search', 'sort', 'page'];
+  queryParams = [
+    'search',
+    'sort',
+    'page',
+    {
+      isReviewRequiredFilterEnabled: 'review',
+    },
+  ];
   @tracked search = '';
   @tracked sort = '-modified';
   @tracked page = 0;
+  @tracked isReviewRequiredFilterEnabled = false;
+  serviceNeedsReview = serviceNeedsReview;
 
   get publicServices() {
     if (this.model.loadPublicServices.isFinished) {
@@ -50,6 +61,16 @@ export default class PublicServicesIndexController extends Controller {
     yield timeout(500);
 
     this.search = searchValue;
+    this.resetPagination();
+  }
+
+  @action
+  toggleReviewRequiredFilter() {
+    this.isReviewRequiredFilterEnabled = !this.isReviewRequiredFilterEnabled;
+    this.resetPagination();
+  }
+
+  resetPagination() {
     this.page = 0;
   }
 }

--- a/app/models/public-service.js
+++ b/app/models/public-service.js
@@ -5,10 +5,32 @@ export default class PublicServiceModel extends ConceptualPublicServiceModel {
   @belongsTo('conceptual-public-service', { inverse: null })
   concept;
 
+  @belongsTo('concept', { async: false, inverse: null })
+  reviewStatus;
+
   get isSent() {
     return (
-      this.status.uri ===
+      this.status?.uri ===
       'http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c'
     );
   }
+}
+
+export function serviceNeedsReview(publicService) {
+  return Boolean(publicService.reviewStatus);
+}
+
+const REVIEW_STATUS = {
+  UPDATED:
+    'http://lblod.data.gift/concepts/5a3168e2-f39b-4b5d-8638-29f935023c83',
+  DELETED:
+    'http://lblod.data.gift/concepts/cf22e8d1-23c3-45da-89bc-00826eaf23c3',
+};
+
+export function isConceptUpdated(reviewStatus) {
+  return reviewStatus?.uri === REVIEW_STATUS.UPDATED;
+}
+
+export function isConceptDeleted(reviewStatus) {
+  return reviewStatus?.uri === REVIEW_STATUS.DELETED;
 }

--- a/app/routes/public-services/details.js
+++ b/app/routes/public-services/details.js
@@ -7,13 +7,19 @@ export default class PublicServicesDetailsRoute extends Route {
 
   async model({ serviceId }) {
     const publicService = await loadPublicServiceDetails(this.store, serviceId);
-    const status = await publicService.status;
     const readOnly =
-      status.uri !==
+      publicService.status.uri !==
       'http://lblod.data.gift/concepts/79a52da4-f491-4e2f-9374-89a13cde8ecd';
+
     return {
       publicService,
       readOnly,
     };
+  }
+
+  setupController(controller, { publicService }) {
+    super.setupController(...arguments);
+
+    controller.reviewStatus = publicService.reviewStatus;
   }
 }

--- a/app/routes/public-services/index.js
+++ b/app/routes/public-services/index.js
@@ -17,6 +17,9 @@ export default class PublicServicesIndexRoute extends Route {
     sort: {
       refreshModel: true,
     },
+    isReviewRequiredFilterEnabled: {
+      refreshModel: true,
+    },
   };
 
   async model(params) {
@@ -27,7 +30,12 @@ export default class PublicServicesIndexRoute extends Route {
   }
 
   @restartableTask
-  *loadPublicServicesTask({ search, page, sort }) {
+  *loadPublicServicesTask({
+    search,
+    page,
+    sort,
+    isReviewRequiredFilterEnabled,
+  }) {
     let query = {
       'filter[created-by][:uri:]': this.currentSession.group.uri,
       'page[number]': page,
@@ -41,6 +49,10 @@ export default class PublicServicesIndexRoute extends Route {
       query.sort = sort;
     }
 
+    if (isReviewRequiredFilterEnabled) {
+      query['filter[:has:review-status]'] = true;
+    }
+
     let publicServices = yield this.store.query('public-service', query);
 
     let promises = [];
@@ -49,7 +61,8 @@ export default class PublicServicesIndexRoute extends Route {
         service.hasMany('targetAudiences').reload(),
         service.hasMany('executingAuthorityLevels').reload(),
         service.belongsTo('type').reload(),
-        service.belongsTo('status').reload()
+        service.belongsTo('status').reload(),
+        service.belongsTo('reviewStatus').reload()
       );
     });
 

--- a/app/serializers/public-service.js
+++ b/app/serializers/public-service.js
@@ -1,6 +1,6 @@
 import ApplicationSerializer from './application';
 
-export const ALLOWED_FIELDS = ['concept', 'modified', 'status'];
+export const ALLOWED_FIELDS = ['concept', 'modified', 'status', 'reviewStatus'];
 
 export default class PublicServiceSerializer extends ApplicationSerializer {
   serializeAttribute(snapshot, json, attributeName) {

--- a/app/templates/public-services/details.hbs
+++ b/app/templates/public-services/details.hbs
@@ -9,8 +9,13 @@
   </Group>
 </AuToolbar>
 
-<AuToolbar @border="bottom" @size="large" as |Group|>
-  <Group>
+<AuToolbar
+  @border="bottom"
+  @size="medium"
+  class="au-u-flex au-u-flex--vertical-start"
+  as |Group|
+>
+  <Group class="au-u-margin-bottom-small">
     <DataList as |Data|>
       <Data>
         <:title>Product type</:title>
@@ -62,16 +67,61 @@
         <:title>Status document</:title>
         <:content>
           {{#if @model.publicService.status.label}}
-          <PublicServices::Status @uri={{@model.publicService.status.uri}}>
-            {{@model.publicService.status.label}}
-          </PublicServices::Status>
+            <PublicServices::Status @uri={{@model.publicService.status.uri}}>
+              {{@model.publicService.status.label}}
+            </PublicServices::Status>
           {{else}}
-          –
+            –
           {{/if}}
         </:content>
       </Data>
     </DataList>
   </Group>
+
+  {{#if (or this.showReviewRequiredMessage this.markAsReviewed.isRunning)}}
+    <Group>
+      <AuAlert
+        @title="Herziening nodig"
+        @skin="warning"
+        @icon="alert-triangle"
+        @size="small"
+        class="au-u-margin-bottom-none"
+      >
+        <p>
+          {{#if (this.isConceptUpdated @model.publicService.reviewStatus)}}
+            Het concept waarop dit product is gebaseerd, werd aangepast. Gelieve
+            na te kijken of je deze versie ook wil aanpassen.
+          {{else}}
+            Het concept waarop dit product is gebaseerd, werd verwijderd.
+            Gelieve na te kijken of je deze versie ook wil verwijderen.
+          {{/if}}
+        </p>
+        <div class="au-u-margin-top-small">
+          <AuButtonGroup>
+            <AuLink
+              @route="public-services.concept-details"
+              @model={{@model.publicService.concept.id}}
+              @skin="button"
+              @icon="eye"
+              target="blank"
+            >
+              Concept bekijken
+            </AuLink>
+            <AuButton
+              @skin="secondary"
+              @icon="check"
+              @disabled={{this.markAsReviewed.isRunning}}
+              @loading={{this.markAsReviewed.isRunning}}
+              @loadingMessage="Aan het verwerken"
+              {{on "click" (perform this.markAsReviewed)}}
+            >
+              Geen aanpassingen nodig
+            </AuButton>
+          </AuButtonGroup>
+        </div>
+      </AuAlert>
+    </Group>
+  {{/if}}
 </AuToolbar>
 
 <AuTabs as |Tab|>

--- a/app/templates/public-services/index.hbs
+++ b/app/templates/public-services/index.hbs
@@ -1,23 +1,25 @@
-<AuToolbar @border="bottom" @size="large" @nowrap={{true}} as |Group|>
+<AuToolbar @size="large" as |Group|>
   <Group>
     <AuHeading @skin="2" data-test-loket="public-services-page-title">
       Producten- en dienstencatalogus
     </AuHeading>
   </Group>
   <Group class="au-u-flex au-u-flex--vertical-center">
-    <label for="search" class="au-u-hidden-visually">Vul uw zoekterm in</label>
+    <div>
+      <label for="search" class="au-u-hidden-visually">Vul uw zoekterm in</label>
 
-    {{! TODO: Replace this with `AuInput` once we get rid of 2-way-binding }}
-    <span class="au-c-input-wrapper au-c-input-wrapper--left">
-      <AuIcon @icon="search" />
-      <input
-        value={{this.search}}
-        id="search"
-        class="au-c-input"
-        placeholder="Vul uw zoekterm in"
-        {{on "input" (perform this.searchTask value="target.value")}}
-      />
-    </span>
+      {{! TODO: Replace this with `AuInput` once we get rid of 2-way-binding }}
+      <span class="au-c-input-wrapper au-c-input-wrapper--left">
+        <AuIcon @icon="search" />
+        <input
+          value={{this.search}}
+          id="search"
+          class="au-c-input"
+          placeholder="Vul uw zoekterm in"
+          {{on "input" (perform this.searchTask value="target.value")}}
+        />
+      </span>
+    </div>
     <AuLink
       @route="public-services.add"
       @icon="add"
@@ -26,6 +28,19 @@
     >
       Product of dienst toevoegen
     </AuLink>
+  </Group>
+</AuToolbar>
+
+<AuToolbar @border="bottom" @size="medium" as |Group|>
+  <Group class="au-u-flex au-u-flex--vertical-center">
+    <AuToggleSwitch
+      @label="Herziening nodig"
+      @checked={{this.isReviewRequiredFilterEnabled}}
+      @onChange={{this.toggleReviewRequiredFilter}}
+    />
+    <AuHelpText @skin="tertiary" class="au-u-margin-top-none">
+      Toon enkel producten waarvan het concept aangepast of verwijderd werd.
+    </AuHelpText>
   </Group>
 </AuToolbar>
 
@@ -94,7 +109,15 @@
       </tr>
     {{else if this.hasResults}}
       <Content.body as |publicService|>
-        <td>{{! template-lint-disable no-triple-curlies~}} {{{publicService.nameNl}}}</td>
+        <td>
+          {{! template-lint-disable no-triple-curlies~}}
+          {{{publicService.nameNl}}}
+          {{#if (this.serviceNeedsReview publicService)}}
+            <AuPill @skin="warning" @size="small" @icon="alert-triangle">
+              Herziening nodig
+            </AuPill>
+          {{/if}}
+        </td>
         <td>{{publicService.type.label}}</td>
         <td>
           {{#each publicService.targetAudiences as |tag|}}
@@ -122,9 +145,7 @@
              </td> --}}
         <td>
           {{#if publicService.status.uri}}
-            <PublicServices::Status
-              @uri={{publicService.status.uri}}
-            >
+            <PublicServices::Status @uri={{publicService.status.uri}}>
               {{publicService.status.label}}
             </PublicServices::Status>
           {{else}}
@@ -132,15 +153,15 @@
           {{/if}}
         </td>
         <td class="u-table-cell-fit-content">
-              <AuLink
-                @icon={{if publicService.isSent "eye" "pencil"}}
-                @iconAlignment="left"
-                @skin="primary"
-                @route="public-services.details"
-                @model={{publicService.id}}
-              >
-                {{if publicService.isSent "Bekijk" "Bewerk"}}
-              </AuLink>
+          <AuLink
+            @icon={{if publicService.isSent "eye" "pencil"}}
+            @iconAlignment="left"
+            @skin="primary"
+            @route="public-services.details"
+            @model={{publicService.id}}
+          >
+            {{if publicService.isSent "Bekijk" "Bewerk"}}
+          </AuLink>
         </td>
       </Content.body>
     {{else}}

--- a/app/utils/public-services.js
+++ b/app/utils/public-services.js
@@ -1,6 +1,6 @@
 export function loadPublicServiceDetails(store, publicServiceId) {
   return store.findRecord('public-service', publicServiceId, {
     reload: true,
-    include: 'type,status',
+    include: 'concept,type,status,review-status',
   });
 }


### PR DESCRIPTION
On the overview page we now show a label if the concept was changed. It's also possible to display only the services that have underlying changes to make it easier for the user.

On the details page we now show an alert if the concept is changed (with slightly different text based on the type of change) with a link to the concept details page, and a button to mark the service as reviewed.

**Testing**
This branch is needed: https://github.com/lblod/app-digitaal-loket/pull/320
The easiest way to test this is to add some temporary code to the public-services.details route model hook:

```js
  async model({ serviceId }) {
    const publicService = await loadPublicServiceDetails(this.store, serviceId);
   
    // "Updated" status
    let status = await this.store.findRecord('concept', '5a3168e2-f39b-4b5d-8638-29f935023c83');
    // or "Deleted" status
    // let status = yield this.store.findRecord('concept', 'cf22e8d1-23c3-45da-89bc-00826eaf23c3');
    publicService.reviewStatus = status;
    await publicService.save();
   
   //...
```
You can then browse to the details page of the service you want to give a certain state. Once the state is updated you can comment it again and refresh the page.