### PR TITLE
Fix: set correct recipient when sending as ABB

### DIFF
--- a/app/components/berichtencentrum/conversatie-reactie.hbs
+++ b/app/components/berichtencentrum/conversatie-reactie.hbs
@@ -54,11 +54,21 @@
     </div>
 
     <AuButtonGroup>
-      <AuButton {{on 'click' this.verstuurBericht}} @disabled={{this.cantSend}} class="js-accordion__toggle js-accordion-bound">
+      <AuButton
+        {{on 'click' (perform this.verstuurBericht)}}
+        @loading={{this.verstuurBericht.isRunning}}
+        @loadingMessage="Versturen"
+        @disabled={{this.cantSend}}
+        class="js-accordion__toggle js-accordion-bound">
         Verstuur bericht
       </AuButton>
       {{#if (macroCondition (macroGetOwnConfig "controle"))}}
-        <AuButton {{on 'click' this.verstuurBerichtAlsABB}} @disabled={{this.cantSend}} class="js-accordion__toggle js-accordion-bound">
+        <AuButton
+          {{on 'click' (perform this.verstuurBerichtAlsABB)}}
+          @loading={{this.verstuurBerichtAlsABB.isRunning}}
+          @loadingMessage="Versturen"
+          @disabled={{this.cantSend}}
+          class="js-accordion__toggle js-accordion-bound">
           Verstuur bericht als ABB
         </AuButton>
       {{/if}}

--- a/app/components/berichtencentrum/conversatie-reactie.js
+++ b/app/components/berichtencentrum/conversatie-reactie.js
@@ -88,6 +88,8 @@ export default class BerichtencentrumConversatieReactieComponent extends Compone
 
   @action
   async verstuurBerichtAlsABB() {
+    const bestuurseenheid = this.currentSession.group;
+    const user = this.currentSession.user;
     const abb = (
       await this.store.query('bestuurseenheid', {
         'filter[:uri:]':
@@ -103,7 +105,8 @@ export default class BerichtencentrumConversatieReactieComponent extends Compone
         // aangekomen              : new Date(),
         verzonden: new Date(),
         van: abb,
-        naar: this.originator,
+        auteur: user,
+        naar: bestuurseenheid,
         bijlagen: this.bijlagen,
         typeCommunicatie: this.args.conversatie.currentTypeCommunicatie,
       });

--- a/app/components/berichtencentrum/conversatie-reactie.js
+++ b/app/components/berichtencentrum/conversatie-reactie.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { A } from '@ember/array';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { task } from 'ember-concurrency';
 
 export default class BerichtencentrumConversatieReactieComponent extends Component {
   @service() router;
@@ -47,8 +48,7 @@ export default class BerichtencentrumConversatieReactieComponent extends Compone
     this.originator = null;
   }
 
-  @action
-  async verstuurBericht() {
+  verstuurBericht = task(async () => {
     const bestuurseenheid = this.currentSession.group;
     const user = this.currentSession.user;
 
@@ -84,10 +84,9 @@ export default class BerichtencentrumConversatieReactieComponent extends Compone
     } catch (err) {
       alert(err.message);
     }
-  }
+  });
 
-  @action
-  async verstuurBerichtAlsABB() {
+  verstuurBerichtAlsABB = task(async () => {
     const bestuurseenheid = this.currentSession.group;
     const user = this.currentSession.user;
     const abb = (
@@ -129,7 +128,7 @@ export default class BerichtencentrumConversatieReactieComponent extends Compone
     } catch (err) {
       alert(err.message);
     }
-  }
+  });
 
   @action
   async attachFile(fileId) {


### PR DESCRIPTION
Due to creeping deadlines and reckless merging we forgot to test a few scenario's with relation to sending messages as ABB in Berichtencentrum. In some cases, the recipient and sender could be both the same, namely ABB. The recipient can be set to the administrative body that is used to log in with.