### PR TITLE
Add support for concept archiving

### DIFF
--- a/app/controllers/public-services/concept-details.js
+++ b/app/controllers/public-services/concept-details.js
@@ -1,6 +1,9 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 
+const ARCHIVED_STATUS =
+  'http://lblod.data.gift/concepts/3f2666df-1dae-4cc2-a8dc-e8213e713081';
+
 export default class PublicServicesConceptDetailsController extends Controller {
   queryParams = [{ isPreview: 'preview', publicServiceId: 'id' }];
   isPreview = false;
@@ -8,6 +11,10 @@ export default class PublicServicesConceptDetailsController extends Controller {
 
   get isLinkFlowPreview() {
     return Boolean(this.publicServiceId);
+  }
+
+  get isArchived() {
+    return this.model.concept.status?.uri === ARCHIVED_STATUS;
   }
 
   @action async hideNewConceptMessage() {

--- a/app/controllers/public-services/details.js
+++ b/app/controllers/public-services/details.js
@@ -14,10 +14,17 @@ export default class PublicServicesDetailsController extends Controller {
   // We use a separate flag, otherwise the message would be hidden before the save was actually completed
   @tracked reviewStatus;
   @tracked shouldShowUnlinkWarning = false;
-  isConceptUpdated = isConceptUpdated;
 
   get showReviewRequiredMessage() {
     return Boolean(this.reviewStatus);
+  }
+
+  get isConceptUpdatedStatus() {
+    if (!this.showReviewRequiredMessage) {
+      return false;
+    }
+
+    return isConceptUpdated(this.reviewStatus);
   }
 
   get canLinkConcept() {

--- a/app/routes/public-services/add.js
+++ b/app/routes/public-services/add.js
@@ -40,6 +40,7 @@ export default class PublicServicesAddRoute extends Route {
     isInstantiated,
   }) {
     let query = {
+      'filter[:has-no:status]': 'yes',
       'page[number]': page,
       include: 'display-configuration',
     };

--- a/app/routes/public-services/link-concept/index.js
+++ b/app/routes/public-services/link-concept/index.js
@@ -36,6 +36,7 @@ export default class PublicServicesLinkConceptIndexRoute extends Route {
   @restartableTask
   *loadConcepts({ search, page, sort, isNewConcept, isInstantiated }) {
     let query = {
+      'filter[:has-no:status]': 'yes',
       'page[number]': page,
       include: 'display-configuration',
     };

--- a/app/templates/public-services/concept-details.hbs
+++ b/app/templates/public-services/concept-details.hbs
@@ -54,6 +54,16 @@
   </Group>
 </AuToolbar>
 
+{{#if this.isArchived}}
+  <AuAlert
+    @skin="warning"
+    @icon="circle-info"
+    @title="Dit concept werd gearchiveerd"
+    @size="small"
+    class="au-u-margin-left au-u-margin-right au-u-margin-bottom-none"
+  />
+{{/if}}
+
 {{#if @model.concept.displayConfiguration.isNewConcept}}
   <AuAlert
     @skin="success"

--- a/app/templates/public-services/details.hbs
+++ b/app/templates/public-services/details.hbs
@@ -148,24 +148,25 @@
   {{#if (or this.showReviewRequiredMessage this.markAsReviewed.isRunning)}}
     <Group>
       <AuAlert
-        @title="Herziening nodig"
-        @skin="warning"
+        @title={{if this.isConceptUpdated "Herziening nodig" "Concept gearchiveerd"}}
+        @skin={{if this.isConceptUpdated "warning" "error"}}
         @icon="alert-triangle"
         @size="small"
         class="au-u-margin-bottom-none"
       >
         <p>
-          {{#if (this.isConceptUpdated @model.publicService.reviewStatus)}}
+          {{#if this.isConceptUpdated}}
             Het concept waarop dit product is gebaseerd, werd aangepast. Gelieve
             na te kijken of je deze versie ook wil aanpassen.
           {{else}}
-            Het concept waarop dit product is gebaseerd, werd verwijderd.
-            Gelieve na te kijken of je deze versie ook wil verwijderen.
+            Het concept waarop dit product is gebaseerd, werd gearchiveerd.
+            Gelieve na te kijken of je deze versie wil behouden, aanpassen of
+            verwijderen.
           {{/if}}
         </p>
         <div class="au-u-margin-top-small">
           <AuButtonGroup>
-            {{#if (this.isConceptUpdated @model.publicService.reviewStatus)}}
+            {{#if @model.publicService.concept}}
               <AuLink
                 @route="public-services.concept-details"
                 @model={{@model.publicService.concept.id}}


### PR DESCRIPTION
We already supported deletes of concepts, but IPDC never actually deletes concepts, it archives them, so we follow the same pattern here.

We now also filter out archived concepts from both the creation and link flows.