### PR TITLE
Fix the spacing between pills in table rows

### DIFF
--- a/app/components/pill-list.hbs
+++ b/app/components/pill-list.hbs
@@ -1,0 +1,7 @@
+{{#if @list}}
+  <AuList @direction="horizontal" class="au-u-flex--wrap" as |Item|>
+    {{#each @list as |item|}}
+      <Item>{{yield item}}</Item>
+    {{/each}}
+  </AuList>
+{{/if}}

--- a/app/templates/public-services/add.hbs
+++ b/app/templates/public-services/add.hbs
@@ -150,25 +150,31 @@
             <td>{{publicService.productId}}</td>
             <td>{{publicService.type.label}}</td>
             <td>
-              {{#each publicService.targetAudiences as |targetAudience|}}
+              <PillList
+                @list={{publicService.targetAudiences}}
+                as |targetAudience|
+              >
                 <AuPill>
                   {{targetAudience.label}}
                 </AuPill>
-              {{/each}}
+              </PillList>
             </td>
             <td>
-              {{#each publicService.competentAuthorityLevels as |level|}}
+              <PillList
+                @list={{publicService.competentAuthorityLevels}}
+                as |level|
+              >
                 <AuPill>
                   {{level.label}}
                 </AuPill>
-              {{/each}}
+              </PillList>
             </td>
             <td>
-              {{#each publicService.conceptTags as |tag|}}
+              <PillList @list={{publicService.conceptTags}} as |tag|>
                 <AuPill>
                   {{tag.label}}
                 </AuPill>
-              {{/each}}
+              </PillList>
             </td>
             <td class="u-table-cell-fit-content">
               <AuLink

--- a/app/templates/public-services/index.hbs
+++ b/app/templates/public-services/index.hbs
@@ -121,18 +121,21 @@
         </td>
         <td>{{publicService.type.label}}</td>
         <td>
-          {{#each publicService.targetAudiences as |tag|}}
+          <PillList @list={{publicService.targetAudiences}} as |targetAudience|>
             <AuPill>
-              {{tag.label}}
+              {{targetAudience.label}}
             </AuPill>
-          {{/each}}
+          </PillList>
         </td>
         <td>
-          {{#each publicService.executingAuthorityLevels as |tag|}}
+          <PillList
+            @list={{publicService.executingAuthorityLevels}}
+            as |executingAuthorityLevel|
+          >
             <AuPill>
-              {{tag.label}}
+              {{executingAuthorityLevel.label}}
             </AuPill>
-          {{/each}}
+          </PillList>
         </td>
         <td>
           {{moment-format publicService.modified "DD-MM-YYYY - HH:mm"}}

--- a/app/templates/public-services/link-concept/index.hbs
+++ b/app/templates/public-services/link-concept/index.hbs
@@ -169,25 +169,25 @@
             <td>{{concept.productId}}</td>
             <td>{{concept.type.label}}</td>
             <td>
-              {{#each concept.targetAudiences as |targetAudience|}}
+              <PillList @list={{concept.targetAudiences}} as |targetAudience|>
                 <AuPill>
                   {{targetAudience.label}}
                 </AuPill>
-              {{/each}}
+              </PillList>
             </td>
             <td>
-              {{#each concept.competentAuthorityLevels as |level|}}
+              <PillList @list={{concept.competentAuthorityLevels}} as |level|>
                 <AuPill>
                   {{level.label}}
                 </AuPill>
-              {{/each}}
+              </PillList>
             </td>
             <td>
-              {{#each concept.conceptTags as |tag|}}
+              <PillList @list={{concept.conceptTags}} as |tag|>
                 <AuPill>
                   {{tag.label}}
                 </AuPill>
-              {{/each}}
+              </PillList>
             </td>
             <td class="u-table-cell-fit-content">
               <AuLink


### PR DESCRIPTION
When the pills wrapped around there was no whitespace between them, this fixes that issue by wrapping them in a `AuList` component.


Before:
![image](https://github.com/lblod/frontend-loket/assets/3533236/dcfbba77-d119-401f-b5b6-f5691aba1df7)

After:
![image](https://github.com/lblod/frontend-loket/assets/3533236/f7c25ae0-57d9-4e8d-a953-5444252ff7e9)
