### PR TITLE
Hide the "Concept bekijken" button when the concept was deleted

### DIFF
--- a/app/templates/public-services/details.hbs
+++ b/app/templates/public-services/details.hbs
@@ -98,15 +98,17 @@
         </p>
         <div class="au-u-margin-top-small">
           <AuButtonGroup>
-            <AuLink
-              @route="public-services.concept-details"
-              @model={{@model.publicService.concept.id}}
-              @skin="button"
-              @icon="eye"
-              target="blank"
-            >
-              Concept bekijken
-            </AuLink>
+            {{#if (this.isConceptUpdated @model.publicService.reviewStatus)}}
+              <AuLink
+                @route="public-services.concept-details"
+                @model={{@model.publicService.concept.id}}
+                @skin="button"
+                @icon="eye"
+                target="blank"
+              >
+                Concept bekijken
+              </AuLink>
+            {{/if}}
             <AuButton
               @skin="secondary"
               @icon="check"


### PR DESCRIPTION
This button doesn't make sense for the deleted status since there is no concept to link to anymore 😄.