### PR TITLE
Enhance: loading state on send buttons

### DIFF
--- a/app/components/berichtencentrum/conversatie-reactie.hbs
+++ b/app/components/berichtencentrum/conversatie-reactie.hbs
@@ -54,11 +54,17 @@
     </div>
 
     <AuButtonGroup>
-      <AuButton {{on 'click' this.verstuurBericht}} @disabled={{this.cantSend}} class="js-accordion__toggle js-accordion-bound">
+      <AuButton
+        {{on 'click' this.verstuurBericht}}
+        @disabled={{this.cantSend}}
+        class="js-accordion__toggle js-accordion-bound">
         Verstuur bericht
       </AuButton>
       {{#if (macroCondition (macroGetOwnConfig "controle"))}}
-        <AuButton {{on 'click' this.verstuurBerichtAlsABB}} @disabled={{this.cantSend}} class="js-accordion__toggle js-accordion-bound">
+        <AuButton
+          {{on 'click' this.verstuurBerichtAlsABB}}
+          @disabled={{this.cantSend}}
+          class="js-accordion__toggle js-accordion-bound">
           Verstuur bericht als ABB
         </AuButton>
       {{/if}}

--- a/app/components/berichtencentrum/conversatie-reactie.hbs
+++ b/app/components/berichtencentrum/conversatie-reactie.hbs
@@ -57,6 +57,7 @@
       <AuButton
         {{on 'click' (perform this.verstuurBericht)}}
         @loading={{this.verstuurBericht.isRunning}}
+        @loadingMessage="Versturen"
         @disabled={{this.cantSend}}
         class="js-accordion__toggle js-accordion-bound">
         Verstuur bericht
@@ -65,6 +66,7 @@
         <AuButton
           {{on 'click' (perform this.verstuurBerichtAlsABB)}}
           @loading={{this.verstuurBerichtAlsABB.isRunning}}
+          @loadingMessage="Versturen"
           @disabled={{this.cantSend}}
           class="js-accordion__toggle js-accordion-bound">
           Verstuur bericht als ABB

--- a/app/components/berichtencentrum/conversatie-reactie.hbs
+++ b/app/components/berichtencentrum/conversatie-reactie.hbs
@@ -55,14 +55,16 @@
 
     <AuButtonGroup>
       <AuButton
-        {{on 'click' this.verstuurBericht}}
+        {{on 'click' (perform this.verstuurBericht)}}
+        @loading={{this.verstuurBericht.isRunning}}
         @disabled={{this.cantSend}}
         class="js-accordion__toggle js-accordion-bound">
         Verstuur bericht
       </AuButton>
       {{#if (macroCondition (macroGetOwnConfig "controle"))}}
         <AuButton
-          {{on 'click' this.verstuurBerichtAlsABB}}
+          {{on 'click' (perform this.verstuurBerichtAlsABB)}}
+          @loading={{this.verstuurBerichtAlsABB.isRunning}}
           @disabled={{this.cantSend}}
           class="js-accordion__toggle js-accordion-bound">
           Verstuur bericht als ABB

--- a/app/components/berichtencentrum/conversatie-reactie.js
+++ b/app/components/berichtencentrum/conversatie-reactie.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { A } from '@ember/array';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { task } from 'ember-concurrency';
 
 export default class BerichtencentrumConversatieReactieComponent extends Component {
   @service() router;
@@ -47,8 +48,7 @@ export default class BerichtencentrumConversatieReactieComponent extends Compone
     this.originator = null;
   }
 
-  @action
-  async verstuurBericht() {
+  verstuurBericht = task(async () => {
     const bestuurseenheid = this.currentSession.group;
     const user = this.currentSession.user;
 
@@ -84,10 +84,9 @@ export default class BerichtencentrumConversatieReactieComponent extends Compone
     } catch (err) {
       alert(err.message);
     }
-  }
+  });
 
-  @action
-  async verstuurBerichtAlsABB() {
+  verstuurBerichtAlsABB = task(async () => {
     const bestuurseenheid = this.currentSession.group;
     const user = this.currentSession.user;
     const abb = (
@@ -129,7 +128,7 @@ export default class BerichtencentrumConversatieReactieComponent extends Compone
     } catch (err) {
       alert(err.message);
     }
-  }
+  });
 
   @action
   async attachFile(fileId) {


### PR DESCRIPTION
This PR converts the message sending actions to Ember Concurrency Tasks to make use of their state to easily add a loading indicator on the buttons.