### PR TITLE
Update to ember-submission-form-fields v2.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@lblod/ember-acmidm-login": "2.0.0-beta.1",
         "@lblod/ember-mock-login": "^0.7.0",
         "@lblod/ember-rdfa-editor": "^3.5.0",
-        "@lblod/ember-submission-form-fields": "^2.10.0",
+        "@lblod/ember-submission-form-fields": "^2.11.0",
         "@lblod/submission-form-helpers": "^2.2.0",
         "@sentry/ember": "^7.54.0",
         "broccoli-asset-rev": "^3.0.0",
@@ -5325,9 +5325,9 @@
       }
     },
     "node_modules/@lblod/ember-submission-form-fields": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.10.0.tgz",
-      "integrity": "sha512-fQFrwDxHADZvsgW6w6+xXFjrEgw8J3HuSkoayE0srWxuDmGYTPGRMWCFkTqL4tcC55EoYHaidR1muzrKPs+cbA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.11.0.tgz",
+      "integrity": "sha512-EAvrSMRHw6PuLreWyARddFDu2nE/nfxzk8qghHce4HM5+wYekXPSZ4Y+cuhALgZEolQXXl6/fw1pDxZS4Hco9g==",
       "dev": true,
       "dependencies": {
         "@lblod/submission-form-helpers": "^2.0.1",
@@ -43560,9 +43560,9 @@
       }
     },
     "@lblod/ember-submission-form-fields": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.10.0.tgz",
-      "integrity": "sha512-fQFrwDxHADZvsgW6w6+xXFjrEgw8J3HuSkoayE0srWxuDmGYTPGRMWCFkTqL4tcC55EoYHaidR1muzrKPs+cbA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.11.0.tgz",
+      "integrity": "sha512-EAvrSMRHw6PuLreWyARddFDu2nE/nfxzk8qghHce4HM5+wYekXPSZ4Y+cuhALgZEolQXXl6/fw1pDxZS4Hco9g==",
       "dev": true,
       "requires": {
         "@lblod/submission-form-helpers": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@lblod/ember-acmidm-login": "2.0.0-beta.1",
     "@lblod/ember-mock-login": "^0.7.0",
     "@lblod/ember-rdfa-editor": "^3.5.0",
-    "@lblod/ember-submission-form-fields": "^2.10.0",
+    "@lblod/ember-submission-form-fields": "^2.11.0",
     "@lblod/submission-form-helpers": "^2.2.0",
     "@sentry/ember": "^7.54.0",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
# Description
DL-5180

This PR is about updating `ember-submission-form-fields` to v2.11.0 to use the new alert field in the Besluit handhaven na ontvangst schorsingsbesluit (besluit handhaven) form.

- Bumping `ember-submission-form-fields` to v2.11.0

See feature -> https://github.com/lblod/ember-submission-form-fields/commit/3ed7941cb2ac392e866de8d593d965bdedaf6210


# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

# Related module

- https://github.com/lblod/ember-submission-form-fields

# How to test (Not mandatory here)

1. Checkout on PR branch
2. npm install
3. Start the `app-digitaal-loket` stack on branch `feature/adjust-besluit-handhaven-form` + frontend, migrations should run.
4. Log as a worship-service. 
5. Select Toezicht module and create a new submission with the dossier type of 'Besluit handhaven na ontvangst schorsingsbesluit'.
6. It should create the submission.

# What to check (Not mandatory here)

- Should create a submission without errors
- Existing submissions should have the new label

# Links to other PR's

- https://github.com/lblod/app-digitaal-loket/pull/428


# Notes

**Bump frontend-loket**
