### PR TITLE
Update the submit button text in the Toezicht module

### DIFF
--- a/app/templates/supervision/submissions/edit.hbs
+++ b/app/templates/supervision/submissions/edit.hbs
@@ -82,7 +82,7 @@
       <AuButton data-test-field-uri="submit-form-button"
                 @disabled={{if (or this.save.isRunning this.submit.isRunning this.delete.isRunning) "true"}}
                 @loading={{if this.submit.isRunning "true"}}
-                {{on "click" (perform this.submit)}}>Verzend naar Vlaamse overheid</AuButton>
+                {{on "click" (perform this.submit)}}>Verzenden</AuButton>
       <AuButton @disabled={{if (or this.save.isRunning this.submit.isRunning this.delete.isRunning) "true"}}
                 @loading={{if this.save.isRunning "true"}}
                 @skin={{"secondary"}}


### PR DESCRIPTION
Not everyone who uses the toezicht module submits documents to governments, so this makes the button label more generic.

DL-4394