### PR TITLE
Fix: Messages in Conversations not saving

### DIFF
--- a/app/components/berichtencentrum/conversatie-reactie.js
+++ b/app/components/berichtencentrum/conversatie-reactie.js
@@ -94,7 +94,6 @@ export default class BerichtencentrumConversatieReactieComponent extends Compone
           'http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b',
       })
     ).at(0);
-    const user = this.currentSession.user;
 
     try {
       this.collapse();
@@ -104,7 +103,6 @@ export default class BerichtencentrumConversatieReactieComponent extends Compone
         // aangekomen              : new Date(),
         verzonden: new Date(),
         van: abb,
-        auteur: user,
         naar: this.originator,
         bijlagen: this.bijlagen,
         typeCommunicatie: this.args.conversatie.currentTypeCommunicatie,

--- a/app/components/berichtencentrum/conversatie-reactie.js
+++ b/app/components/berichtencentrum/conversatie-reactie.js
@@ -66,9 +66,20 @@ export default class BerichtencentrumConversatieReactieComponent extends Compone
         typeCommunicatie: this.args.conversatie.currentTypeCommunicatie,
       });
 
+      //The creator field must only be set at the end when all data is in the
+      //database. This field is used to trigger the
+      //vendor-data-distribution-service and should not be triggered too soon.
+      //Store the default value, set it to a placeholder and restore later
+      const creatorDefault = reactie.creator;
+      reactie.creator = 'pending';
+      await reactie.save();
+
       this.args.conversatie.berichten.push(reactie);
       this.args.conversatie.laatsteBericht = reactie;
       await this.args.conversatie.save();
+
+      //Restore the default value and save again
+      reactie.creator = creatorDefault;
       await reactie.save();
     } catch (err) {
       alert(err.message);
@@ -99,9 +110,20 @@ export default class BerichtencentrumConversatieReactieComponent extends Compone
         typeCommunicatie: this.args.conversatie.currentTypeCommunicatie,
       });
 
+      //The creator field must only be set at the end when all data is in the
+      //database. This field is used to trigger the
+      //vendor-data-distribution-service and should not be triggered too soon.
+      //Store the default value, set it to a placeholder and restore later
+      const creatorDefault = reactie.creator;
+      reactie.creator = 'pending';
+      await reactie.save();
+
       this.args.conversatie.berichten.push(reactie);
       this.args.conversatie.laatsteBericht = reactie;
       await this.args.conversatie.save();
+
+      //Restore the default value and save again
+      reactie.creator = creatorDefault;
       await reactie.save();
     } catch (err) {
       alert(err.message);

--- a/app/models/bericht.js
+++ b/app/models/bericht.js
@@ -21,6 +21,7 @@ export default class BerichtModel extends Model {
   @belongsTo('bestuurseenheid', {
     async: false,
     inverse: null,
+    polymorphic: true,
   })
   van;
 
@@ -33,6 +34,7 @@ export default class BerichtModel extends Model {
   @belongsTo('bestuurseenheid', {
     async: false,
     inverse: null,
+    polymorphic: true,
   })
   naar;
 


### PR DESCRIPTION
This PR fixes some relationships that should be marked as polymorphic, and reorders the saving of responses to make sure that the vendor-data-distribution-service gets a clean trigger when the conversation is also saved.