### PR TITLE
Add a build-time feature flag to all "controle" logic

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -102,6 +102,26 @@ trigger:
   event:
     - tag
 ---
+kind: pipeline
+type: docker
+name: release-controle
+steps:
+- name: push-tagged-build
+  image: plugins/docker
+  settings:
+    repo: ${DRONE_REPO}
+    tags: ${DRONE_TAG##v}-controle
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    purge: true
+    build_args:
+      - CONTROLE=true
+trigger:
+  event:
+    - tag
+---
 kind: secret
 name: docker_username
 data: z1mn+LhdmJHSXCP9vHnZ9oQ08Qb/YeRa/6lPfO+bgMoJJhXxzF23ug==

--- a/.lint-todo
+++ b/.lint-todo
@@ -41,3 +41,11 @@ add|ember-template-lint|no-curly-component-invocation|232|12|232|12|a648df2a8942
 add|ember-template-lint|no-curly-component-invocation|87|16|87|16|a9691f1a4f9bea71401f6223a01f98514da33726|1678838400000|||app/templates/mandatenbeheer/fracties.hbs
 add|ember-template-lint|no-curly-component-invocation|95|16|95|16|82e19ec4bfc240d5fd6708b391894de75b42e2dc|1678838400000|||app/templates/mandatenbeheer/fracties.hbs
 add|ember-template-lint|no-action|7|18|7|18|be51c27cc7a2bc76b71c185656c46f6d0496d6ad|1678838400000|||app/templates/components/mandatenbeheer/mandataris-duplicate-selector.hbs
+remove|ember-template-lint|no-curly-component-invocation|88|12|88|12|a648df2a8942089664709fe267c21257bed78525|1678838400000|||app/components/mandatenbeheer/mandataris-edit.hbs
+remove|ember-template-lint|no-curly-component-invocation|232|12|232|12|a648df2a8942089664709fe267c21257bed78525|1678838400000|||app/components/mandatenbeheer/mandataris-edit.hbs
+remove|ember-template-lint|no-curly-component-invocation|87|16|87|16|a9691f1a4f9bea71401f6223a01f98514da33726|1678838400000|||app/templates/mandatenbeheer/fracties.hbs
+remove|ember-template-lint|no-curly-component-invocation|95|16|95|16|82e19ec4bfc240d5fd6708b391894de75b42e2dc|1678838400000|||app/templates/mandatenbeheer/fracties.hbs
+add|ember-template-lint|no-curly-component-invocation|89|14|89|14|725adc1151446359f9c21ea54af318b7c01e474e|1678838400000|||app/components/mandatenbeheer/mandataris-edit.hbs
+add|ember-template-lint|no-curly-component-invocation|235|14|235|14|725adc1151446359f9c21ea54af318b7c01e474e|1678838400000|||app/components/mandatenbeheer/mandataris-edit.hbs
+add|ember-template-lint|no-curly-component-invocation|88|18|88|18|daf746c4fb4e39be85dc6448f01c0db64cd22fd3|1678838400000|||app/templates/mandatenbeheer/fracties.hbs
+add|ember-template-lint|no-curly-component-invocation|96|18|96|18|e3b84a15c08219bf7b7baae06f7aba4dcaba2ef9|1678838400000|||app/templates/mandatenbeheer/fracties.hbs

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,12 @@ FROM madnificent/ember:3.27.0 as builder
 
 LABEL maintainer="info@redpencil.io"
 
+ARG CONTROLE=false
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
-RUN EMBER_TEST_SELECTORS_STRIP=false ember build -prod
+RUN CONTROLE=$CONTROLE EMBER_TEST_SELECTORS_STRIP=false ember build -prod
 
 FROM semtech/ember-proxy-service:1.5.1
 

--- a/app/components/mandatenbeheer/fractie-table-row.hbs
+++ b/app/components/mandatenbeheer/fractie-table-row.hbs
@@ -31,12 +31,15 @@
         <AuIcon @icon="pencil" @alignment="left" />
         Bewerk
       </AuButton>
+      {{!-- TODO: this.canRemove is undefined, is this still needed? --}}
       {{#if this.canRemove}}
         <AuButton @icon="bin" @alert={{true}} {{on "click" this.remove}}>Verwijder</AuButton>
       {{/if}}
     {{/if}}
   </td>
-  <td>
-    {{@fractie.generatedFromGelinktNotuleren}}
-  </td>
+  {{#if (macroCondition (macroGetOwnConfig "controle"))}}
+    <td>
+      {{@fractie.generatedFromGelinktNotuleren}}
+    </td>
+  {{/if}}
 </tr>

--- a/app/components/mandatenbeheer/mandataris-edit.hbs
+++ b/app/components/mandatenbeheer/mandataris-edit.hbs
@@ -77,32 +77,34 @@
             bestuursorganen=this.bestuursorganen
           }}
         </div>
-        <div>
-          <div class="au-u-margin-bottom-tiny">
-            <AuControlCheckbox
-              @checked={{this.isDuplicated}}
-              @onChange={{fn (mut this.isDuplicated)}}
-            >Is het een duplicaat?</AuControlCheckbox>
-          </div>
-          {{#if this.isDuplicated}}
-            {{mandatenbeheer/mandataris-duplicate-selector
-              onSelect=(action 'setduplicatedMandataris')
-              mandatarissen=this.mandatarissen
-              currentMandataris=this.mandataris
-              duplicatedMandataris=this.duplicatedMandataris
-              allowClear=true
-            }}
-            <div>
-              <AuLabel for="duplication-reason">Reden voor duplicatie</AuLabel>
-              <AuInput
-                id="duplication-reason"
-                class="input-field input-field--block u-spacer--tiny js-js-input-pattern-bound"
-                placeholder="Reden voor duplicatie"
-                @value={{mut this.duplicationReason}}
-              />
+        {{#if (macroCondition (macroGetOwnConfig "controle"))}}
+          <div>
+            <div class="au-u-margin-bottom-tiny">
+              <AuControlCheckbox
+                @checked={{this.isDuplicated}}
+                @onChange={{fn (mut this.isDuplicated)}}
+              >Is het een duplicaat?</AuControlCheckbox>
             </div>
-          {{/if}}
-        </div>
+            {{#if this.isDuplicated}}
+              {{mandatenbeheer/mandataris-duplicate-selector
+                onSelect=(action 'setduplicatedMandataris')
+                mandatarissen=this.mandatarissen
+                currentMandataris=this.mandataris
+                duplicatedMandataris=this.duplicatedMandataris
+                allowClear=true
+              }}
+              <div>
+                <AuLabel for="duplication-reason">Reden voor duplicatie</AuLabel>
+                <AuInput
+                  id="duplication-reason"
+                  class="input-field input-field--block u-spacer--tiny js-js-input-pattern-bound"
+                  placeholder="Reden voor duplicatie"
+                  @value={{mut this.duplicationReason}}
+                />
+              </div>
+            {{/if}}
+          </div>
+        {{/if}}
       </div>
 
       <div class="au-u-margin-top">
@@ -220,33 +222,35 @@
             bestuursorganen=this.bestuursorganen
           }}
         </div>
-        <div>
-          <div class="au-u-margin-bottom-tiny">
-            <AuControlCheckbox
-              @checked={{this.isDuplicated}}
-              @onChange={{fn (mut this.isDuplicated)}}
-            >Is het een duplicaat?</AuControlCheckbox>
-          </div>
-
-          {{#if this.isDuplicated}}
-            {{mandatenbeheer/mandataris-duplicate-selector
-              onSelect=(action 'setduplicatedMandataris')
-              mandatarissen=this.mandatarissen
-              currentMandataris=this.mandataris
-              duplicatedMandataris=this.duplicatedMandataris
-              allowClear=true
-            }}
-            <div class="au-u-margin-top-small">
-              <AuLabel for="duplicationReason">Reden voor duplicatie</AuLabel>
-              <AuInput
-                id="duplicationReason"
-                class="input-field input-field--block u-spacer--tiny js-js-input-pattern-bound"
-                placeholder="Reden voor duplicatie"
-                @value={{mut this.duplicationReason}}
-              />
+        {{#if (macroCondition (macroGetOwnConfig "controle"))}}
+          <div>
+            <div class="au-u-margin-bottom-tiny">
+              <AuControlCheckbox
+                @checked={{this.isDuplicated}}
+                @onChange={{fn (mut this.isDuplicated)}}
+              >Is het een duplicaat?</AuControlCheckbox>
             </div>
-          {{/if}}
-        </div>
+
+            {{#if this.isDuplicated}}
+              {{mandatenbeheer/mandataris-duplicate-selector
+                onSelect=(action 'setduplicatedMandataris')
+                mandatarissen=this.mandatarissen
+                currentMandataris=this.mandataris
+                duplicatedMandataris=this.duplicatedMandataris
+                allowClear=true
+              }}
+              <div class="au-u-margin-top-small">
+                <AuLabel for="duplicationReason">Reden voor duplicatie</AuLabel>
+                <AuInput
+                  id="duplicationReason"
+                  class="input-field input-field--block u-spacer--tiny js-js-input-pattern-bound"
+                  placeholder="Reden voor duplicatie"
+                  @value={{mut this.duplicationReason}}
+                />
+              </div>
+            {{/if}}
+          </div>
+        {{/if}}
       </div>
 
       <div class="au-u-margin-top">

--- a/app/components/mandatenbeheer/mandataris-summary.hbs
+++ b/app/components/mandatenbeheer/mandataris-summary.hbs
@@ -32,9 +32,11 @@
         {{#if this.fractie}}
         <li class="au-c-list-horizontal__item">{{this.fractie}}</li>
         {{/if}}
-        <li class="au-c-list-horizontal__item">Gelinkt notuleren? {{this.gelinktNotuleren}}</li>
-        {{#if @mandataris.duplicateOf}}
-        <li class="au-c-list-horizontal__item">Gedupliceerd</li>
+        {{#if (macroCondition (macroGetOwnConfig "controle"))}}
+          <li class="au-c-list-horizontal__item">Gelinkt notuleren? {{this.gelinktNotuleren}}</li>
+          {{#if @mandataris.duplicateOf}}
+            <li class="au-c-list-horizontal__item">Gedupliceerd</li>
+          {{/if}}
         {{/if}}
       </ul>
     </AuContent>

--- a/app/components/mandatenbeheer/mandataris-table.hbs
+++ b/app/components/mandatenbeheer/mandataris-table.hbs
@@ -5,7 +5,9 @@
       {{#unless @displaySubset}}
         <th class="au-u-visible-small-up">Orgaan</th>
       {{/unless}}
-      <AuDataTableThSortable @field='isBestuurlijkeAliasVan.verifiedMandaten' @currentSorting={{@sort}} @label='Nagekeken' class="u-hidden-mobile" />
+      {{#if (macroCondition (macroGetOwnConfig "controle"))}}
+        <AuDataTableThSortable @field='isBestuurlijkeAliasVan.verifiedMandaten' @currentSorting={{@sort}} @label='Nagekeken' class="u-hidden-mobile" />
+      {{/if}}
       <AuDataTableThSortable @field='isBestuurlijkeAliasVan.gebruikteVoornaam' @currentSorting={{@sort}} @label='Naam' class="au-u-visible-small-up" />
       <AuDataTableThSortable @field='isBestuurlijkeAliasVan.achternaam' @currentSorting={{@sort}} @label='Familienaam'/>
       {{#unless @displaySubset}}
@@ -16,12 +18,16 @@
         <AuDataTableThSortable @field='start' @currentSorting={{@sort}} @label='Start mandaat' class="au-u-visible-medium-up" />
         <AuDataTableThSortable @field='einde' @currentSorting={{@sort}} @label='Einde mandaat' class="au-u-visible-medium-up" />
       {{/unless}}
-      <AuDataTableThSortable @field='generatedFromGelinktNotuleren' @currentSorting={{@sort}} @label='Gelinkt Notuleren'/>
-      <AuDataTableThSortable @field='duplicateOf.bekleedt.bestuursfunctie.label' @currentSorting={{@sort}} @label='Gedupliceerd'/>
+      {{#if (macroCondition (macroGetOwnConfig "controle"))}}
+        <AuDataTableThSortable @field='generatedFromGelinktNotuleren' @currentSorting={{@sort}} @label='Gelinkt Notuleren'/>
+        <AuDataTableThSortable @field='duplicateOf.bekleedt.bestuursfunctie.label' @currentSorting={{@sort}} @label='Gedupliceerd'/>
+      {{/if}}
       <th></th>
-      {{#unless @displaySubset}}
-      <th></th>
-      {{/unless}}
+      {{#if (macroCondition (macroGetOwnConfig "controle"))}}
+        {{#unless @displaySubset}}
+        <th></th>
+        {{/unless}}
+      {{/if}}
     </c.header>
     <c.body data-test-loket="mandatarissen-body" as |row|>
       {{#unless @displaySubset}}
@@ -32,9 +38,11 @@
         {{/each}}
         </td>
       {{/unless}}
-      <td>
-        <AuControlCheckbox @checked={{row.isBestuurlijkeAliasVan.verifiedMandaten}} @disabled={{true}} />
-      </td>
+      {{#if (macroCondition (macroGetOwnConfig "controle"))}}
+        <td>
+          <AuControlCheckbox @checked={{row.isBestuurlijkeAliasVan.verifiedMandaten}} @disabled={{true}} />
+        </td>
+      {{/if}}
       <td class="au-u-visible-small-up">
         {{row.isBestuurlijkeAliasVan.gebruikteVoornaam}}
       </td>
@@ -53,26 +61,27 @@
         <td class="au-u-visible-medium-up">{{moment-format row.start 'DD-MM-YYYY'}}</td>
         <td class="au-u-visible-medium-up">{{moment-format row.einde 'DD-MM-YYYY'}}</td>
       {{/unless}}
-      <td>
-        {{row.generatedFromGelinktNotuleren}}
-      </td>
-      <td>
-        {{#if row.duplicateOf}}
-          true
-        {{else}}
-          false
-        {{/if}}
-      </td>
-      {{#unless @displaySubset}}
-        <td><LinkTo @route={{@editRoute}} @model={{row.isBestuurlijkeAliasVan.id}} class="au-c-link"> Bewerk </LinkTo></td>
+      {{#if (macroCondition (macroGetOwnConfig "controle"))}}
         <td>
-          <AuButton @skin="link" @icon="bin" @alert="true" {{on "click" (fn this.removeMandataris row)}}>
-            Verwijder
-          </AuButton>
+          {{row.generatedFromGelinktNotuleren}}
         </td>
-      {{/unless}}
-      {{#if @displaySubset}}
-        <td><LinkTo @route={{@editRoute}} @model={{row.isBestuurlijkeAliasVan.id}} class="au-c-link"> Bewerk </LinkTo></td>
+        <td>
+          {{#if row.duplicateOf}}
+            true
+          {{else}}
+            false
+          {{/if}}
+        </td>
+      {{/if}}
+      <td><LinkTo @route={{@editRoute}} @model={{row.isBestuurlijkeAliasVan.id}} class="au-c-link"> Bewerk </LinkTo></td>
+      {{#if (macroCondition (macroGetOwnConfig "controle"))}}
+        {{#unless @displaySubset}}
+          <td>
+            <AuButton @skin="link" @icon="bin" @alert="true" {{on "click" (fn this.removeMandataris row)}}>
+              Verwijder
+            </AuButton>
+          </td>
+        {{/unless}}
       {{/if}}
     </c.body>
   </t.content>

--- a/app/components/mandatenbeheer/persoon-mandaten-edit.hbs
+++ b/app/components/mandatenbeheer/persoon-mandaten-edit.hbs
@@ -53,15 +53,18 @@
         <AuIcon @icon="add" @alignment="left" />
         Voeg nieuw mandaat toe
       </AuButton>
-      {{!-- This section is here temporarily for ABB to review all the mandates in August --}}
-      <AuAlert @icon="alert-triangle" @skin="warning" class="au-u-margin-top-small">
-        <p class="au-u-margin-bottom-small">
-          <AuControlCheckbox @checked={{@persoon.verifiedMandaten}} @onChange={{this.updateVerifiedMandaten}}>
-            De persoon en al de bijbehorende mandaten werden nagekeken.
-          </AuControlCheckbox>
-        </p>
-        <p>Wil u graag een <strong>mandaat of mandataris verwijderen</strong>, de <strong>gegevens van een mandataris wijzigen</strong> of een <strong>fractie toevoegen of aanpassen</strong>? Zoek naar de juiste tab in <a href="https://docs.google.com/spreadsheets/d/13D38ZLH0toLlJ2u7lBwywUThM77ze1O6YUOMFL9T2lQ/edit#gid=0" target="_blank" rel="noopener noreferrer" class="au-c-link">deze controle sheet</a> om het door te geven.</p>
-      </AuAlert>
+
+      {{#if (macroCondition (macroGetOwnConfig "controle"))}}
+        {{!-- This section is here temporarily for ABB to review all the mandates in August --}}
+        <AuAlert @icon="alert-triangle" @skin="warning" class="au-u-margin-top-small">
+          <p class="au-u-margin-bottom-small">
+            <AuControlCheckbox @checked={{@persoon.verifiedMandaten}} @onChange={{this.updateVerifiedMandaten}}>
+              De persoon en al de bijbehorende mandaten werden nagekeken.
+            </AuControlCheckbox>
+          </p>
+          <p>Wil u graag een <strong>mandaat of mandataris verwijderen</strong>, de <strong>gegevens van een mandataris wijzigen</strong> of een <strong>fractie toevoegen of aanpassen</strong>? Zoek naar de juiste tab in <a href="https://docs.google.com/spreadsheets/d/13D38ZLH0toLlJ2u7lBwywUThM77ze1O6YUOMFL9T2lQ/edit#gid=0" target="_blank" rel="noopener noreferrer" class="au-c-link">deze controle sheet</a> om het door te geven.</p>
+        </AuAlert>
+      {{/if}}
     </div>
   </div>
 </div>

--- a/app/controllers/supervision/submissions/index.js
+++ b/app/controllers/supervision/submissions/index.js
@@ -11,11 +11,6 @@ export default class SupervisionSubmissionsIndexController extends Controller {
   sort = 'status.label,-sent-date,-modified';
 
   @action
-  lookAt(submission) {
-    this.router.transitionTo('supervision.submissions.edit', submission.id);
-  }
-
-  @action
   reopen(submission) {
     const hasAcknowledged = confirm(
       'Weet je zeker dat je dit wilt doen? Deze actie kan onverwachte gevolgen hebben!'

--- a/app/templates/mandatenbeheer/fracties.hbs
+++ b/app/templates/mandatenbeheer/fracties.hbs
@@ -65,53 +65,55 @@
         </table>
       </div>
 
-      {{#if this.saveFractie.isRunning}}
-        <div class="loader-wrapper">
-          <div class="loader">
-            <span class="u-visually-hidden">Bezig...</span>
+      {{#if (macroCondition (macroGetOwnConfig "controle"))}}
+        {{#if this.saveFractie.isRunning}}
+          <div class="loader-wrapper">
+            <div class="loader">
+              <span class="u-visually-hidden">Bezig...</span>
+            </div>
           </div>
-        </div>
-      {{else}}
-        <div class="container-flex--scroll">
-          <table class="data-table data-table--nowrap">
-            <thead>
-              <tr class="data-table__header">
-                <th>Fractienaam</th>
-                <th>Bestuursperiode</th>
-                <th></th>
-                <th>Gelinkt notuleren</th>
-              </tr>
-            </thead>
-            <tbody>
-              {{#if this.newFractie}}
-                {{mandatenbeheer/fractie-table-row
-                    onCancel=this.cancelEdit
-                    onSave=(perform this.saveFractie)
-                    fractie=this.newFractie
-                    editMode=true
-                }}
-              {{/if}}
-              {{#each this.model as |row|}}
-                {{mandatenbeheer/fractie-table-row
-                    onCancel=this.cancelEdit
-                    onSave=(perform this.saveFractie)
-                    fractie=row
-                }}
-              {{else}}
-                {{#unless this.newFractie}}
-                  <tr>
-                    <td colspan="3">
-                      Geen fracties gevonden.
-                      <AuButton @skin="link" {{on "click" this.createNewFractie}}>
-                        Voeg een nieuwe fractie toe
-                      </AuButton>
-                    </td>
-                  </tr>
-                {{/unless}}
-              {{/each}}
-            </tbody>
-          </table>
-        </div>
+        {{else}}
+          <div class="container-flex--scroll">
+            <table class="data-table data-table--nowrap">
+              <thead>
+                <tr class="data-table__header">
+                  <th>Fractienaam</th>
+                  <th>Bestuursperiode</th>
+                  <th></th>
+                  <th>Gelinkt notuleren</th>
+                </tr>
+              </thead>
+              <tbody>
+                {{#if this.newFractie}}
+                  {{mandatenbeheer/fractie-table-row
+                      onCancel=this.cancelEdit
+                      onSave=(perform this.saveFractie)
+                      fractie=this.newFractie
+                      editMode=true
+                  }}
+                {{/if}}
+                {{#each this.model as |row|}}
+                  {{mandatenbeheer/fractie-table-row
+                      onCancel=this.cancelEdit
+                      onSave=(perform this.saveFractie)
+                      fractie=row
+                  }}
+                {{else}}
+                  {{#unless this.newFractie}}
+                    <tr>
+                      <td colspan="3">
+                        Geen fracties gevonden.
+                        <AuButton @skin="link" {{on "click" this.createNewFractie}}>
+                          Voeg een nieuwe fractie toe
+                        </AuButton>
+                      </td>
+                    </tr>
+                  {{/unless}}
+                {{/each}}
+              </tbody>
+            </table>
+          </div>
+        {{/if}}
       {{/if}}
     </div>
   </div>

--- a/app/templates/supervision/submissions/index.hbs
+++ b/app/templates/supervision/submissions/index.hbs
@@ -56,19 +56,16 @@
       </td>
       <td>
         <AuButtonGroup @inline={{true}}>
-
-          <AuButton @icon="eye"
-                    @skin="tertiary"
-            {{on "click" (fn this.lookAt row)}}>
-            Bekijk
-          </AuButton>
-          <AuButton @icon="redo"
-                    @skin="tertiary"
-                    @alert={{true}}
-                    @disabled={{not row.status.isSent}}
-            {{on "click" (fn this.reopen row)}}>
-            Reopen
-          </AuButton>
+          <AuLink @route="supervision.submissions.edit" @model={{row.id}} @icon="eye">Bekijk</AuLink>
+          {{#if (macroCondition (macroGetOwnConfig "controle"))}}
+            <AuButton @icon="redo"
+                      @skin="link"
+                      @alert={{true}}
+                      @disabled={{not row.status.isSent}}
+              {{on "click" (fn this.reopen row)}}>
+              Reopen
+            </AuButton>
+          {{/if}}
         </AuButtonGroup>
       </td>
     </c.body>

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -12,6 +12,11 @@ module.exports = function (defaults) {
       dutchDatePickerLocalization: true,
       disableWormholeElement: true,
     },
+    '@embroider/macros': {
+      setOwnConfig: {
+        controle: process.env.CONTROLE === 'true',
+      },
+    },
   };
 
   if (process.env.EMBER_TEST_SELECTORS_STRIP == 'false') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@babel/plugin-proposal-decorators": "^7.20.7",
         "@ember/optional-features": "^2.0.0",
         "@ember/test-helpers": "^2.6.0",
+        "@embroider/macros": "^1.10.0",
         "@glimmer/component": "^1.0.4",
         "@glimmer/tracking": "^1.0.4",
         "@lblod/ember-acmidm-login": "2.0.0-beta.1",
@@ -4298,12 +4299,12 @@
       }
     },
     "node_modules/@embroider/macros": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.9.0.tgz",
-      "integrity": "sha512-12ElrRT+mX3aSixGHjHnfsnyoH1hw5nM+P+Ax0ITZdp6TaAvWZ8dENnVHltdnv4ssHiX0EsVEXmqbIIdMN4nLA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.10.0.tgz",
+      "integrity": "sha512-LMbfQGk/a+f6xtvAv5fq/wf2LRxETnbgSCLUf/z6ebzmuskOUxrke+uP55chF/loWrARi9g6erFQ7RDOUoBMSg==",
       "dev": true,
       "dependencies": {
-        "@embroider/shared-internals": "1.8.3",
+        "@embroider/shared-internals": "2.0.0",
         "assert-never": "^1.2.1",
         "babel-import-util": "^1.1.0",
         "ember-cli-babel": "^7.26.6",
@@ -4311,6 +4312,25 @@
         "lodash": "^4.17.21",
         "resolve": "^1.20.0",
         "semver": "^7.3.2"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/@embroider/macros/node_modules/@embroider/shared-internals": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.0.0.tgz",
+      "integrity": "sha512-qZ2/xky9mWm5YC6noOa6AiAwgISEQ78YTZNv4SNu2PFgEK/H+Ha/3ddngzGSsnXkVnIHZyxIBzhxETonQYHY9g==",
+      "dev": true,
+      "dependencies": {
+        "babel-import-util": "^1.1.0",
+        "ember-rfc176-data": "^0.3.17",
+        "fs-extra": "^9.1.0",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.21",
+        "resolve-package-path": "^4.0.1",
+        "semver": "^7.3.5",
+        "typescript-memoize": "^1.0.1"
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
@@ -39280,7 +39300,7 @@
       "dev": true,
       "requires": {
         "@duetds/date-picker": "^1.4.0",
-        "@embroider/macros": "^1.0.0",
+        "@embroider/macros": "^1.10.0",
         "@floating-ui/dom": "^1.1.0",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
@@ -42132,7 +42152,7 @@
       "integrity": "sha512-5cJ1niIdOJC6k6KtIn9HGbr1DATJQp4ZqMv1vbi6LKQWbVCQ3byvKONtUEi3H0wcewlrcaWCqXOgm0nACzCOQA==",
       "dev": true,
       "requires": {
-        "@embroider/macros": "^1.0.0",
+        "@embroider/macros": "^1.10.0",
         "ember-cli-babel": "^7.26.11",
         "ember-modifier-manager-polyfill": "^1.2.0"
       }
@@ -42153,7 +42173,7 @@
       "dev": true,
       "requires": {
         "@ember/test-waiters": "^3.0.0",
-        "@embroider/macros": "^1.0.0",
+        "@embroider/macros": "^1.10.0",
         "@embroider/util": "^1.0.0",
         "broccoli-debug": "^0.6.5",
         "broccoli-funnel": "^3.0.8",
@@ -42358,12 +42378,12 @@
       }
     },
     "@embroider/macros": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.9.0.tgz",
-      "integrity": "sha512-12ElrRT+mX3aSixGHjHnfsnyoH1hw5nM+P+Ax0ITZdp6TaAvWZ8dENnVHltdnv4ssHiX0EsVEXmqbIIdMN4nLA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.10.0.tgz",
+      "integrity": "sha512-LMbfQGk/a+f6xtvAv5fq/wf2LRxETnbgSCLUf/z6ebzmuskOUxrke+uP55chF/loWrARi9g6erFQ7RDOUoBMSg==",
       "dev": true,
       "requires": {
-        "@embroider/shared-internals": "1.8.3",
+        "@embroider/shared-internals": "2.0.0",
         "assert-never": "^1.2.1",
         "babel-import-util": "^1.1.0",
         "ember-cli-babel": "^7.26.11",
@@ -42371,6 +42391,24 @@
         "lodash": "^4.17.21",
         "resolve": "^1.20.0",
         "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "@embroider/shared-internals": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.0.0.tgz",
+          "integrity": "sha512-qZ2/xky9mWm5YC6noOa6AiAwgISEQ78YTZNv4SNu2PFgEK/H+Ha/3ddngzGSsnXkVnIHZyxIBzhxETonQYHY9g==",
+          "dev": true,
+          "requires": {
+            "babel-import-util": "^1.1.0",
+            "ember-rfc176-data": "^0.3.17",
+            "fs-extra": "^9.1.0",
+            "js-string-escape": "^1.0.1",
+            "lodash": "^4.17.21",
+            "resolve-package-path": "^4.0.1",
+            "semver": "^7.3.5",
+            "typescript-memoize": "^1.0.1"
+          }
+        }
       }
     },
     "@embroider/shared-internals": {
@@ -42395,7 +42433,7 @@
       "integrity": "sha512-9I63iJK6N01OHJafmS/BX0msUkTlmhFMIEmDl/SRNACVi0nS6QfNyTgTTeji1P/DALf6eobg/9t/N4VhS9G9QA==",
       "dev": true,
       "requires": {
-        "@embroider/macros": "^1.0.0",
+        "@embroider/macros": "^1.10.0",
         "broccoli-funnel": "^3.0.5",
         "ember-cli-babel": "^7.26.11"
       }
@@ -49288,7 +49326,7 @@
         "@babel/plugin-proposal-class-properties": "^7.16.7",
         "@babel/plugin-proposal-decorators": "^7.16.7",
         "@babel/preset-env": "^7.16.7",
-        "@embroider/macros": "^1.0.0",
+        "@embroider/macros": "^1.10.0",
         "@embroider/shared-internals": "^2.0.0",
         "babel-loader": "^8.0.6",
         "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
@@ -49431,7 +49469,7 @@
       "dev": true,
       "requires": {
         "@ember/render-modifiers": "^2.0.4",
-        "@embroider/macros": "^1.0.0",
+        "@embroider/macros": "^1.10.0",
         "@embroider/util": "^1.0.0",
         "@glimmer/component": "^1.0.4",
         "@glimmer/tracking": "^1.0.4",
@@ -53803,7 +53841,7 @@
         "@ember/test-helpers": "^2.4.2",
         "@ember/test-waiters": "^3.0.0",
         "@embroider/addon-shim": "^1.5.0",
-        "@embroider/macros": "^1.0.0",
+        "@embroider/macros": "^1.10.0",
         "@glimmer/component": "^1.0.4",
         "@glimmer/tracking": "^1.0.4",
         "ember-auto-import": "^2.0.0",
@@ -53917,7 +53955,7 @@
       "integrity": "sha512-uNmv1cPG/4qsac8oIf5txJ2FZ8p88LEpG4P3dNcjsJS98Y8hd0GPMFwVqpnzI78Lz7VYRGQWY4jnE4qm5R3j4g==",
       "dev": true,
       "requires": {
-        "@embroider/macros": "^1.0.0",
+        "@embroider/macros": "^1.10.0",
         "ember-cli-babel": "^7.26.11"
       }
     },
@@ -57812,7 +57850,7 @@
       "integrity": "sha512-MhrJnpyTTie+Uo9PWiEX4f0t5y70vBjjgcS56aLOvwlSwfInNCtOEgQ/zH89J2dnYUVidebm/1FTubQ2meSjbw==",
       "dev": true,
       "requires": {
-        "@embroider/macros": "^1.0.0",
+        "@embroider/macros": "^1.10.0",
         "ember-cli-babel": "^7.26.11"
       }
     },

--- a/package.json
+++ b/package.json
@@ -23,12 +23,13 @@
     "lint:js:fix": "eslint . --fix",
     "release": "release-it",
     "start": "ember serve",
+    "start:controle": "CONTROLE=true ember serve",
     "test": "npm-run-all lint test:*",
     "test:ember": "ember test"
   },
   "overrides": {
     "@appuniversum/ember-appuniversum": "$@appuniversum/ember-appuniversum",
-    "@embroider/macros": "^1.0.0",
+    "@embroider/macros": "$@embroider/macros",
     "@embroider/util": "^1.0.0",
     "ember-cli-babel": "$ember-cli-babel",
     "moment": "^2.29.1"
@@ -42,6 +43,7 @@
     "@babel/plugin-proposal-decorators": "^7.20.7",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.6.0",
+    "@embroider/macros": "^1.10.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "@lblod/ember-acmidm-login": "2.0.0-beta.1",


### PR DESCRIPTION
This uses the [embroider macros](https://github.com/embroider-build/embroider/tree/main/packages/macros) to add a flag that allows us to toggle the controle functionality at build time.

This allows us to merge the 'batch-edit' branch back into the main branch which makes maintenance and releases easier.

`npm run start:controle` can be used to run the controle version of the app. A new build-pipeline will be used to build the controle image. The -prod version is dropped since it seems we didn't use that in production.

I used [this diff view](https://github.com/lblod/frontend-loket/compare/development...9146a21440f59533a77459b5cfb0ee7921126c75) as the reference.