### PR TITLE
Fix a semantic forms regression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -117,9 +117,9 @@
       }
     },
     "node_modules/@appuniversum/ember-appuniversum": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-2.4.2.tgz",
-      "integrity": "sha512-Uv1l8bjcIEv/KJ2il/UOgUmQAl/eGgJeXRbNtbF6mP+A+UVhxJscETBYt9/MMs1tgtsePOm7JrHbiWfKQHoebQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-2.5.0.tgz",
+      "integrity": "sha512-0BGJNQhksbgKiz9dF2+Dhx09170WIFh06bqp8MPWP6/5pEuFG8DoiNYb/DRqhiv1xiD6yPBtIt9GG+WhHzudwg==",
       "dev": true,
       "dependencies": {
         "@duetds/date-picker": "^1.4.0",
@@ -39384,9 +39384,9 @@
       }
     },
     "@appuniversum/ember-appuniversum": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-2.4.2.tgz",
-      "integrity": "sha512-Uv1l8bjcIEv/KJ2il/UOgUmQAl/eGgJeXRbNtbF6mP+A+UVhxJscETBYt9/MMs1tgtsePOm7JrHbiWfKQHoebQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-2.5.0.tgz",
+      "integrity": "sha512-0BGJNQhksbgKiz9dF2+Dhx09170WIFh06bqp8MPWP6/5pEuFG8DoiNYb/DRqhiv1xiD6yPBtIt9GG+WhHzudwg==",
       "dev": true,
       "requires": {
         "@duetds/date-picker": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -28,17 +28,13 @@
     "test:ember": "ember test"
   },
   "overrides": {
-    "@appuniversum/ember-appuniversum": "$@appuniversum/ember-appuniversum",
     "@embroider/macros": "$@embroider/macros",
     "@embroider/util": "^1.0.0",
     "ember-cli-babel": "$ember-cli-babel",
     "moment": "^2.29.1"
   },
-  "overridesNotes": {
-    "appuniversum": "ember-acmidm-login brings in a v1 version. We can remove the override once that is resolved."
-  },
   "devDependencies": {
-    "@appuniversum/ember-appuniversum": "^2.4.2",
+    "@appuniversum/ember-appuniversum": "^2.5.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.7",
     "@ember/optional-features": "^2.0.0",


### PR DESCRIPTION
One of the forms in "toezicht" uses a checkbox component that requires Appuniversum 2.5. Our SemVer version should support that already, but it seems the npm overrides made it ignore that requirement and we were still on 2.4. This meant that an error would be thrown because the component could not be found.

We can safely remove the override since we updated to the latest beta of ember-acmidm-login which no longer brings in a v1 version.