### PR TITLE
Add a "global system notification" bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,52 @@
 # frontend-loket
 
 Frontend of the loket application
+
+## Environment variables
+
+The [ember-proxy-service](https://github.com/mu-semtech/ember-proxy-service#configure-environment-variables-in-the-frontends-container) docker image (which we use to host the frontend) supports configuring environment variables. The following options are available for the loket image.
+
+### General
+
+| Name                                       | Description                                                                             |
+| ------------------------------------------ | --------------------------------------------------------------------------------------- |
+| `EMBER_LPDC_URL`                           | Link to the LPDC application (only required when the feature flag is enabled)           |
+| `EMBER_WORSHIP_DECISIONS_DATABASE_URL`     | Link to the worship decisions database                                                  |
+| `EMBER_WORSHIP_ORGANISATIONS_DATABASE_URL` | Link to the worship organisations database                                              |
+| `EMBER_GLOBAL_SYSTEM_NOTIFICATION`         | This can be used to display a message at the top of the application. HTML is supported. |
+
+### ACM/IDM
+
+| Name                               | Description                                                                                                                                              |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `EMBER_ACMIDM_CLIENT_ID`           | The unique client id for a specific environment                                                                                                          |
+| `EMBER_ACMIDM_AUTH_URL`            | The URL where users will be redirected to when they want to log in                                                                                       |
+| `EMBER_ACMIDM_AUTH_REDIRECT_URL`   | The callback URL that ACM/IDM will use after the user logs in successfully                                                                               |
+| `EMBER_ACMIDM_LOGOUT_URL`          | The URL where users will be redirected to when they want to log out                                                                                      |
+| `EMBER_ACMIDM_SWITCH_REDIRECT_URL` | The URL that will be used when "switching users" is enabled in ACM/IDM. After logout, users can select one of their other accounts to simplify the flow. |
+
+> When ACM/IDM is not configured, the frontend will default to the "mock login" setup instead.
+
+### Feature flags
+
+Feature flags are new / experimental features that can be enabled by setting them to "true".
+
+| Name                          | Description                                                                                                                        |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `EMBER_FEATURE_LPDC_EXTERNAL` | Replaces the built-in LPDC module with a link to the external application. Old bookmarks will be redirected to the new app as well |
+
+### Plausible
+
+| Name                         | Description                                                                      |
+| ---------------------------- | -------------------------------------------------------------------------------- |
+| `EMBER_ANALYTICS_API_HOST`   | The URL of the Plausible host to which all events will be sent                   |
+| `EMBER_ANALYTICS_APP_DOMAIN` | The app domain which will be used to group the events in the Plausible dashboard |
+
+> Analytics will only be enabled when both variables are configured.
+
+### Sentry
+
+| Name                       | Description                                                                                     |
+| -------------------------- | ----------------------------------------------------------------------------------------------- |
+| `EMBER_SENTRY_DSN`         | Sentry DSN. Setting this activates the sentry integration.                                      |
+| `EMBER_SENTRY_ENVIRONMENT` | The name of the environment under which the errors should be reported. Defaults to 'production' |

--- a/app/components/global-system-notification.hbs
+++ b/app/components/global-system-notification.hbs
@@ -1,0 +1,14 @@
+{{#if this.show}}
+  <AuAlert
+    @skin="warning"
+    @size="tiny"
+    @closable={{true}}
+    class="au-u-margin-bottom-none"
+    ...attributes
+  >
+    <p class="au-u-text-center">
+      {{!template-lint-disable no-triple-curlies}}
+      {{{this.notification}}}
+    </p>
+  </AuAlert>
+{{/if}}

--- a/app/components/global-system-notification.js
+++ b/app/components/global-system-notification.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+import config from 'frontend-loket/config/environment';
+
+export default class GlobalSystemNotification extends Component {
+  get notification() {
+    return config.globalSystemNotification;
+  }
+
+  get show() {
+    return !config.globalSystemNotification.startsWith('{{');
+  }
+}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,6 +1,7 @@
 {{page-title this.appTitle}}
 
 <AuApp>
+  <GlobalSystemNotification />
   <AuMainHeader
     @brandLink={{unless
       this.session.isAuthenticated
@@ -26,19 +27,11 @@
           @alignment="right"
           role="menu"
         >
-          <AuLink
-            @route="auth.switch"
-            @icon="switch"
-            role="menuitem"
-          >
+          <AuLink @route="auth.switch" @icon="switch" role="menuitem">
             Wissel van bestuurseenheid
           </AuLink>
 
-          <AuLink
-            @route="auth.logout"
-            @icon="logout"
-            role="menuitem"
-          >
+          <AuLink @route="auth.logout" @icon="logout" role="menuitem">
             Afmelden
           </AuLink>
         </AuDropdown>

--- a/config/environment.js
+++ b/config/environment.js
@@ -57,6 +57,7 @@ module.exports = function (environment) {
       // It also prevents the performance instrumentation code from running when Sentry isn't enabled (which is something that ideally is fixed in the addon itself).
       disablePerformance: true,
     },
+    globalSystemNotification: '{{GLOBAL_SYSTEM_NOTIFICATION}}',
   };
 
   if (environment === 'development') {


### PR DESCRIPTION
This adds a new "EMBER_GLOBAL_SYSTEM_NOTIFICATION" environment variable that can be used to display maintenance messages when needed. HTML is supported, so we can link to external pages as well.

An example planned maintenance notification could look like this:
![image](https://github.com/lblod/frontend-loket/assets/3533236/a29e21f3-b9c4-4cd2-901b-f1bbb36bbd69)

Targetting master so we can release it without other changes in dev.
