### PR TITLE
Disable autofill on start and end date fields when creating mandataris

### DIFF
--- a/app/templates/eredienst-mandatenbeheer/new.hbs
+++ b/app/templates/eredienst-mandatenbeheer/new.hbs
@@ -106,6 +106,7 @@
               @error={{showError}}
               @warning={{showWarning}}
               @width="block"
+              autocomplete="off"
               id="mandate-start-date"
             />
             {{#if showError}}
@@ -148,6 +149,7 @@
               @error={{showError}}
               @warning={{showWarning}}
               @width="block"
+              autocomplete="off"
               id="mandate-end-date"
             />
             {{#if showError}}


### PR DESCRIPTION
(Addresses DL-5081) Disables auto-fill on start and end date fields when creating a mandate which was causing issues with the validation code of the `Startdatum` field.

I checked the mandataris edit page to see if auto-fill shows up, but I did not see any browser autopilot window when setting/changing the start and end dates.