### PR TITLE
Berichtencentrum: Use type from conversation instead of from last message

### DIFF
--- a/app/components/berichtencentrum/conversatie-table.hbs
+++ b/app/components/berichtencentrum/conversatie-table.hbs
@@ -13,7 +13,7 @@
   <t.content as |c|>
     <c.header>
       <AuDataTableThSortable @label='Betreft' @field='betreft' @currentSorting={{@sort}} />
-      <AuDataTableThSortable @label='Type communicatie' @field='laatste-bericht.type-communicatie' @currentSorting={{@sort}} />
+      <AuDataTableThSortable @label='Type communicatie' @field='currentTypeCommunicatie' @currentSorting={{@sort}} />
       <AuDataTableThSortable @label='Dossiernummer' @field='dossiernummer' @currentSorting={{@sort}} class="au-u-visible-small-up" />
       {{#unless @renderSmallTable}}
          <AuDataTableThSortable @label='Laatste bericht' @field='laatste-bericht.verzonden' @currentSorting={{@sort}} class="au-u-visible-small-up" />
@@ -23,7 +23,7 @@
     </c.header>
     <c.body data-test-loket="berichtencentrum-body" as |conversatie|>
       <td>{{conversatie.betreft}}</td>
-      <td>{{conversatie.laatsteBericht.typeCommunicatie}}</td>
+      <td>{{conversatie.currentTypeCommunicatie}}</td>
       <td class="au-u-visible-small-up au-u-word-break">{{conversatie.dossiernummer}}</td>
       {{#unless @renderSmallTable}}
         <td class="au-u-visible-small-up">{{moment-format conversatie.laatsteBericht.verzonden 'DD-MM-YYYY'}}</td>


### PR DESCRIPTION
Instead of asking from the last message in the conversation use the type from the conversation itself to show in the conversation table.

A conversation is always started in Loket, no? Even if not, the model for a conversation describes a type. So it should always have a type. Messages don't always have a type (some vendors don't send a type) and therefore the conversation type was sometimes shown as blank until a response was sent.