### PR TITLE
Add a `UrbanRenewal::FinancingTotals` custom field component

### DIFF
--- a/app/components/rdf-form-fields/urban-renewal/financing-totals.hbs
+++ b/app/components/rdf-form-fields/urban-renewal/financing-totals.hbs
@@ -1,0 +1,40 @@
+<AuTable>
+  <:title>Totaal</:title>
+  <:header>
+    <tr>
+      <th></th>
+      <th>Bedrag</th>
+      <th>Percentage</th>
+    </tr>
+  </:header>
+  <:body>
+    <tr>
+      <th>Eigen aandeel stad</th>
+      <td>{{this.formatAmount this.totals.own}}</td>
+      <td>{{this.formatPercentage
+          (this.calculatePercentage this.totals.own this.totals.total)
+        }}</td>
+    </tr>
+    <tr>
+      <th>Private partners</th>
+      <td>{{this.formatAmount this.totals.private}}</td>
+      <td>{{this.formatPercentage
+          (this.calculatePercentage this.totals.private this.totals.total)
+        }}</td>
+    </tr>
+    <tr>
+      <th>Publieke partners</th>
+      <td>{{this.formatAmount this.totals.public}}</td>
+      <td>{{this.formatPercentage
+          (this.calculatePercentage this.totals.public this.totals.total)
+        }}</td>
+    </tr>
+  </:body>
+  <:footer>
+    <tr>
+      <th>Totaal</th>
+      <td>{{this.formatAmount this.totals.total}}</td>
+      <td>{{this.formatPercentage 1}}</td>
+    </tr>
+  </:footer>
+</AuTable>

--- a/app/components/rdf-form-fields/urban-renewal/financing-totals.js
+++ b/app/components/rdf-form-fields/urban-renewal/financing-totals.js
@@ -1,0 +1,113 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { guidFor } from '@ember/object/internals';
+import { Literal, Namespace } from 'rdflib';
+
+const EXT = new Namespace('http://mu.semte.ch/vocabularies/ext/');
+const PARTNER_TYPE = new Namespace(
+  'http://lblod.data.gift/vocabularies/subsidie/concept/FinancieringPartnerType/'
+);
+
+export default class FinancingTotals extends Component {
+  @tracked totals;
+  id = guidFor(this);
+
+  formatAmount = (amount) => {
+    return new Intl.NumberFormat('nl-BE', {
+      style: 'currency',
+      currency: 'EUR',
+    }).format(amount);
+  };
+
+  formatPercentage = (percentage) => {
+    return new Intl.NumberFormat('nl-BE', {
+      style: 'percent',
+      maximumFractionDigits: 2,
+    }).format(percentage);
+  };
+
+  calculatePercentage = (amount, total) => {
+    if (total === 0) {
+      return 0;
+    }
+
+    return amount / total;
+  };
+
+  constructor() {
+    super(...arguments);
+
+    this.calculateTotals();
+
+    this.args.formStore.registerObserver(() => {
+      // This will potentially run a lot of times. We can probably check the delta and see if the change affects this component, but due to time constraints we're skipping that for now.
+      // It's also possible that the delta checking is more intensive than the actual computations, but that would have to be benchmarked.
+      this.calculateTotals();
+    }, this.id);
+  }
+
+  calculateTotals() {
+    const { formStore, graphs, sourceNode } = this.args;
+
+    const financingPartners = formStore
+      .match(sourceNode, EXT('financingPartner', undefined, graphs))
+      .reduce((financingPartners, triple) => {
+        const partner = {
+          node: triple.object,
+        };
+        const partnerType = formStore.any(
+          partner.node,
+          EXT('partnerType'),
+          undefined,
+          graphs.sourceGraph
+        );
+
+        if (partnerType) {
+          partner.type = partnerType;
+          const financingAmountLiteral = formStore.any(
+            partner.node,
+            EXT('financingAmount'),
+            undefined,
+            graphs.sourceGraph
+          );
+
+          partner.amount = financingAmountLiteral
+            ? Literal.toJS(financingAmountLiteral)
+            : 0;
+
+          financingPartners.push(partner);
+        }
+
+        return financingPartners;
+      }, []);
+
+    const totals = new Totals();
+
+    financingPartners.forEach((partner) => {
+      if (partner.type.equals(PARTNER_TYPE('EigenAandeel'))) {
+        totals.own += partner.amount;
+      } else if (partner.type.equals(PARTNER_TYPE('Privaat'))) {
+        totals.private += partner.amount;
+      } else if (partner.type.equals(PARTNER_TYPE('Publiek'))) {
+        totals.public += partner.amount;
+      }
+    });
+
+    this.totals = totals;
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+    this.args.formStore.deregisterObserver(this.id);
+  }
+}
+
+class Totals {
+  own = 0;
+  private = 0;
+  public = 0;
+
+  get total() {
+    return this.own + this.private + this.public;
+  }
+}

--- a/app/routes/subsidy/applications/edit.js
+++ b/app/routes/subsidy/applications/edit.js
@@ -16,6 +16,7 @@ import PlanLivingTogetherTableEditComponent from 'frontend-loket/components/rdf-
 import PlanLivingTogetherTableShowComponent from 'frontend-loket/components/rdf-form-fields/plan-living-together-table/show';
 import AccountabilityTableEditComponent from 'frontend-loket/components/rdf-form-fields/accountability-table/edit';
 import AccountabilityTableShowComponent from 'frontend-loket/components/rdf-form-fields/accountability-table/show';
+import FinancingTotalsComponent from 'frontend-loket/components/rdf-form-fields/urban-renewal/financing-totals';
 
 export default class SubsidyApplicationsEditRoute extends Route {
   @service store;
@@ -94,6 +95,11 @@ export default class SubsidyApplicationsEditRoute extends Route {
         displayType: 'http://lblod.data.gift/display-types/accountabilityTable',
         edit: AccountabilityTableEditComponent,
         show: AccountabilityTableShowComponent,
+      },
+      {
+        displayType:
+          'http://lblod.data.gift/display-types/urbanRenewalFinancingTotals',
+        edit: FinancingTotalsComponent,
       },
     ]);
   }


### PR DESCRIPTION
This field shows a "totals" summary based on the entries in the financing table.  

The styling looks a bit wonky, but that's because of the conflicting table styles in _shame.scss. We still need to convert the old custom tables to the new AuTable component before we can delete those.

![image](https://user-images.githubusercontent.com/3533236/230383972-1cdf990f-243d-4740-bff9-1fac9382f372.png)
