### PR TITLE
Update to ember-promise-modals v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "ember-power-select": "^6.0.0",
         "ember-power-select-with-create": "^1.0.0",
         "ember-promise-helpers": "^2.0.0",
-        "ember-promise-modals": "^3.0.1",
+        "ember-promise-modals": "^4.0.0",
         "ember-qunit": "^5.1.5",
         "ember-resolver": "^8.0.3",
         "ember-router-service-refresh-polyfill": "^1.0.1",
@@ -22347,21 +22347,21 @@
       }
     },
     "node_modules/ember-promise-modals": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ember-promise-modals/-/ember-promise-modals-3.0.1.tgz",
-      "integrity": "sha512-A6SGi2ktH496Yt4ECkiY4ahvf1SogisUzOosAPzoziLPd1raNnyhEG/c4zuHNde00qMwGG3ulEzhZPewKJCwhw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ember-promise-modals/-/ember-promise-modals-4.0.0.tgz",
+      "integrity": "sha512-dC3hyd1WuKncUEOxEqFFF3tthoYNo+ZfXmXKmAkNYvbkHofRgImtXKBgepO+PyoXfHeBvm4Ol66+Vpovk7ZYgg==",
       "dev": true,
       "dependencies": {
         "@ember/test-waiters": "^3.0.1",
-        "@embroider/util": "^1.6.0",
+        "@embroider/util": "^1.7.1",
         "broccoli-funnel": "^3.0.8",
         "broccoli-merge-trees": "^4.2.0",
         "broccoli-postcss": "^6.0.1",
-        "ember-auto-import": "^2.4.1",
+        "ember-auto-import": "^2.4.2",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-htmlbars": "^6.0.1",
-        "focus-trap": "^6.7.3",
-        "postcss-preset-env": "^7.4.3"
+        "focus-trap": "^6.9.3",
+        "postcss-preset-env": "^7.6.0"
       },
       "engines": {
         "node": "12.* || >= 14.*"
@@ -57550,9 +57550,9 @@
       }
     },
     "ember-promise-modals": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ember-promise-modals/-/ember-promise-modals-3.0.1.tgz",
-      "integrity": "sha512-A6SGi2ktH496Yt4ECkiY4ahvf1SogisUzOosAPzoziLPd1raNnyhEG/c4zuHNde00qMwGG3ulEzhZPewKJCwhw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ember-promise-modals/-/ember-promise-modals-4.0.0.tgz",
+      "integrity": "sha512-dC3hyd1WuKncUEOxEqFFF3tthoYNo+ZfXmXKmAkNYvbkHofRgImtXKBgepO+PyoXfHeBvm4Ol66+Vpovk7ZYgg==",
       "dev": true,
       "requires": {
         "@ember/test-waiters": "^3.0.1",
@@ -57560,11 +57560,11 @@
         "broccoli-funnel": "^3.0.8",
         "broccoli-merge-trees": "^4.2.0",
         "broccoli-postcss": "^6.0.1",
-        "ember-auto-import": "^2.4.1",
+        "ember-auto-import": "^2.4.2",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-htmlbars": "^6.0.1",
-        "focus-trap": "^6.7.3",
-        "postcss-preset-env": "^7.4.3"
+        "focus-trap": "^6.9.3",
+        "postcss-preset-env": "^7.6.0"
       },
       "dependencies": {
         "broccoli-merge-trees": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "ember-power-select": "^6.0.0",
     "ember-power-select-with-create": "^1.0.0",
     "ember-promise-helpers": "^2.0.0",
-    "ember-promise-modals": "^3.0.1",
+    "ember-promise-modals": "^4.0.0",
     "ember-qunit": "^5.1.5",
     "ember-resolver": "^8.0.3",
     "ember-router-service-refresh-polyfill": "^1.0.1",


### PR DESCRIPTION
This release fixes the issue where the modal wouldn't close in Chromium-based browsers when `prefers-reduced-motion: reduce` is set.

https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion