### PR TITLE
Fix Berichtencentrum trigger VDDS

### DIFF
--- a/app/components/berichtencentrum/conversatie-reactie.js
+++ b/app/components/berichtencentrum/conversatie-reactie.js
@@ -66,7 +66,6 @@ export default class BerichtencentrumConversatieReactieComponent extends Compone
         typeCommunicatie: this.args.conversatie.currentTypeCommunicatie,
       });
 
-      await reactie.save();
       this.args.conversatie.berichten.push(reactie);
       this.args.conversatie.laatsteBericht = reactie;
       await this.args.conversatie.save();

--- a/app/controllers/berichtencentrum/berichten/new.js
+++ b/app/controllers/berichtencentrum/berichten/new.js
@@ -53,6 +53,8 @@ export default class BerichtencentrumBerichtenNewController extends Controller {
       inhoud: '',
       bijlagen: files,
     });
+    const creatorDefault = message.creator;
+    message.creator = 'pending';
     await message.save();
 
     const conversation = this.store.createRecord('conversatie', {
@@ -64,6 +66,9 @@ export default class BerichtencentrumBerichtenNewController extends Controller {
       laatsteBericht: message,
     });
     await conversation.save();
+
+    message.creator = creatorDefault;
+    await message.save();
 
     this.router.transitionTo(
       'berichtencentrum.berichten.conversatie',

--- a/app/controllers/berichtencentrum/berichten/new.js
+++ b/app/controllers/berichtencentrum/berichten/new.js
@@ -53,6 +53,11 @@ export default class BerichtencentrumBerichtenNewController extends Controller {
       inhoud: '',
       bijlagen: files,
     });
+
+    //The creator field must only be set at the end when all data is in the
+    //database. This field is used to trigger the
+    //vendor-data-distribution-service and should not be triggered too soon.
+    //Store the default value, set it to a placeholder and restore later
     const creatorDefault = message.creator;
     message.creator = 'pending';
     await message.save();
@@ -67,6 +72,7 @@ export default class BerichtencentrumBerichtenNewController extends Controller {
     });
     await conversation.save();
 
+    //Restore the default value and save again
     message.creator = creatorDefault;
     await message.save();
 

--- a/app/models/bericht.js
+++ b/app/models/bericht.js
@@ -16,10 +16,7 @@ export default class BerichtModel extends Model {
   //  → see vendor-data-distribution-service
   //It needs the `creator` prop to make the data transactionaly available
   //to the Vendor API. All the data needs to exist at that point.
-  @attr(
-    { defaultValue:
-      'https://github.com/lblod/frontend-loket'
-    }) creator;
+  @attr({ defaultValue: 'https://github.com/lblod/frontend-loket' }) creator;
 
   @belongsTo('bestuurseenheid', {
     async: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend-loket",
-  "version": "0.87.2",
+  "version": "0.87.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend-loket",
-      "version": "0.87.2",
+      "version": "0.87.3",
       "license": "MIT",
       "devDependencies": {
         "@appuniversum/ember-appuniversum": "^2.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend-loket",
-  "version": "0.87.1",
+  "version": "0.87.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend-loket",
-      "version": "0.87.1",
+      "version": "0.87.2",
       "license": "MIT",
       "devDependencies": {
         "@appuniversum/ember-appuniversum": "^2.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-loket",
-  "version": "0.87.2",
+  "version": "0.87.3",
   "private": true,
   "description": "Frontend of loket",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-loket",
-  "version": "0.87.1",
+  "version": "0.87.2",
   "private": true,
   "description": "Frontend of loket",
   "repository": {


### PR DESCRIPTION
We need to make sure that the Bericht is saved after the Conversation and that the creator property is only stored *after* all other data. This can sometimes only be done by setting the creator to some placeholder at first.