### PR TITLE
Add a `lpdc-external` feature flag

### DIFF
--- a/app/components/shared/compact-menu.hbs
+++ b/app/components/shared/compact-menu.hbs
@@ -56,9 +56,20 @@
     </AuLink>
   {{/if}}
   {{#if this.currentSession.canAccessPublicServices}}
-    <AuLink @route="public-services" @icon="unordered-list" @iconAlignment="left" role="menuitem">
-      Producten- en dienstencatalogus
-    </AuLink>
+    {{#if (is-feature-enabled "lpdc-external")}}
+      <AuLinkExternal
+        @icon="link-external"
+        @iconAlignment="left"
+        href={{(lpdc-url)}}
+        role="menuitem"
+      >
+        Producten- en dienstencatalogus
+      </AuLinkExternal>
+    {{else}}
+      <AuLink @route="public-services" @icon="unordered-list" @iconAlignment="left" role="menuitem">
+        Producten- en dienstencatalogus
+      </AuLink>
+    {{/if}}
   {{/if}}
   {{#if this.currentSession.canAccessWorshipDecisionsDb}}
     <AuLinkExternal

--- a/app/components/shared/main-menu.hbs
+++ b/app/components/shared/main-menu.hbs
@@ -75,10 +75,21 @@
     {{/if}}
     {{#if this.currentSession.canAccessPublicServices}}
       <li class="au-c-list-navigation__item">
-        <AuNavigationLink @route="public-services">
-          <AuIcon @icon="unordered-list" @alignment="left" />
-          Producten- en dienstencatalogus
-        </AuNavigationLink>
+        {{#if (is-feature-enabled "lpdc-external")}}
+          <AuLinkExternal
+            @icon="link-external"
+            @iconAlignment="left"
+            class="au-c-list-navigation__link"
+            href={{(lpdc-url)}}
+          >
+            Producten- en dienstencatalogus
+          </AuLinkExternal>
+        {{else}}
+          <AuNavigationLink @route="public-services">
+            <AuIcon @icon="unordered-list" @alignment="left" />
+            Producten- en dienstencatalogus
+          </AuNavigationLink>
+        {{/if}}
       </li>
     {{/if}}
     {{#if this.currentSession.canAccessWorshipDecisionsDb}}

--- a/app/helpers/lpdc-url.js
+++ b/app/helpers/lpdc-url.js
@@ -1,0 +1,5 @@
+import config from 'frontend-loket/config/environment';
+
+export default function lpdcUrl() {
+  return config.lpdcUrl;
+}

--- a/app/router.js
+++ b/app/router.js
@@ -1,5 +1,6 @@
 import EmberRouter from '@ember/routing/router';
 import config from 'frontend-loket/config/environment';
+import isFeatureEnabled from './helpers/is-feature-enabled';
 
 export default class Router extends EmberRouter {
   location = config.locationType;
@@ -105,29 +106,46 @@ Router.map(function () {
     });
   });
 
-  this.route(
-    'public-services',
-    { path: '/producten-en-dienstencatalogus' },
-    function () {
-      this.route('add', { path: '/toevoegen' });
-      this.route('new', { path: '/nieuw' });
-      this.route('details', { path: '/:serviceId' }, function () {
-        this.route('content', { path: '/inhoud' });
-        this.route('properties', { path: '/eigenschappen' });
-      });
-      this.route('link-concept', { path: '/:serviceId/koppelen' }, function () {
-        this.route('link', { path: '/:conceptId' });
-      });
-      this.route(
-        'concept-details',
-        { path: '/concept/:conceptId' },
-        function () {
+  if (!isFeatureEnabled('lpdc-external')) {
+    this.route(
+      'public-services',
+      { path: '/producten-en-dienstencatalogus' },
+      function () {
+        this.route('add', { path: '/toevoegen' });
+        this.route('new', { path: '/nieuw' });
+        this.route('details', { path: '/:serviceId' }, function () {
           this.route('content', { path: '/inhoud' });
           this.route('properties', { path: '/eigenschappen' });
-        }
-      );
-    }
-  );
+        });
+        this.route(
+          'link-concept',
+          { path: '/:serviceId/koppelen' },
+          function () {
+            this.route('link', { path: '/:conceptId' });
+          }
+        );
+        this.route(
+          'concept-details',
+          { path: '/concept/:conceptId' },
+          function () {
+            this.route('content', { path: '/inhoud' });
+            this.route('properties', { path: '/eigenschappen' });
+          }
+        );
+      }
+    );
+  } else {
+    this.route(
+      'lpdc-external-redirect',
+      { path: '/producten-en-dienstencatalogus' },
+      function () {
+        // We need the child routes since `/producten-en-dienstencatalogus/*` won't match the case without a subpath
+        // By using an index and named route with a path we work around that issue. The lpdc-external-redirect route
+        // then retrieves the needed data from the transition object.
+        this.route('with-path', { path: '/*path' });
+      }
+    );
+  }
 
   this.route('route-not-found', {
     path: '/*wildcard',

--- a/app/routes/lpdc-external-redirect.js
+++ b/app/routes/lpdc-external-redirect.js
@@ -1,0 +1,23 @@
+import Route from '@ember/routing/route';
+import config from 'frontend-loket/config/environment';
+import { inject as service } from '@ember/service';
+
+export default class LpdcExternalRedirectRoute extends Route {
+  @service router;
+
+  model(params, transition) {
+    if (!config.lpdcUrl.startsWith('{{')) {
+      const lpdcUrl = new URL(config.lpdcUrl);
+
+      if (transition.to.localName === 'with-path') {
+        const { path } = transition.to.params;
+        lpdcUrl.pathname = path;
+      }
+
+      window.location.replace(lpdcUrl);
+    } else {
+      // The URL isn't configured so we redirect to the index page instead.
+      this.router.replaceWith('index');
+    }
+  }
+}

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -2,6 +2,7 @@ import Service, { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { setContext, setUser } from '@sentry/ember';
 import config from 'frontend-loket/config/environment';
+import isFeatureEnabled from 'frontend-loket/helpers/is-feature-enabled';
 import { SHOULD_ENABLE_SENTRY } from 'frontend-loket/utils/sentry';
 
 const MODULE = {
@@ -130,6 +131,13 @@ export default class CurrentSessionService extends Service {
   }
 
   get canAccessPublicServices() {
+    if (isFeatureEnabled('lpdc-external')) {
+      return (
+        this.canAccess(MODULE.PUBLIC_SERVICES) &&
+        !config.lpdcUrl.startsWith('{{')
+      );
+    }
+
     return this.canAccess(MODULE.PUBLIC_SERVICES);
   }
 }

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -155,7 +155,16 @@
           <:title>Producten- en dienstencatalogus</:title>
           <:description>Beheer uw producten en diensten.</:description>
           <:link>
-            <AuLink @route="public-services" @skin="button">Ga naar de producten- en dienstencatalogus</AuLink>
+            {{#if (is-feature-enabled "lpdc-external")}}
+              <AuLinkExternal
+                @skin="button"
+                href={{(lpdc-url)}}
+              >
+                Ga naar de producten- en dienstencatalogus (externe link)
+              </AuLinkExternal>
+            {{else}}
+              <AuLink @route="public-services" @skin="button">Ga naar de producten- en dienstencatalogus</AuLink>
+            {{/if}}
           </:link>
         </LoketModuleCard>
         </li>

--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -291,36 +291,38 @@
               </AuCard>
             </div>
 
-            <div class="au-o-grid__item au-u-1-2@small au-u-1-3@medium">
-              <AuCard @textCenter="true" as |c|>
-                <c.header @badgeSkin="brand" @badgeIcon="unordered-list">
-                  <AuHeading @level="3" @skin="4">
-                    Producten- en dienstencatalogus
-                  </AuHeading>
-                </c.header>
-                <c.content>
-                  <p class="au-u-margin-top-tiny">Beheer uw producten en diensten.</p>
-                </c.content>
-                <c.footer>
-                  <p>
-                    <AuLinkExternal
-                      @skin="button"
-                      @icon="link"
-                      href="https://www.vlaanderen.be/lokaal-bestuur/digitale-transformatie/lokale-producten-en-dienstencatalogus"
-                    >
-                      Meer informatie
-                    </AuLinkExternal>
-                    <AuLinkExternal
-                      @skin="button-secondary"
-                      @icon="manual"
-                      href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/producten-en-dienstencatalogus"
-                    >
-                      Handleiding
-                    </AuLinkExternal>
-                  </p>
-                </c.footer>
-              </AuCard>
-            </div>
+            {{#if (not (is-feature-enabled "lpdc-external"))}}
+              <div class="au-o-grid__item au-u-1-2@small au-u-1-3@medium">
+                <AuCard @textCenter="true" as |c|>
+                  <c.header @badgeSkin="brand" @badgeIcon="unordered-list">
+                    <AuHeading @level="3" @skin="4">
+                      Producten- en dienstencatalogus
+                    </AuHeading>
+                  </c.header>
+                  <c.content>
+                    <p class="au-u-margin-top-tiny">Beheer uw producten en diensten.</p>
+                  </c.content>
+                  <c.footer>
+                    <p>
+                      <AuLinkExternal
+                        @skin="button"
+                        @icon="link"
+                        href="https://www.vlaanderen.be/lokaal-bestuur/digitale-transformatie/lokale-producten-en-dienstencatalogus"
+                      >
+                        Meer informatie
+                      </AuLinkExternal>
+                      <AuLinkExternal
+                        @skin="button-secondary"
+                        @icon="manual"
+                        href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/producten-en-dienstencatalogus"
+                      >
+                        Handleiding
+                      </AuLinkExternal>
+                    </p>
+                  </c.footer>
+                </AuCard>
+              </div>
+            {{/if}}
           </div>
         </div>
       </section>

--- a/app/templates/lpdc-external-redirect.hbs
+++ b/app/templates/lpdc-external-redirect.hbs
@@ -1,0 +1,5 @@
+{{page-title "Aan het doorverwijzen naar de producten- en dienstencatalogus"}}
+
+<PageLoader>
+  Aan het doorverwijzen naar de producten- en dienstencatalogus
+</PageLoader>

--- a/config/environment.js
+++ b/config/environment.js
@@ -34,9 +34,11 @@ module.exports = function (environment) {
       authRedirectUrl: '{{ACMIDM_AUTH_REDIRECT_URL}}',
       switchRedirectUrl: '{{ACMIDM_SWITCH_REDIRECT_URL}}',
     },
-    // features: {
-    //   'feature-name': '{{FEATURE_ENV_VAR_NAME}}',
-    // },
+    features: {
+      // 'feature-name': '{{FEATURE_ENV_VAR_NAME}}',
+      'lpdc-external': '{{FEATURE_LPDC_EXTERNAL}}',
+    },
+    lpdcUrl: '{{LPDC_URL}}',
     worshipDecisionsDatabaseUrl: '{{WORSHIP_DECISIONS_DATABASE_URL}}',
     worshipOrganisationsDatabaseUrl: '{{WORSHIP_ORGANISATIONS_DATABASE_URL}}',
     'ember-plausible': {


### PR DESCRIPTION
This flag allows us to disable the LPDC module from the server. Once the new lpdc app is deployed to production we can remove the flag and all the code that is no longer needed.

Servers can enable this feature by adding the following config to the docker-compose.overrides.yml file:

```yml
services:
  frontend:
    environment:
      EMBER_FEATURE_LPDC_EXTERNAL: "true"
      EMBER_LPDC_URL: "https://ipdc.lokaalbestuur.lblod.info" # not the real url
```

To test, add temporary values for these in the `config/environment.js` file.