### PR TITLE
Update to ember-submission-form-fields v2.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@lblod/ember-acmidm-login": "2.0.0-beta.1",
         "@lblod/ember-mock-login": "^0.7.0",
         "@lblod/ember-rdfa-editor": "^3.5.0",
-        "@lblod/ember-submission-form-fields": "^2.9.1",
+        "@lblod/ember-submission-form-fields": "^2.10.0",
         "@lblod/submission-form-helpers": "^2.2.0",
         "broccoli-asset-rev": "^3.0.0",
         "browser-update": "^3.3.38",
@@ -5324,9 +5324,9 @@
       }
     },
     "node_modules/@lblod/ember-submission-form-fields": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.9.1.tgz",
-      "integrity": "sha512-AWSRjElKTK/49Ou6ZZ9EwraIKdTU0guTj/Zx7rT9sBY67KGP82Whni1SWVmm0bmKaFg1/ylV1oKZN2eScgEHpA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.10.0.tgz",
+      "integrity": "sha512-fQFrwDxHADZvsgW6w6+xXFjrEgw8J3HuSkoayE0srWxuDmGYTPGRMWCFkTqL4tcC55EoYHaidR1muzrKPs+cbA==",
       "dev": true,
       "dependencies": {
         "@lblod/submission-form-helpers": "^2.0.1",
@@ -43320,9 +43320,9 @@
       }
     },
     "@lblod/ember-submission-form-fields": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.9.1.tgz",
-      "integrity": "sha512-AWSRjElKTK/49Ou6ZZ9EwraIKdTU0guTj/Zx7rT9sBY67KGP82Whni1SWVmm0bmKaFg1/ylV1oKZN2eScgEHpA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.10.0.tgz",
+      "integrity": "sha512-fQFrwDxHADZvsgW6w6+xXFjrEgw8J3HuSkoayE0srWxuDmGYTPGRMWCFkTqL4tcC55EoYHaidR1muzrKPs+cbA==",
       "dev": true,
       "requires": {
         "@lblod/submission-form-helpers": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@lblod/ember-acmidm-login": "2.0.0-beta.1",
     "@lblod/ember-mock-login": "^0.7.0",
     "@lblod/ember-rdfa-editor": "^3.5.0",
-    "@lblod/ember-submission-form-fields": "^2.9.1",
+    "@lblod/ember-submission-form-fields": "^2.10.0",
     "@lblod/submission-form-helpers": "^2.2.0",
     "broccoli-asset-rev": "^3.0.0",
     "browser-update": "^3.3.38",


### PR DESCRIPTION
This version includes the "min count" feature we need for the subsidy forms.

Changelog: https://github.com/lblod/ember-submission-form-fields/blob/master/CHANGELOG.md#v2100-2023-04-21