### PR TITLE
Implement the new end date prefill logic

### DIFF
--- a/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
+++ b/app/controllers/eredienst-mandatenbeheer/mandataris/edit.js
@@ -9,7 +9,7 @@ import {
   findPrimaryContactPoint,
   isValidPrimaryContact,
 } from 'frontend-loket/models/contact-punt';
-import { setEndDates } from 'frontend-loket/utils/eredienst-mandatenbeheer';
+import { setMandate } from 'frontend-loket/utils/eredienst-mandatenbeheer';
 import { validateMandaat } from 'frontend-loket/models/worship-mandatee';
 import { combineFullAddress, isValidAdres } from 'frontend-loket/models/adres';
 export default class EredienstMandatenbeheerMandatarisEditController extends Controller {
@@ -30,8 +30,7 @@ export default class EredienstMandatenbeheerMandatarisEditController extends Con
 
   @action
   async setMandaat(mandaat) {
-    this.model.bekleedt = mandaat;
-    const maybeWarning = await setEndDates(this.store, this.model, mandaat);
+    const maybeWarning = await setMandate(this.store, this.model, mandaat);
 
     if (maybeWarning) {
       this.warningMessages = maybeWarning;

--- a/app/controllers/eredienst-mandatenbeheer/new.js
+++ b/app/controllers/eredienst-mandatenbeheer/new.js
@@ -10,7 +10,7 @@ import {
   isValidPrimaryContact,
 } from 'frontend-loket/models/contact-punt';
 import { validateMandaat } from 'frontend-loket/models/worship-mandatee';
-import { setEndDates } from 'frontend-loket/utils/eredienst-mandatenbeheer';
+import { setMandate } from 'frontend-loket/utils/eredienst-mandatenbeheer';
 
 export default class EredienstMandatenbeheerNewController extends Controller {
   @service router;
@@ -59,9 +59,7 @@ export default class EredienstMandatenbeheerNewController extends Controller {
   @action
   async setMandaat(mandaat) {
     const { worshipMandatee } = this.model;
-    worshipMandatee.bekleedt = mandaat;
-    worshipMandatee.errors.remove('bekleedt');
-    const maybeWarnings = await setEndDates(
+    const maybeWarnings = await setMandate(
       this.store,
       worshipMandatee,
       mandaat

--- a/app/templates/eredienst-mandatenbeheer/mandataris/edit.hbs
+++ b/app/templates/eredienst-mandatenbeheer/mandataris/edit.hbs
@@ -60,7 +60,7 @@
       {{/if}}
       {{/let}}
     </div>
-    <div class="au-o-grid au-o-grid--tiny au-u-margin-bottom-small">
+    <div class="au-o-grid au-o-grid--tiny au-o-grid--right au-u-margin-bottom-small">
       <div class="au-o-grid__item au-u-1-2">
       {{#let (if @model.errors.start true false) as |showError|}}
         <AuLabel for="mandate-correction-start-date"
@@ -114,17 +114,20 @@
           {{/if}}
         {{/let}}
       </div>
+      {{#if @model.bekleedt}}
+        <div class="au-o-grid__item au-u-1-2">
+          <div class="au-u-margin-bottom-small">
+            <AuLabel for="mandate-expected-end-date">Geplande einddatum</AuLabel>
+            <AuInput
+              @value={{if @model.expectedEndDate (moment-format @model.expectedEndDate 'DD-MM-YYYY') 'N/A'}}
+              @disabled={{true}}
+              @id="mandate-expected-end-date"
+              @width="block"
+            />
+          </div>
+        </div>
+      {{/if}}
     </div>
-    {{#if @model.bekleedt}}
-    <div class="au-u-margin-bottom-small">
-      <AuLabel for="mandate-expected-end-date">Geplande einddatum</AuLabel>
-      <AuInput
-        @value={{if @model.expectedEndDate (moment-format @model.expectedEndDate 'DD-MM-YYYY') 'N/A'}}
-        @disabled={{true}}
-        @id="mandate-expected-end-date"
-      />
-    </div>
-    {{/if}}
   </div>
 
   <AuHr @size="small" />

--- a/app/templates/eredienst-mandatenbeheer/new.hbs
+++ b/app/templates/eredienst-mandatenbeheer/new.hbs
@@ -81,8 +81,8 @@
         {{/let}}
       </div>
 
-      <div class="au-o-grid au-o-grid--tiny au-u-margin-bottom-small">
-        <div class="au-o-grid__item au-u-1-2">
+      <div class="au-o-grid au-o-grid--tiny au-o-grid--right au-u-margin-bottom-small">
+        <div class="au-o-grid__item au-u-1-2@small">
         {{#let (if @model.worshipMandatee.errors.start true false) as |showError|}}
           <AuLabel for="mandate-start-date"
             @error={{showError}}
@@ -107,7 +107,7 @@
         {{/let}}
         </div>
 
-        <div class="au-o-grid__item au-u-1-2">
+        <div class="au-o-grid__item au-u-1-2@small">
           {{#let
             (if @model.worshipMandatee.errors.einde true false)
             (if this.warningMessages.einde true false)
@@ -136,18 +136,21 @@
             {{/if}}
           {{/let}}
         </div>
-      </div>
-
-      {{#if @model.worshipMandatee.bekleedt}}
-        <div class="au-u-margin-bottom-small">
-          <AuLabel for="mandate-expected-end-date">Geplande einddatum</AuLabel>
-          <AuInput
-            @value={{if @model.worshipMandatee.expectedEndDate (moment-format @model.worshipMandatee.expectedEndDate 'DD-MM-YYYY') 'N/A'}}
-            @disabled={{true}}
-            @id="mandate-expected-end-date"
-          />
-        </div>
+        {{#if @model.worshipMandatee.bekleedt}}
+          <div class="au-o-grid__item au-u-1-2@small">
+            <div class="au-u-margin-bottom-small">
+              <AuLabel for="mandate-expected-end-date">Geplande einddatum</AuLabel>
+              <AuInput
+                @icon="calendar"
+                @value={{if @model.worshipMandatee.expectedEndDate (moment-format @model.worshipMandatee.expectedEndDate 'DD-MM-YYYY') 'N/A'}}
+                @disabled={{true}}
+                @id="mandate-expected-end-date"
+                @width="block"
+              />
+            </div>
+          </div>
         {{/if}}
+      </div>
     </div>
 
     <AuHr @size="small" />

--- a/app/utils/eredienst-mandatenbeheer.js
+++ b/app/utils/eredienst-mandatenbeheer.js
@@ -6,35 +6,102 @@ import { isSameIsoDate } from './date';
  * so the greatest binding-einde is the expectedEndDate for each selected mandate.
  * @returns an object with warning messages as properties if any warnings need to be shown
  */
-export async function setEndDates(store, mandataris, mandaat) {
-  const lifetimeMandate =
-    'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5972fccd87f864c4ec06bfbd20b5008b'; // Bestuurslid (van rechtswege) is a lifetime mandate
+export async function setMandate(store, mandataris, mandaat) {
+  const currentMandate = await mandataris.bekleedt;
+  const hasCurrentMandate = Boolean(currentMandate);
+
   let bestuursfunctie = await mandaat.bestuursfunctie;
 
   const currentEndDate = mandataris.einde;
+  const currentExpectedEndDate = mandataris.expectedEndDate;
+  const isCurrentlyEmpty = !currentEndDate;
+  const wasDateChangedManually =
+    hasCurrentMandate && !isSameIsoDate(currentEndDate, currentExpectedEndDate);
+
   let warnings;
 
-  if (bestuursfunctie.uri === lifetimeMandate) {
-    mandataris.expectedEndDate = undefined;
-    mandataris.einde = undefined;
-  } else {
-    let bestuursorganenInTijd = await store.query('bestuursorgaan', {
-      'filter[bevat][:uri:]': mandaat.uri,
-      sort: '-binding-start',
-    });
-    let plannedEndDates = bestuursorganenInTijd.map(
-      (bestuursorgaan) => bestuursorgaan.bindingEinde
-    );
-    mandataris.expectedEndDate = plannedEndDates[0];
-    mandataris.einde = plannedEndDates[0];
+  //   Scenarios:
+
+  // - er was nog geen mandaat geselecteerd: prefill end date, geen warning
+  // - er was een mandaat geselecteerd:
+  //     - de einddatum is leeg => prefill end date, warning?
+  //     - einddatum is gelijk aan de vorige expected end date
+  //         - nieuw mandaat is niet “van rechtswege” => overschrijf met nieuwe expected end date, warning als de nieuwe datum anders is dan de vorige
+  //         -  nieuw mandaat is “van rechtswege” => veld leegmaken, warning tonen? (volgens bug issue niet)
+  //     - einddatum werd manueel aangepast => niet overschrijven, warning dat de gebruiker het veld moet nakijken (ook voor “van rechtswege”, volgens bug issue niet)?
+
+  // TODO: DRY this up once all the cases are covered so we know the final logic.
+  if (!hasCurrentMandate) {
+    if (isLifetimeBoardPosition(bestuursfunctie)) {
+      mandataris.expectedEndDate = undefined;
+      mandataris.einde = undefined;
+    } else {
+      const expectedEndDate = await getExpectedEndDateForPosition(
+        store,
+        mandaat
+      );
+      mandataris.expectedEndDate = expectedEndDate;
+      mandataris.einde = expectedEndDate;
+    }
+  } else if (isCurrentlyEmpty) {
+    if (isLifetimeBoardPosition(bestuursfunctie)) {
+      mandataris.expectedEndDate = undefined;
+      mandataris.einde = undefined;
+    } else {
+      const expectedEndDate = await getExpectedEndDateForPosition(
+        store,
+        mandaat
+      );
+      mandataris.expectedEndDate = expectedEndDate;
+      mandataris.einde = expectedEndDate;
+    }
+  } else if (!wasDateChangedManually) {
+    if (isLifetimeBoardPosition(bestuursfunctie)) {
+      mandataris.expectedEndDate = undefined;
+      mandataris.einde = undefined;
+    } else {
+      const expectedEndDate = await getExpectedEndDateForPosition(
+        store,
+        mandaat
+      );
+      mandataris.expectedEndDate = expectedEndDate;
+      mandataris.einde = expectedEndDate;
+
+      if (!isSameIsoDate(expectedEndDate, currentEndDate)) {
+        warnings = {
+          einde:
+            'De einddatum werd automatisch aangepast naar de nieuwe geplande einddatum. Gelieve de einddatum te controleren',
+        };
+      }
+    }
+  } else if (wasDateChangedManually) {
+    if (!isLifetimeBoardPosition) {
+      warnings = {
+        einde: 'De functie werd aangepast. Gelieve de einddatum te controleren',
+      };
+    }
   }
 
-  if (!isSameIsoDate(mandataris.einde, currentEndDate)) {
-    warnings = {
-      einde:
-        'De einddatum werd automatisch aangepast naar de nieuwe geplande einddatum. Gelieve de einddatum te controleren',
-    };
-  }
-
+  mandataris.bekleedt = mandaat;
+  mandataris.errors.remove('bekleedt');
   return warnings;
+}
+
+async function getExpectedEndDateForPosition(store, mandaat) {
+  let bestuursorganenInTijd = await store.query('bestuursorgaan', {
+    'filter[bevat][:uri:]': mandaat.uri,
+    sort: '-binding-start',
+  });
+  let expectedEndDates = bestuursorganenInTijd.map(
+    (bestuursorgaan) => bestuursorgaan.bindingEinde
+  );
+
+  return expectedEndDates[0];
+}
+
+export function isLifetimeBoardPosition(boardPosition) {
+  const lifetimeBoardPosition =
+    'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5972fccd87f864c4ec06bfbd20b5008b'; // Bestuurslid (van rechtswege) is a lifetime mandate
+
+  return boardPosition.uri === lifetimeBoardPosition;
 }


### PR DESCRIPTION
The old logic wasn't approved so we implement the more complicated version that should cover all use-cases (even if they probably won't happen in practice)

It also includes a suggestion by the design team to display the expected end date below the end date field.
![image](https://user-images.githubusercontent.com/3533236/224691604-5f710ba5-7821-4178-af17-f8611c5102c0.png)

WIP, because the logic needs to be approved before merging, and we need a cleanup round to remove the duplicated branches.