### PR TITLE
Add the `convert-to-currency` helper

### DIFF
--- a/app/helpers/convert-to-currency.js
+++ b/app/helpers/convert-to-currency.js
@@ -1,0 +1,13 @@
+export default function convertToCurrency(value) {
+  console.log('hello');
+  const formatter = new Intl.NumberFormat('nl-BE', {
+    style: 'currency',
+    currency: 'EUR',
+  });
+
+  if (isNaN(value)) {
+    return value;
+  } else {
+    return formatter.format(value);
+  }
+}


### PR DESCRIPTION
This helper is used in some of the custom subsidy form field components which were transfered(https://github.com/lblod/frontend-loket/pull/88) from the `ember-submission-form-fields` addon. It seems we forgot to transfer this helper but it was still working since the addon still exported it. We move it here now so it can be removed from the addon.