### PR TITLE
Fix the rich text editor field validations

### DIFF
--- a/app/components/rdf-form-fields/rich-text-editor.js
+++ b/app/components/rdf-form-fields/rich-text-editor.js
@@ -110,7 +110,10 @@ export default class RdfFormFieldsRichTextEditorComponent extends SimpleInputFie
 
     //rdfaEditor setup is async, updateValue may be called before it is set
     if (this.editorController) {
-      const editorValue = this.editorController.htmlContent;
+      this.hasBeenFocused = true;
+      const htmlContent = this.editorController.htmlContent;
+      // TODO: This is a known "issue" in the editor so it might be solved there as well. Check if this is still needed when updating the editor.
+      const editorValue = hasTextContent(htmlContent) ? htmlContent : '';
 
       // Only trigger an update if the value actually changed.
       // This prevents that the form observer is triggered even though no editor content was changed.
@@ -128,4 +131,11 @@ export default class RdfFormFieldsRichTextEditorComponent extends SimpleInputFie
       this.value = '';
     }
   }
+}
+
+function hasTextContent(htmlContent) {
+  const div = document.createElement('div');
+  div.innerHTML = htmlContent;
+
+  return Boolean(div.textContent);
 }


### PR DESCRIPTION
It seems one of the say-editor updates caused a change in the `htmlContent` value when the editor is (visually) empty. Before the update it used to be an empty string, but now it returns an empty `<p>` tag instead. This also has the side effect that the "required" validation no longer works as expected since the field has content (even if it is not visible). We now check the `textContent` to determine if the field is empty or not.

We now also set the `hasBeenFocused` to true when the field is focused, so the validation errors will be shown earlier, in line with the other form fields.