### PR TITLE
Update the LPDC user manual links

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -178,7 +178,7 @@
           <LoketModuleCard
             @icon="unordered-list"
             @extraInformationLink="https://www.vlaanderen.be/lokaal-bestuur/digitale-transformatie/lokale-producten-en-dienstencatalogus"
-            @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/producten-en-dienstencatalogus"
+            @userManualLink="https://abb-vlaanderen.gitbook.io/informatie-lpdc/"
           >
             <:title>Producten- en dienstencatalogus</:title>
             <:description>Beheer uw producten en diensten.</:description>

--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -353,7 +353,7 @@
                     <AuLinkExternal
                       @skin="button-secondary"
                       @icon="manual"
-                      href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/producten-en-dienstencatalogus"
+                      href="https://abb-vlaanderen.gitbook.io/informatie-lpdc/"
                     >
                       Handleiding
                     </AuLinkExternal>


### PR DESCRIPTION
There is a new manual for the separate app, so we now link to this one instead.

Builds on #340 and #336 because we modified related code there. Those need to be merged first.