### PR TITLE
Fix an issue when reopening a supervision submission

### DIFF
--- a/app/controllers/supervision/submissions/index.js
+++ b/app/controllers/supervision/submissions/index.js
@@ -1,28 +1,34 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { CONCEPT_STATUS_UUID } from '../../../models/submission-document-status';
+import { CONCEPT_STATUS } from 'frontend-loket/models/submission-document-status';
 
 export default class SupervisionSubmissionsIndexController extends Controller {
   @service router;
+  @service store;
 
   page = 0;
   size = 20;
   sort = 'status.label,-sent-date,-modified';
 
   @action
-  reopen(submission) {
+  async reopen(submission) {
     const hasAcknowledged = confirm(
       'Weet je zeker dat je dit wilt doen? Deze actie kan onverwachte gevolgen hebben!'
     );
+
     if (hasAcknowledged) {
-      this.store
-        .findRecord('submission-document-status', CONCEPT_STATUS_UUID)
-        .then(function (concept) {
-          submission.status = concept;
-          submission.sentDate = null;
-          submission.save();
-        });
+      const concept = (
+        await this.store.query('submission-document-status', {
+          filter: {
+            ':uri:': CONCEPT_STATUS,
+          },
+        })
+      ).at(0);
+
+      submission.status = concept;
+      submission.sentDate = null;
+      submission.save();
     }
   }
 }


### PR DESCRIPTION
This import doesn't exist (anymore?) so reopening fails. This only affected the controle environment so it went unnoticed.