### PR TITLE
Subsidy form improvements

### DIFF
--- a/app/templates/subsidy/applications/edit/step/edit.hbs
+++ b/app/templates/subsidy/applications/edit/step/edit.hbs
@@ -1,21 +1,19 @@
 <div class="au-c-body-container au-c-body-container--scroll">
 
   <div
-    class="{{if this.saveConcept.isRunning 'au-c-form--disabled'}}
-      {{if this.submit.isRunning 'au-c-form--disabled'}}"
+    class="au-o-box {{if (or this.saveConcept.isRunning this.submit.isRunning) 'au-c-form--disabled'}}"
   >
-    <div class="au-o-grid__item au-u-2-3@medium au-u-1-1">
-      <RdfForm
-        @groupClass="au-o-grid__item au-u-2-4 au-u-1-1@small"
-        @form={{this.form}}
-        @show={{if (or this.submitted (not this.isActiveStep)) "true"}}
-        @graphs={{this.graphs}}
-        @sourceNode={{this.sourceNode}}
-        @formStore={{this.formStore}}
-        @forceShowErrors={{this.forceShowErrors}}
-        @useNewListingLayout={{true}}
-      />
-    </div>
+    <RdfForm
+      @groupClass="au-o-grid__item"
+      @form={{this.form}}
+      @show={{if (or this.submitted (not this.isActiveStep)) "true"}}
+      @graphs={{this.graphs}}
+      @sourceNode={{this.sourceNode}}
+      @formStore={{this.formStore}}
+      @forceShowErrors={{this.forceShowErrors}}
+      @useNewListingLayout={{true}}
+      class="au-u-max-width-medium"
+    />
   </div>
 
   <AuToolbar @size="large" as |Group|>

--- a/app/templates/subsidy/applications/edit/step/edit.hbs
+++ b/app/templates/subsidy/applications/edit/step/edit.hbs
@@ -13,6 +13,7 @@
         @sourceNode={{this.sourceNode}}
         @formStore={{this.formStore}}
         @forceShowErrors={{this.forceShowErrors}}
+        @useNewListingLayout={{true}}
       />
     </div>
   </div>

--- a/app/templates/subsidy/applications/edit/step/edit.hbs
+++ b/app/templates/subsidy/applications/edit/step/edit.hbs
@@ -12,6 +12,7 @@
       @formStore={{this.formStore}}
       @forceShowErrors={{this.forceShowErrors}}
       @useNewListingLayout={{true}}
+      @level={{2}}
       class="au-u-max-width-medium"
     />
   </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@lblod/ember-acmidm-login": "2.0.0-beta.1",
         "@lblod/ember-mock-login": "^0.7.0",
         "@lblod/ember-rdfa-editor": "^3.5.0",
-        "@lblod/ember-submission-form-fields": "^2.8.0",
+        "@lblod/ember-submission-form-fields": "^2.9.1",
         "@lblod/submission-form-helpers": "^2.2.0",
         "broccoli-asset-rev": "^3.0.0",
         "browser-update": "^3.3.38",
@@ -5324,9 +5324,9 @@
       }
     },
     "node_modules/@lblod/ember-submission-form-fields": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.8.0.tgz",
-      "integrity": "sha512-mHwEkZH1ZiDTjg+tMvwutPjqHD93L/DkXzhMLNVso/WJfUXJPvFmTjc4QbcmRLxCZc2vk6k4QMcToZWaIbdjYQ==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.9.1.tgz",
+      "integrity": "sha512-AWSRjElKTK/49Ou6ZZ9EwraIKdTU0guTj/Zx7rT9sBY67KGP82Whni1SWVmm0bmKaFg1/ylV1oKZN2eScgEHpA==",
       "dev": true,
       "dependencies": {
         "@lblod/submission-form-helpers": "^2.0.1",
@@ -43320,9 +43320,9 @@
       }
     },
     "@lblod/ember-submission-form-fields": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.8.0.tgz",
-      "integrity": "sha512-mHwEkZH1ZiDTjg+tMvwutPjqHD93L/DkXzhMLNVso/WJfUXJPvFmTjc4QbcmRLxCZc2vk6k4QMcToZWaIbdjYQ==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.9.1.tgz",
+      "integrity": "sha512-AWSRjElKTK/49Ou6ZZ9EwraIKdTU0guTj/Zx7rT9sBY67KGP82Whni1SWVmm0bmKaFg1/ylV1oKZN2eScgEHpA==",
       "dev": true,
       "requires": {
         "@lblod/submission-form-helpers": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@lblod/ember-acmidm-login": "2.0.0-beta.1",
     "@lblod/ember-mock-login": "^0.7.0",
     "@lblod/ember-rdfa-editor": "^3.5.0",
-    "@lblod/ember-submission-form-fields": "^2.8.0",
+    "@lblod/ember-submission-form-fields": "^2.9.1",
     "@lblod/submission-form-helpers": "^2.2.0",
     "broccoli-asset-rev": "^3.0.0",
     "browser-update": "^3.3.38",


### PR DESCRIPTION
This:
- bumps to the latest version of the form addon since that includes some improvements
- tweaks the width of the form so that it works better on smaller (and very wide) screens:

<details>
<summary>1280px wide screen before the changes</summary>

![image](https://user-images.githubusercontent.com/3533236/231832200-b7055558-cd94-4a39-8462-02f70e7ef614.png)
</details>


<details>
<summary>1280px wide screen after the changes</summary>

![image](https://user-images.githubusercontent.com/3533236/231831578-e468288d-7de6-440c-b0e4-aba82ed386b7.png)
</details>

Instead of using a 2/3 screen width we now use a max width of 1024px. On small screens this has the advantage that more space is used which means less horizontal scrolling. On large screens this limits the width to a better size instead of infinitely growing with your screen.