### PR TITLE
Ensure the order is maintained when creating multiple listing items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@lblod/ember-acmidm-login": "^1.4.0",
         "@lblod/ember-mock-login": "^0.7.0",
         "@lblod/ember-rdfa-editor": "^2.1.0",
-        "@lblod/ember-submission-form-fields": "^2.6.0",
+        "@lblod/ember-submission-form-fields": "^2.7.0",
         "@lblod/submission-form-helpers": "^2.2.0",
         "broccoli-asset-rev": "^3.0.0",
         "browser-update": "^3.3.38",
@@ -5466,9 +5466,9 @@
       }
     },
     "node_modules/@lblod/ember-submission-form-fields": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.6.0.tgz",
-      "integrity": "sha512-kSqoaVfJzHOZ86LRnfPU4Kr88AJ2whBhcGRQ4nuNTfzLbfYkN4c7zOEsga1k9WqXptuQTf161QKS+Ed0grhTEQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.7.0.tgz",
+      "integrity": "sha512-p9hwnNf1hsD9wdr36fAWHNfugkJLFrwfI/PfunDlbnx9s01oeaO/p+fmKR3XiUy6gQSDZAB2wm4lWna67vytNA==",
       "dev": true,
       "dependencies": {
         "@lblod/submission-form-helpers": "^2.0.1",
@@ -43582,9 +43582,9 @@
       }
     },
     "@lblod/ember-submission-form-fields": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.6.0.tgz",
-      "integrity": "sha512-kSqoaVfJzHOZ86LRnfPU4Kr88AJ2whBhcGRQ4nuNTfzLbfYkN4c7zOEsga1k9WqXptuQTf161QKS+Ed0grhTEQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.7.0.tgz",
+      "integrity": "sha512-p9hwnNf1hsD9wdr36fAWHNfugkJLFrwfI/PfunDlbnx9s01oeaO/p+fmKR3XiUy6gQSDZAB2wm4lWna67vytNA==",
       "dev": true,
       "requires": {
         "@lblod/submission-form-helpers": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@lblod/ember-acmidm-login": "^1.4.0",
     "@lblod/ember-mock-login": "^0.7.0",
     "@lblod/ember-rdfa-editor": "^2.1.0",
-    "@lblod/ember-submission-form-fields": "^2.6.0",
+    "@lblod/ember-submission-form-fields": "^2.7.0",
     "@lblod/submission-form-helpers": "^2.2.0",
     "broccoli-asset-rev": "^3.0.0",
     "browser-update": "^3.3.38",


### PR DESCRIPTION
This updates ember-submission-form-fields to v2.7 which includes the "order" feature. New listing items will receive an order, so they can be rendered consistently after reloads.