### PR TITLE
Add productID to both index and add pages for public services

### DIFF
--- a/app/models/conceptual-public-service.js
+++ b/app/models/conceptual-public-service.js
@@ -2,6 +2,7 @@ import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export default class ConceptualPublicServiceModel extends Model {
   @attr uri;
+  @attr productId;
   @attr('language-string-set') name;
   @attr('datetime') startDate;
   @attr('datetime') endDate;

--- a/app/templates/public-services/add.hbs
+++ b/app/templates/public-services/add.hbs
@@ -44,7 +44,7 @@
         @currentSorting={{this.sort}}
         @label="Productnaam"
       />
-      <th>ProductID</th>
+      <th>IPDC Concept ID</th>
       <AuDataTableThSortable
         @field="type"
         @currentSorting={{this.sort}}

--- a/app/templates/public-services/add.hbs
+++ b/app/templates/public-services/add.hbs
@@ -44,6 +44,7 @@
         @currentSorting={{this.sort}}
         @label="Productnaam"
       />
+      <th>ProductID</th>
       <AuDataTableThSortable
         @field="type"
         @currentSorting={{this.sort}}
@@ -95,6 +96,7 @@
             {{{publicService.nameNl}}}
           </AuLink>
         </td>
+        <td>{{publicService.productId}}</td>
         <td>{{publicService.type.label}}</td>
         <td>
           {{#each publicService.targetAudiences as |targetAudience|}}

--- a/app/templates/public-services/details.hbs
+++ b/app/templates/public-services/details.hbs
@@ -25,7 +25,6 @@
                   <AuLink
                     @route="public-services.concept-details"
                     @model={{@model.publicService.concept.id}}
-                    @query={{hash preview=true}}
                   >
                     {{productId}}
                   </AuLink>

--- a/app/templates/public-services/details.hbs
+++ b/app/templates/public-services/details.hbs
@@ -20,13 +20,17 @@
         <Data>
           <:title>IPDC Concept ID</:title>
           <:content>
-            <AuLink
-              @route="public-services.concept-details"
-              @model={{@model.publicService.concept.id}}
-              @query={{hash preview=true}}
-            >
-              <ValueWithPlaceholder @value={{@model.publicService.concept.productId}} />
-            </AuLink>
+            <ValueWithPlaceholder @value={{@model.publicService.concept.productId}}>
+                <:value as |productId|>
+                  <AuLink
+                    @route="public-services.concept-details"
+                    @model={{@model.publicService.concept.id}}
+                    @query={{hash preview=true}}
+                  >
+                    {{productId}}
+                  </AuLink>
+                </:value>
+            </ValueWithPlaceholder>
           </:content>
         </Data>
       <Data>

--- a/app/templates/public-services/details.hbs
+++ b/app/templates/public-services/details.hbs
@@ -17,6 +17,18 @@
 >
   <Group class="au-u-margin-bottom-small">
     <DataList as |Data|>
+        <Data>
+          <:title>IPDC Concept ID</:title>
+          <:content>
+            <AuLink
+              @route="public-services.concept-details"
+              @model={{@model.publicService.concept.id}}
+              @query={{hash preview=true}}
+            >
+              <ValueWithPlaceholder @value={{@model.publicService.concept.productId}} />
+            </AuLink>
+          </:content>
+        </Data>
       <Data>
         <:title>Product type</:title>
         <:content>

--- a/app/templates/public-services/index.hbs
+++ b/app/templates/public-services/index.hbs
@@ -56,9 +56,6 @@
       <th>
         Productnaam
       </th>
-      <th>
-        ProductID
-      </th>
       <AuDataTableThSortable
         @field="type"
         @currentSorting={{this.sort}}
@@ -121,7 +118,6 @@
             </AuPill>
           {{/if}}
         </td>
-        <td>{{publicService.productId}}</td>
         <td>{{publicService.type.label}}</td>
         <td>
           {{#each publicService.targetAudiences as |tag|}}

--- a/app/templates/public-services/index.hbs
+++ b/app/templates/public-services/index.hbs
@@ -56,6 +56,9 @@
       <th>
         Productnaam
       </th>
+      <th>
+        ProductID
+      </th>
       <AuDataTableThSortable
         @field="type"
         @currentSorting={{this.sort}}
@@ -118,6 +121,7 @@
             </AuPill>
           {{/if}}
         </td>
+        <td>{{publicService.productId}}</td>
         <td>{{publicService.type.label}}</td>
         <td>
           {{#each publicService.targetAudiences as |tag|}}


### PR DESCRIPTION
(Addresses DL-4551) Allows productID to be visible for users in the index and add pages of the services module.