### PR TITLE
[Bedienarenbeheer] Add permanent alert

### DIFF
--- a/app/templates/worship-ministers-management/index.hbs
+++ b/app/templates/worship-ministers-management/index.hbs
@@ -11,7 +11,9 @@
   {{/unless}}
 </AuToolbar>
 
-<AuAlert @skin="warning" @icon="alert-triangle" @size="small">Behoort u tot een rooms-katholiek bestuur van de eredienst? Het (aarts)bisdom zal de gegevens van de bedienaren beheren. U dient dus géén bedienaren te registreren.</AuAlert>
+<AuAlert @skin="warning" @icon="alert-triangle" @size="small">Behoort u tot een rooms-katholiek bestuur van de eredienst? Het (aarts)bisdom zal de gegevens van de bedienaren beheren. U dient dus géén bedienaren te registreren. Meer informatie hierover vindt u in de <AuLinkExternal
+      href="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/bedienarenbeheer#registratievrijstelling-voor-rooms-katholieke-besturen-van-de-eredienst"
+    >handleiding</AuLinkExternal>.</AuAlert>
 
 <AuDataTable
   @content={{this.model}}

--- a/app/templates/worship-ministers-management/index.hbs
+++ b/app/templates/worship-ministers-management/index.hbs
@@ -11,6 +11,8 @@
   {{/unless}}
 </AuToolbar>
 
+<AuAlert @skin="warning" @icon="alert-triangle" @size="small">Behoort u tot een rooms-katholiek bestuur van de eredienst? Het (aarts)bisdom zal de gegevens van de bedienaren beheren. U dient dus géén bedienaren te registreren.</AuAlert>
+
 <AuDataTable
   @content={{this.model}}
   @isLoading={{this.isLoadingModel}}


### PR DESCRIPTION
DL-4759

Adding permanent alert in `/bedienarenbeheer` page with the following text “Behoort u tot een rooms-katholiek bestuur van de eredienst? Het (aarts)bisdom zal de gegevens van de bedienaren beheren. U dient dus géén bedienaren te registreren.”  

Adding text "Meer informatie hierover vindt u in de handleiding." with an `<AuLinkExternal>` to the manual. (edit)

~~It's not mentioned, but do we add "Meer informatie over in handleiding" with an external link to the gitbook ?~~