### PR TITLE
Don't show the unsaved changes modal for read-only forms

### DIFF
--- a/app/components/public-services/details-page.js
+++ b/app/components/public-services/details-page.js
@@ -51,7 +51,10 @@ export default class PublicServicesDetailsPageComponent extends Component {
     super(...arguments);
     this.loadForm.perform();
     this.sourceNode = new NamedNode(this.args.publicService.uri);
-    this.router.on('routeWillChange', this, this.showUnsavedChangesModal);
+
+    if (!this.args.readOnly) {
+      this.router.on('routeWillChange', this, this.showUnsavedChangesModal);
+    }
   }
 
   @task
@@ -74,7 +77,9 @@ export default class PublicServicesDetailsPageComponent extends Component {
       FORM_GRAPHS.formGraph
     );
 
-    formStore.registerObserver(this.updateFormDirtyState, this.id);
+    if (!this.args.readOnly) {
+      formStore.registerObserver(this.updateFormDirtyState, this.id);
+    }
 
     this.form = form;
     this.formStore = formStore;
@@ -263,8 +268,10 @@ export default class PublicServicesDetailsPageComponent extends Component {
   willDestroy() {
     super.willDestroy(...arguments);
 
-    this.formStore?.deregisterObserver(this.id);
-    this.router.off('routeWillChange', this, this.showUnsavedChangesModal);
+    if (!this.args.readOnly) {
+      this.formStore?.deregisterObserver(this.id);
+      this.router.off('routeWillChange', this, this.showUnsavedChangesModal);
+    }
   }
 }
 

--- a/app/templates/public-services/details/content.hbs
+++ b/app/templates/public-services/details/content.hbs
@@ -2,7 +2,10 @@
 
 <PublicServices::DetailsPage
   @publicService={{@model.publicService}}
-  @readOnly={{@model.readOnly}}
+  {{! We use `this.model` here since the value is used in the willDestroy method, and the `@model` version is undefined at that point.
+      More information: https://github.com/emberjs/ember.js/issues/18987
+  }}
+  @readOnly={{this.model.readOnly}}
   @formId="cd0b5eba-33c1-45d9-aed9-75194c3728d3"
   @tabName="au-c-rdf-form--content"
 />

--- a/app/templates/public-services/details/properties.hbs
+++ b/app/templates/public-services/details/properties.hbs
@@ -2,7 +2,10 @@
 
 <PublicServices::DetailsPage
   @publicService={{@model.publicService}}
-  @readOnly={{@model.readOnly}}
+  {{! We use `this.model` here since the value is used in the willDestroy method, and the `@model` version is undefined at that point.
+      More information: https://github.com/emberjs/ember.js/issues/18987
+  }}
+  @readOnly={{this.model.readOnly}}
   @formId="149a7247-0294-44a5-a281-0a4d3782b4fd"
   @tabName="au-c-rdf-form--properties"
 />


### PR DESCRIPTION
In some cases, form fields update the form store even when the form is in read-only mode. This is essentially a bug in the fields, and it should be fixed, but it's easy to introduce such regressions.

This change simply removes the change handlers so that the modal will never be shown when the form is in read-only mode. That way the popup will not be displayed even if fields update the form store by accident.

DL-5218