### PR TITLE
Replace links to the old website with the new equivalents

### DIFF
--- a/app/components/rdf-form-fields/application-form-table/edit.hbs
+++ b/app/components/rdf-form-fields/application-form-table/edit.hbs
@@ -3,9 +3,11 @@
   aanmerking komt voor infrastructuursubsidies.
 </AuLabel>
 <AuHelpText class="au-u-margin-bottom-small">
-  Niet zeker wat u moet invullen? Ga naar de <a
-  href="https://lokaalbestuur.vlaanderen.be/loket-lokaal-bestuur-module-subsidies" target="_blank" rel="noopener noreferrer">informatiepagina
-  over subsidies</a> die u kan indienen via het loket.
+  Niet zeker wat u moet invullen? Ga naar de
+  <AuLinkExternal
+    href="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/subsidiebeheer"
+  >informatiepagina over subsidies</AuLinkExternal>
+  die u kan indienen via het loket.
 </AuHelpText>
 <AuLabel @error={{this.hasErrors}} @required={{this.isRequired}} for={{this.inputFor}}>
   {{@field.label}}

--- a/app/components/rdf-form-fields/application-form-table/show.hbs
+++ b/app/components/rdf-form-fields/application-form-table/show.hbs
@@ -2,7 +2,11 @@
   Vul in per organisator: het aantal opgevangen kinderen voor alle volle dagen, voor alle halve dagen en voor infrastructuur.
 </AuLabel>
 <AuHelpText class="au-u-margin-bottom-small">
-  Niet zeker wat u moet invullen? Ga naar de <a href="https://lokaalbestuur.vlaanderen.be/loket-lokaal-bestuur-module-subsidies" target="_blank" rel="noopener noreferrer">informatiepagina over subsidies</a> die u kan indienen via het loket.
+  Niet zeker wat u moet invullen? Ga naar de
+  <AuLinkExternal
+    href="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/subsidiebeheer"
+  >informatiepagina over subsidies</AuLinkExternal>
+  die u kan indienen via het loket.
 </AuHelpText>
 <table class="data-table data-table--zebra data-table--tight au-u-margin-top-small ">
   <caption class="au-u-hidden-visually">Vul het aantal opgevangen kinderen voor alle volle en halve dagen en het aantal kinderen dat in aanmerking komt voor infrastructuursubsidies per organisator in</caption>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -15,7 +15,7 @@
       <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
           @icon="search-folder"
-          @extraInformationLink="https://lokaalbestuur.vlaanderen.be/loket-lokaal-bestuur-module-toezicht"
+          @extraInformationLink="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/toezicht"
           @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/toezicht"
         >
           <:title>Toezicht</:title>
@@ -30,7 +30,7 @@
       <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
           @icon="message"
-          @extraInformationLink="https://lokaalbestuur.vlaanderen.be/loket-lokaal-bestuur-module-berichtencentrum"
+          @extraInformationLink="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/berichtencentrum"
           @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/berichtencentrum"
         >
           <:title>Berichtencentrum</:title>
@@ -45,7 +45,7 @@
       <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
           @icon="document"
-          @extraInformationLink="https://lokaalbestuur.vlaanderen.be/bbc-strategisch-en-financieel-beleid/digitale-rapportering"
+          @extraInformationLink="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/beleids-en-beheerscyclus-digitale-rapportering-bbc-dr"
           @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/bbc-dr"
         >
           <:title>BBC-DR</:title>
@@ -60,7 +60,7 @@
       <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
           @icon="user-fill"
-          @extraInformationLink="https://lokaalbestuur.vlaanderen.be/mandatarissen/mandatendatabank"
+          @extraInformationLink="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/mandatenbeheer-lokale-besturen"
           @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/mandatenbeheer"
         >
           <:title>Mandatenbeheer</:title>
@@ -75,7 +75,7 @@
         <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
           <LoketModuleCard
             @icon="user"
-            @extraInformationLink="https://lokaalbestuur.vlaanderen.be/erediensten"
+            @extraInformationLink="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/bedienarenbeheer"
             @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/bedienarenbeheer"
           >
             <:title>Bedienarenbeheer</:title>
@@ -90,7 +90,7 @@
         <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
           <LoketModuleCard
             @icon="users-four-of-four"
-            @extraInformationLink="https://lokaalbestuur.vlaanderen.be/erediensten"
+            @extraInformationLink="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/mandatenbeheer-erediensten"
             @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/mandatenbeheer"
           >
             <:title>Mandatenbeheer</:title>
@@ -105,7 +105,7 @@
       <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
           @icon="user-popup"
-          @extraInformationLink="https://lokaalbestuur.vlaanderen.be/personeel/databank-leidinggevenden"
+          @extraInformationLink="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/leidinggevendenbeheer"
           @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/leidinggevendenbeheer"
         >
           <:title>Leidinggevendenbeheer</:title>
@@ -134,7 +134,7 @@
       <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
           @icon="documents"
-          @extraInformationLink="https://lokaalbestuur.vlaanderen.be/loket-lokaal-bestuur-module-subsidies"
+          @extraInformationLink="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/subsidiebeheer"
           @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/subsidiebeheer"
         >
           <:title>Subsidiebeheer</:title>
@@ -149,7 +149,7 @@
         <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
         <LoketModuleCard
           @icon="unordered-list"
-          @extraInformationLink="https://lokaalbestuur.vlaanderen.be/lokale-producten-en-dienstencatalogus"
+          @extraInformationLink="https://www.vlaanderen.be/lokaal-bestuur/digitale-transformatie/lokale-producten-en-dienstencatalogus"
           @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/producten-en-dienstencatalogus"
         >
           <:title>Producten- en dienstencatalogus</:title>

--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -38,8 +38,20 @@
                 </c.content>
                 <c.footer>
                   <p>
-                    <a class="au-c-button" href="https://lokaalbestuur.vlaanderen.be/mijn-binnenland" target="_blank" rel="noopener noreferrer">Meer informatie</a>
-                    <a class="au-c-button au-c-button--secondary" href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/toezicht" target="_blank" rel="noopener noreferrer">Handleiding</a>
+                    <AuLinkExternal
+                      @skin="button"
+                      @icon="link"
+                      href="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/toezicht"
+                    >
+                      Meer informatie
+                    </AuLinkExternal>
+                    <AuLinkExternal
+                      @skin="button-secondary"
+                      @icon="manual"
+                      href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/toezicht"
+                    >
+                      Handleiding
+                    </AuLinkExternal>
                   </p>
                 </c.footer>
               </AuCard>
@@ -56,8 +68,20 @@
                 </c.content>
                 <c.footer>
                   <p>
-                    <a class="au-c-button" href="https://lokaalbestuur.vlaanderen.be/loket-lokaal-bestuur-module-berichtencentrum" target="_blank" rel="noopener noreferrer">Meer informatie</a>
-                    <a class="au-c-button au-c-button--secondary" href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/berichtencentrum" target="_blank" rel="noopener noreferrer">Handleiding</a>
+                    <AuLinkExternal
+                      @skin="button"
+                      @icon="link"
+                      href="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/berichtencentrum"
+                    >
+                      Meer informatie
+                    </AuLinkExternal>
+                    <AuLinkExternal
+                      @skin="button-secondary"
+                      @icon="manual"
+                      href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/berichtencentrum"
+                    >
+                      Handleiding
+                    </AuLinkExternal>
                   </p>
                 </c.footer>
               </AuCard>
@@ -74,8 +98,20 @@
                 </c.content>
                 <c.footer>
                   <p>
-                    <a class="au-c-button" href="https://lokaalbestuur.vlaanderen.be/bbc-strategisch-en-financieel-beleid/digitale-rapportering" target="_blank" rel="noopener noreferrer">Meer informatie</a>
-                    <a class="au-c-button au-c-button--secondary" href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/bbc-dr" target="_blank" rel="noopener noreferrer">Handleiding</a>
+                    <AuLinkExternal
+                      @skin="button"
+                      @icon="link"
+                      href="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/beleids-en-beheerscyclus-digitale-rapportering-bbc-dr"
+                    >
+                      Meer informatie
+                    </AuLinkExternal>
+                    <AuLinkExternal
+                      @skin="button-secondary"
+                      @icon="manual"
+                      href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/bbc-dr"
+                    >
+                      Handleiding
+                    </AuLinkExternal>
                   </p>
                 </c.footer>
               </AuCard>
@@ -92,8 +128,20 @@
                 </c.content>
                 <c.footer>
                   <p>
-                    <a class="au-c-button" href="https://lokaalbestuur.vlaanderen.be/mandatarissen/mandatendatabank" target="_blank" rel="noopener noreferrer">Meer informatie</a>
-                    <a class="au-c-button au-c-button--secondary" href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/mandatenbeheer" target="_blank" rel="noopener noreferrer">Handleiding</a>
+                    <AuLinkExternal
+                      @skin="button"
+                      @icon="link"
+                      href="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/mandatenbeheer-lokale-besturen"
+                    >
+                      Meer informatie
+                    </AuLinkExternal>
+                    <AuLinkExternal
+                      @skin="button-secondary"
+                      @icon="manual"
+                      href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/mandatenbeheer"
+                    >
+                      Handleiding
+                    </AuLinkExternal>
                   </p>
                 </c.footer>
               </AuCard>
@@ -110,8 +158,20 @@
                 </c.content>
                 <c.footer>
                   <p>
-                    <a class="au-c-button" href="https://lokaalbestuur.vlaanderen.be/erediensten" target="_blank" rel="noopener noreferrer">Meer informatie</a>
-                    <a class="au-c-button au-c-button--secondary" href="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/bedienarenbeheer" target="_blank" rel="noopener noreferrer">Handleiding</a>
+                    <AuLinkExternal
+                      @skin="button"
+                      @icon="link"
+                      href="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/bedienarenbeheer"
+                    >
+                      Meer informatie
+                    </AuLinkExternal>
+                    <AuLinkExternal
+                      @skin="button-secondary"
+                      @icon="manual"
+                      href="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/bedienarenbeheer"
+                    >
+                      Handleiding
+                    </AuLinkExternal>
                   </p>
                 </c.footer>
               </AuCard>
@@ -128,8 +188,20 @@
                 </c.content>
                 <c.footer>
                   <p>
-                    <a class="au-c-button" href="https://lokaalbestuur.vlaanderen.be/erediensten" target="_blank" rel="noopener noreferrer">Meer informatie</a>
-                    <a class="au-c-button au-c-button--secondary" href="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/mandatenbeheer" target="_blank" rel="noopener noreferrer">Handleiding</a>
+                    <AuLinkExternal
+                      @skin="button"
+                      @icon="link"
+                      href="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/mandatenbeheer-erediensten"
+                    >
+                      Meer informatie
+                    </AuLinkExternal>
+                    <AuLinkExternal
+                      @skin="button-secondary"
+                      @icon="manual"
+                      href="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/mandatenbeheer"
+                    >
+                      Handleiding
+                    </AuLinkExternal>
                   </p>
                 </c.footer>
               </AuCard>
@@ -146,8 +218,20 @@
                 </c.content>
                 <c.footer>
                   <p>
-                    <a class="au-c-button" href="https://lokaalbestuur.vlaanderen.be/personeel/databank-leidinggevenden" target="_blank" rel="noopener noreferrer">Meer informatie</a>
-                    <a class="au-c-button au-c-button--secondary" href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/leidinggevendenbeheer" target="_blank" rel="noopener noreferrer">Handleiding</a>
+                    <AuLinkExternal
+                      @skin="button"
+                      @icon="link"
+                      href="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/leidinggevendenbeheer"
+                    >
+                      Meer informatie
+                    </AuLinkExternal>
+                    <AuLinkExternal
+                      @skin="button-secondary"
+                      @icon="manual"
+                      href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/leidinggevendenbeheer"
+                    >
+                      Handleiding
+                    </AuLinkExternal>
                   </p>
                 </c.footer>
               </AuCard>
@@ -164,7 +248,13 @@
                 </c.content>
                 <c.footer>
                   <p>
-                    <a class="au-c-button au-c-button--secondary" href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/personeelsbeheer" target="_blank" rel="noopener noreferrer">Handleiding</a>
+                    <AuLinkExternal
+                      @skin="button-secondary"
+                      @icon="manual"
+                      href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/personeelsbeheer"
+                    >
+                      Handleiding
+                    </AuLinkExternal>
                   </p>
                 </c.footer>
               </AuCard>
@@ -182,8 +272,20 @@
                 </c.content>
                 <c.footer>
                   <p>
-                    <a class="au-c-button" href="https://lokaalbestuur.vlaanderen.be/loket-lokaal-bestuur-module-subsidies" target="_blank" rel="noopener noreferrer">Meer informatie</a>
-                    <a class="au-c-button au-c-button--secondary" href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/subsidiebeheer" target="_blank" rel="noopener noreferrer">Handleiding</a>
+                    <AuLinkExternal
+                      @skin="button"
+                      @icon="link"
+                      href="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/subsidiebeheer"
+                    >
+                      Meer informatie
+                    </AuLinkExternal>
+                    <AuLinkExternal
+                      @skin="button-secondary"
+                      @icon="manual"
+                      href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/subsidiebeheer"
+                    >
+                      Handleiding
+                    </AuLinkExternal>
                   </p>
                 </c.footer>
               </AuCard>
@@ -201,8 +303,20 @@
                 </c.content>
                 <c.footer>
                   <p>
-                    <a class="au-c-button" href="https://lokaalbestuur.vlaanderen.be/lokale-producten-en-dienstencatalogus" target="_blank" rel="noopener noreferrer">Meer informatie</a>
-                    <a class="au-c-button au-c-button--secondary" href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/producten-en-dienstencatalogus" target="_blank" rel="noopener noreferrer">Handleiding</a>
+                    <AuLinkExternal
+                      @skin="button"
+                      @icon="link"
+                      href="https://www.vlaanderen.be/lokaal-bestuur/digitale-transformatie/lokale-producten-en-dienstencatalogus"
+                    >
+                      Meer informatie
+                    </AuLinkExternal>
+                    <AuLinkExternal
+                      @skin="button-secondary"
+                      @icon="manual"
+                      href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/producten-en-dienstencatalogus"
+                    >
+                      Handleiding
+                    </AuLinkExternal>
                   </p>
                 </c.footer>
               </AuCard>

--- a/app/templates/subsidy/applications/available-subsidies-loading.hbs
+++ b/app/templates/subsidy/applications/available-subsidies-loading.hbs
@@ -5,9 +5,12 @@
     <div>
       <AuHeading @skin="2">Beschikbare subsidiemaatregelen</AuHeading>
       <p>
-        Kies een van de subsidiemaatregelen om een nieuwe aanvraag te starten. Bekijk <a
-              href="https://lokaalbestuur.vlaanderen.be/loket-lokaal-bestuur-module-subsidies" target="_blank"
-              rel="noopener noreferrer">inhoudelijke informatie over de subsidies</a> die je hier kan aanvragen.
+        Kies een van de subsidiemaatregelen om een nieuwe aanvraag te starten.
+        Bekijk
+        <AuLinkExternal
+          href="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/subsidiebeheer"
+        >inhoudelijke informatie over de subsidies</AuLinkExternal>
+        die je hier kan aanvragen.
       </p>
     </div>
   </Group>

--- a/app/templates/subsidy/applications/available-subsidies.hbs
+++ b/app/templates/subsidy/applications/available-subsidies.hbs
@@ -7,11 +7,9 @@
       <p>
         Kies een van de subsidiemaatregelen om een nieuwe aanvraag te starten.
         Bekijk
-        <a
-          href="https://lokaalbestuur.vlaanderen.be/loket-lokaal-bestuur-module-subsidies"
-          target="_blank"
-          rel="noopener noreferrer"
-        >inhoudelijke informatie over de subsidies</a>
+        <AuLinkExternal
+          href="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/subsidiebeheer"
+        >inhoudelijke informatie over de subsidies</AuLinkExternal>
         die je hier kan aanvragen.
       </p>
     </div>

--- a/app/templates/subsidy/applications/edit/step/edit.hbs
+++ b/app/templates/subsidy/applications/edit/step/edit.hbs
@@ -92,12 +92,10 @@
             >
               <p>We nemen contact op met de opgegeven contactpersoon over het
                 verdere verloop.
-                <a
-                  href="https://lokaalbestuur.vlaanderen.be/loket-lokaal-bestuur-module-subsidies"
-                  target="_blank"
-                  rel="noreferrer noopener"
+                <AuLinkExternal
+                  href="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/subsidiebeheer"
                 >Vind hier meer informatie over de inhoud en het verloop van de
-                  subsidies</a>.
+                  subsidies</AuLinkExternal>.
               </p>
               <p>Indien u een fout heeft ontdekt, of een vraag heeft, neem
                 contact op met
@@ -125,14 +123,11 @@
 
                     <p>
                       Meer informatie over de subsidieaanvragen vindt u
-                      <a
-                        class="au-c-link"
-                        href="https://lokaalbestuur.vlaanderen.be/loket-lokaal-bestuur-module-subsidies"
-                        target="_blank"
-                        rel="noopener noreferrer"
+                      <AuLinkExternal
+                        href="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/subsidiebeheer"
                       >
                         hier
-                      </a>.<br />
+                      </AuLinkExternal>.<br />
                       Indien u een fout heeft ontdekt, of een vraag heeft, neem
                       contact op met
                       <a


### PR DESCRIPTION
With the go-live of the the new website, all old `https://lokaalbestuur.vlaanderen.be` links redirect to a generic `https://www.vlaanderen.be/lokaal-bestuur` page. This updates these links with their equivalents on the new website.