### PR TITLE
Add trigger for vendor-data-distribution-service

### DIFF
--- a/app/components/berichtencentrum/conversatie-reactie.js
+++ b/app/components/berichtencentrum/conversatie-reactie.js
@@ -70,6 +70,12 @@ export default class BerichtencentrumConversatieReactieComponent extends Compone
       this.args.conversatie.berichten.push(reactie);
       this.args.conversatie.laatsteBericht = reactie;
       await this.args.conversatie.save();
+      //Save message as the last thing
+      //  → see vendor-data-distribution-service
+      //It needs the `creator` prop to make the data transactionaly available
+      //to the Vendor API. All the data needs to exist at that point.
+      reactie.creator = 'https://github.com/lblod/frontend-loket/';
+      await reactie.save();
     } catch (err) {
       alert(err.message);
     }

--- a/app/components/berichtencentrum/conversatie-reactie.js
+++ b/app/components/berichtencentrum/conversatie-reactie.js
@@ -74,7 +74,7 @@ export default class BerichtencentrumConversatieReactieComponent extends Compone
       //  → see vendor-data-distribution-service
       //It needs the `creator` prop to make the data transactionaly available
       //to the Vendor API. All the data needs to exist at that point.
-      reactie.creator = 'https://github.com/lblod/frontend-loket/';
+      reactie.creator = 'https://github.com/lblod/frontend-loket';
       await reactie.save();
     } catch (err) {
       alert(err.message);

--- a/app/models/bericht.js
+++ b/app/models/bericht.js
@@ -11,6 +11,7 @@ export default class BerichtModel extends Model {
   @attr('datetime') aangekomen;
   @attr inhoud;
   @attr typeCommunicatie;
+  @attr creator;
 
   @belongsTo('bestuurseenheid', {
     async: false,


### PR DESCRIPTION
This added property can be used by the vendor-data-distribution-service to trigger the copying of a new message to the Vendor API.