### PR TITLE
[Eredienst-bedienarenbeheer] Replacing mandatarisgegevens by bedienarengegevens

### DIFF
--- a/app/templates/worship-ministers-management/minister/details.hbs
+++ b/app/templates/worship-ministers-management/minister/details.hbs
@@ -21,7 +21,7 @@
   </AuToolbar>
 
 <AuBodyContainer @scroll={{true}}>
-  <AuAlert @icon="alert-triangle" @skin="warning" @size="small">Deze mandatarisgegevens zijn alleen leesbaar. Je kunt ze niet bewerken want ze worden beheerd door uw softwareleverancier.</AuAlert>
+  <AuAlert @icon="alert-triangle" @skin="warning" @size="small">Deze bedienarengegevens zijn alleen leesbaar. Je kunt ze niet bewerken want ze worden beheerd door uw softwareleverancier.</AuAlert>
   <dl class="au-u-2-3@medium au-o-box">
     <div class="au-u-margin-bottom-small">
       <dt class="au-c-label">Functienaam</dt>


### PR DESCRIPTION
DL-4680

Fixing typo, the following alert message is now changed to "Deze bedienarengegevens zijn alleen leesbaar. Je kunt ze niet bewerken want ze worden beheerd door uw softwareleverancier."