### PR TITLE
Fix a `<AuDateInput>` autofill issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.79.1",
       "license": "MIT",
       "devDependencies": {
-        "@appuniversum/ember-appuniversum": "^2.5.0",
+        "@appuniversum/ember-appuniversum": "^2.6.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.7",
         "@ember/optional-features": "^2.0.0",
@@ -117,9 +117,9 @@
       }
     },
     "node_modules/@appuniversum/ember-appuniversum": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-2.5.0.tgz",
-      "integrity": "sha512-0BGJNQhksbgKiz9dF2+Dhx09170WIFh06bqp8MPWP6/5pEuFG8DoiNYb/DRqhiv1xiD6yPBtIt9GG+WhHzudwg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-2.6.0.tgz",
+      "integrity": "sha512-yWYYQYVSVwcWGRvVegLFGzXTe8fag3GCq85K1z+CvFMQ+UxvwkMtiHVf8acgL2tlLrOlfD6AOWvahSoCN6Kkiw==",
       "dev": true,
       "dependencies": {
         "@duetds/date-picker": "^1.4.0",
@@ -39391,9 +39391,9 @@
       }
     },
     "@appuniversum/ember-appuniversum": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-2.5.0.tgz",
-      "integrity": "sha512-0BGJNQhksbgKiz9dF2+Dhx09170WIFh06bqp8MPWP6/5pEuFG8DoiNYb/DRqhiv1xiD6yPBtIt9GG+WhHzudwg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-2.6.0.tgz",
+      "integrity": "sha512-yWYYQYVSVwcWGRvVegLFGzXTe8fag3GCq85K1z+CvFMQ+UxvwkMtiHVf8acgL2tlLrOlfD6AOWvahSoCN6Kkiw==",
       "dev": true,
       "requires": {
         "@duetds/date-picker": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "moment": "^2.29.1"
   },
   "devDependencies": {
-    "@appuniversum/ember-appuniversum": "^2.5.0",
+    "@appuniversum/ember-appuniversum": "^2.6.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.7",
     "@ember/optional-features": "^2.0.0",


### PR DESCRIPTION
Appuniversum 2.6.0 disables autofill for the `<AuDateInput>` component since the inputmask library isn't compatible with Chrome's autofill behavior.

Supersedes #303

DL-5081