### PR TITLE
Disable the submit and save buttons if the form isn't loaded

### DIFF
--- a/app/components/public-services/details-page.hbs
+++ b/app/components/public-services/details-page.hbs
@@ -49,7 +49,7 @@
         </AuButton>
       {{else}}
         <AuButton
-          @disabled={{this.publicServiceAction.isRunning}}
+          @disabled={{not this.canSubmit}}
           {{on "click" this.requestSubmitConfirmation}}
         >
           Verzend naar Vlaamse overheid
@@ -57,10 +57,7 @@
 
         <AuButton
           @skin="secondary"
-          @disabled={{or
-            (not this.hasUnsavedChanges)
-            this.publicServiceAction.isRunning
-          }}
+          @disabled={{not this.canSave}}
           @loading={{this.handleFormSubmit.isRunning}}
           form={{this.id}}
           type="submit"

--- a/app/components/public-services/details-page.js
+++ b/app/components/public-services/details-page.js
@@ -41,9 +41,9 @@ export default class PublicServicesDetailsPageComponent extends Component {
 
   @tracked hasUnsavedChanges = false;
   @tracked forceShowErrors = false;
+  @tracked form;
 
   id = guidFor(this);
-  form;
   formStore;
   graphs = FORM_GRAPHS;
 
@@ -55,6 +55,22 @@ export default class PublicServicesDetailsPageComponent extends Component {
     if (!this.args.readOnly) {
       this.router.on('routeWillChange', this, this.showUnsavedChangesModal);
     }
+  }
+
+  get isInitialized() {
+    return this.loadForm.last.isSuccessful;
+  }
+
+  get canSubmit() {
+    return this.isInitialized && this.publicServiceAction.isIdle;
+  }
+
+  get canSave() {
+    return (
+      this.isInitialized &&
+      this.hasUnsavedChanges &&
+      this.publicServiceAction.isIdle
+    );
   }
 
   @task
@@ -156,6 +172,10 @@ export default class PublicServicesDetailsPageComponent extends Component {
 
   @dropTask
   *saveSemanticForm() {
+    if (!this.canSave) {
+      return;
+    }
+
     let { publicService, formId } = this.args;
     let serializedData = this.formStore.serializeDataWithAddAndDelGraph(
       this.graphs.sourceGraph,
@@ -173,6 +193,10 @@ export default class PublicServicesDetailsPageComponent extends Component {
 
   @action
   requestSubmitConfirmation() {
+    if (!this.canSubmit) {
+      return;
+    }
+
     let isValidForm = validateForm(this.form, {
       ...this.graphs,
       sourceNode: this.sourceNode,


### PR DESCRIPTION
This prevents an edge case where an exception is thrown if the user clicks the submit button before the form is loaded.