### PR TITLE
Fix the formatting of the rich-text editor contents in read-only mode

### DIFF
--- a/app/components/rdf-form-fields/rich-text-editor.hbs
+++ b/app/components/rdf-form-fields/rich-text-editor.hbs
@@ -11,10 +11,10 @@
 {{/if}}
 
 {{#if @show}}
-  <div class="rich-text-editor-content">
+  <AuContent @skin="tiny" class="rich-text-editor-content">
     {{! template-lint-disable no-triple-curlies}}
     {{{this.value}}}
-  </div>
+  </AuContent>
 {{else}}
   <div class="rich-text-editor" {{on "focusout" this.updateValue}}>
     <EditorContainer>

--- a/app/styles/project/_c-rich-text-editor.scss
+++ b/app/styles/project/_c-rich-text-editor.scss
@@ -88,4 +88,9 @@ $toolbar-height: 3.2rem; // TODO: we decrease the toolbar size so more icons fit
   border-color: var(--au-gray-300);
   color: var(--au-gray-700);
   cursor: not-allowed;
+
+  // TODO: Should .au-c-content include link styles?
+  a {
+    @extend .au-c-link;
+  }
 }


### PR DESCRIPTION
Editor:
![Screenshot 2023-05-04 at 10 02 22](https://user-images.githubusercontent.com/3533236/236147878-0bf0e084-78b9-4ccc-921e-75d6547f5c54.png)


read-only:
![Screenshot 2023-05-04 at 10 06 09](https://user-images.githubusercontent.com/3533236/236147924-f649bd58-b1f2-417f-9f2e-e15180c7bb03.png)

