### PR TITLE
Remove the "Jos" placeholder

### DIFF
--- a/app/components/shared/persoon/create-persoon.hbs
+++ b/app/components/shared/persoon/create-persoon.hbs
@@ -58,7 +58,6 @@
           @width="block"
           id="mandataris-roepnaam"
           name="mandataris-roepnaam"
-          placeholder="Jos"
         />
       </div>
       <div>


### PR DESCRIPTION
It looks a bit out-of-place since the other fields don't have placeholders either and arguably looks a bit unprofessional as well.