### PR TITLE
Allow users to unlink an instance from a concept

### DIFF
--- a/app/controllers/public-services/details.js
+++ b/app/controllers/public-services/details.js
@@ -1,15 +1,42 @@
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { dropTask } from 'ember-concurrency';
-import { isConceptUpdated } from 'frontend-loket/models/public-service';
+import { dropTask, task } from 'ember-concurrency';
+import {
+  hasConcept,
+  isConceptUpdated,
+} from 'frontend-loket/models/public-service';
 
 export default class PublicServicesDetailsController extends Controller {
   // We use a separate flag, otherwise the message would be hidden before the save was actually completed
   @tracked reviewStatus;
+  @tracked shouldShowUnlinkWarning = false;
   isConceptUpdated = isConceptUpdated;
 
   get showReviewRequiredMessage() {
     return Boolean(this.reviewStatus);
+  }
+
+  get hasConcept() {
+    return hasConcept(this.model.publicService);
+  }
+
+  get canUnlinkConcept() {
+    const { publicService } = this.model;
+
+    return (
+      this.hasConcept && !publicService.isSent && !this.shouldShowUnlinkWarning
+    );
+  }
+
+  @action
+  showUnlinkWarning() {
+    this.shouldShowUnlinkWarning = true;
+  }
+
+  @action
+  hideUnlinkWarning() {
+    this.shouldShowUnlinkWarning = false;
   }
 
   @dropTask
@@ -21,4 +48,13 @@ export default class PublicServicesDetailsController extends Controller {
 
     this.reviewStatus = null;
   }
+
+  unlinkConcept = task({ drop: true }, async () => {
+    const { publicService } = this.model;
+    publicService.concept = null;
+    publicService.modified = new Date();
+    await publicService.save();
+
+    this.hideUnlinkWarning();
+  });
 }

--- a/app/models/public-service.js
+++ b/app/models/public-service.js
@@ -34,3 +34,9 @@ export function isConceptUpdated(reviewStatus) {
 export function isConceptDeleted(reviewStatus) {
   return reviewStatus?.uri === REVIEW_STATUS.DELETED;
 }
+
+export function hasConcept(publicService) {
+  // This assumes the relationship was already loaded. Either by using includes, or by resolving the promise.
+  // Otherwise this will always return false
+  return Boolean(publicService.belongsTo('concept').id());
+}

--- a/app/templates/public-services/details.hbs
+++ b/app/templates/public-services/details.hbs
@@ -16,81 +16,125 @@
   as |Group|
 >
   <Group class="au-u-margin-bottom-small">
-    <DataList as |Data|>
+    <div>
+      <DataList as |Data|>
         <Data>
           <:title>IPDC Concept ID</:title>
           <:content>
-            <ValueWithPlaceholder @value={{@model.publicService.concept.productId}}>
-                <:value as |productId|>
-                  <AuLink
-                    @route="public-services.concept-details"
-                    @model={{@model.publicService.concept.id}}
-                  >
-                    {{productId}}
-                  </AuLink>
-                </:value>
+            <ValueWithPlaceholder
+              @value={{@model.publicService.concept.productId}}
+            >
+              <:value as |productId|>
+                <AuLink
+                  @route="public-services.concept-details"
+                  @model={{@model.publicService.concept.id}}
+                >
+                  {{productId}}
+                </AuLink>
+              </:value>
+            </ValueWithPlaceholder>
+            {{#if this.canUnlinkConcept}}
+              <AuButton
+                @alert={{true}}
+                @icon="link-broken"
+                @skin="link"
+                {{on "click" this.showUnlinkWarning}}
+              >
+                Loskoppelen
+              </AuButton>
+            {{/if}}
+          </:content>
+        </Data>
+        <Data>
+          <:title>Product type</:title>
+          <:content>
+            <ValueWithPlaceholder @value={{@model.publicService.type.label}} />
+          </:content>
+        </Data>
+        <Data>
+          <:title>Aangemaakt op</:title>
+          <:content>
+            <ValueWithPlaceholder @value={{@model.publicService.created}}>
+              <:value as |value|>
+                {{moment-format value "DD-MM-YYYY - HH:mm"}}
+              </:value>
             </ValueWithPlaceholder>
           </:content>
         </Data>
-      <Data>
-        <:title>Product type</:title>
-        <:content>
-          <ValueWithPlaceholder @value={{@model.publicService.type.label}} />
-        </:content>
-      </Data>
-      <Data>
-        <:title>Aangemaakt op</:title>
-        <:content>
-          <ValueWithPlaceholder @value={{@model.publicService.created}}>
-            <:value as |value|>
-              {{moment-format value "DD-MM-YYYY - HH:mm"}}
-            </:value>
-          </ValueWithPlaceholder>
-        </:content>
-      </Data>
-      <Data>
-        <:title>Bewerkt op</:title>
-        <:content>
-          <ValueWithPlaceholder @value={{@model.publicService.modified}}>
-            <:value as |value|>
-              {{moment-format value "DD-MM-YYYY - HH:mm"}}
-            </:value>
-          </ValueWithPlaceholder>
-        </:content>
-      </Data>
-      <Data>
-        <:title>Geldig vanaf</:title>
-        <:content>
-          <ValueWithPlaceholder @value={{@model.publicService.startDate}}>
-            <:value as |value|>
-              {{moment-format value "DD-MM-YYYY"}}
-            </:value>
-          </ValueWithPlaceholder>
-        </:content>
-      </Data>
-      <Data>
-        <:title>Geldig tot</:title>
-        <:content>
-          <ValueWithPlaceholder @value={{@model.publicService.endDate}}>
-            <:value as |value|>
-              {{moment-format value "DD-MM-YYYY"}}
-            </:value>
-          </ValueWithPlaceholder>
-        </:content>
-      </Data>
-      <Data>
-        <:title>Status document</:title>
-        <:content>
-          {{#if @model.publicService.status.label}}
-            <PublicServices::Status @uri={{@model.publicService.status.uri}}>
-              {{@model.publicService.status.label}}
-            </PublicServices::Status>
-          {{else}}
-            –
-          {{/if}}
-        </:content>
-      </Data>
-    </DataList>
+        <Data>
+          <:title>Bewerkt op</:title>
+          <:content>
+            <ValueWithPlaceholder @value={{@model.publicService.modified}}>
+              <:value as |value|>
+                {{moment-format value "DD-MM-YYYY - HH:mm"}}
+              </:value>
+            </ValueWithPlaceholder>
+          </:content>
+        </Data>
+        <Data>
+          <:title>Geldig vanaf</:title>
+          <:content>
+            <ValueWithPlaceholder @value={{@model.publicService.startDate}}>
+              <:value as |value|>
+                {{moment-format value "DD-MM-YYYY"}}
+              </:value>
+            </ValueWithPlaceholder>
+          </:content>
+        </Data>
+        <Data>
+          <:title>Geldig tot</:title>
+          <:content>
+            <ValueWithPlaceholder @value={{@model.publicService.endDate}}>
+              <:value as |value|>
+                {{moment-format value "DD-MM-YYYY"}}
+              </:value>
+            </ValueWithPlaceholder>
+          </:content>
+        </Data>
+        <Data>
+          <:title>Status document</:title>
+          <:content>
+            {{#if @model.publicService.status.label}}
+              <PublicServices::Status @uri={{@model.publicService.status.uri}}>
+                {{@model.publicService.status.label}}
+              </PublicServices::Status>
+            {{else}}
+              –
+            {{/if}}
+          </:content>
+        </Data>
+      </DataList>
+      {{#if this.shouldShowUnlinkWarning}}
+        <AuAlert
+          @title="Instantie loskoppelen van het concept"
+          @icon="circle-info"
+          @skin="error"
+          @size="small"
+          @closable={{this.unlinkConcept.isIdle}}
+          @onClose={{this.hideUnlinkWarning}}
+          class="au-u-margin-top au-u-max-width-small"
+        >
+          <p class="au-u-margin-top-tiny">
+            De link met het concept waarop dit product is gebaseerd, wordt opgeheven. Hierdoor kan je mogelijke wijzigingen aan het concept niet langer opvolgen.
+            Je kan een instantie op elk moment opnieuw koppelen aan een concept.
+          </p>
+          <AuButtonGroup class="au-u-margin-top-small">
+            <AuButton
+              @icon="link-broken"
+              @alert={{true}}
+              @loading={{this.unlinkConcept.isRunning}}
+              @loadingMessage="Aan het loskoppelen"
+              {{on "click" (perform this.unlinkConcept)}}
+            >Loskoppelen</AuButton>
+            <AuButton
+              @skin="secondary"
+              @disabled={{this.unlinkConcept.isRunning}}
+              {{on "click" this.hideUnlinkWarning}}
+            >Annuleren</AuButton>
+          </AuButtonGroup>
+        </AuAlert>
+      {{/if}}
+    </div>
   </Group>
 
   {{#if (or this.showReviewRequiredMessage this.markAsReviewed.isRunning)}}


### PR DESCRIPTION
DL-5054

Best to be reviewed by hiding whitespace changes:
![image](https://user-images.githubusercontent.com/3533236/232535521-bdf83880-a5c3-41d3-88ac-ef67274e11a0.png)

To test:
- create a new public service instance by selecting a concept in the list
- the unlink button should be visible
- clicking it should ask for confirmation
- confirming should remove the link to the concept (and in a future PR it will then be possible to link to a new concept again)
- Unlinking should not be possible if the status is "published", so users will have to open an instance for editing before the button appears again.
