### PR TITLE
Feature: move subsidy warnings

### DIFF
--- a/app/templates/subsidy/applications/edit/step/edit.hbs
+++ b/app/templates/subsidy/applications/edit/step/edit.hbs
@@ -1,21 +1,6 @@
 <div class="au-c-body-container au-c-body-container--scroll">
 
   <AuToolbar @size="large" class="{{if this.canSubmit 'au-u-padding-none' 'au-u-padding-vertical'}}" as |Group|>
-    {{#if (and this.forceShowErrors (not this.isValidForm))}}
-      <Group class="au-c-toolbar__group--row">
-        <AuAlert
-          @icon="alert-triangle"
-          @title="Kan dossier niet versturen"
-          @skin="error"
-          @size="small"
-          @closable="true"
-          class="au-u-margin-bottom-none"
-        >
-          <p>Kan formulier niet versturen door ontbrekende of foutief ingevulde
-            velden.</p>
-        </AuAlert>
-      </Group>
-    {{/if}}
     <Group class="au-u-margin-top-none au-u-margin-bottom-none">
       {{#unless this.canSubmit}}
         {{! SENDING NOT POSSIBLE }}

--- a/app/templates/subsidy/applications/edit/step/edit.hbs
+++ b/app/templates/subsidy/applications/edit/step/edit.hbs
@@ -142,12 +142,16 @@
           {{else}}
             {{! PREVIOUS STEP NEEDS TO BE COMPLETED FIRST }}
             <div>
+              <AuLink @route="subsidy.applications.edit" @skin="primary">
+                <AuIcon @icon="arrow-left" @alignment="left" />
+                Terug naar vorige stap
+              </AuLink>
               <AuAlert
                 @icon="info-circle"
                 @title="Deze subsidieaanvraag stap is nog niet beschikbaar."
                 @skin="info"
                 @size="small"
-                class="au-u-margin-bottom-small"
+                class="au-u-margin-top-small au-u-margin-bottom-none"
               >
                 <p>Gelieve eerst de nog in te dienen stappen aan te vullen.</p>
                 <p>Indien u een fout heeft ontdekt, of een vraag heeft, neem
@@ -158,10 +162,6 @@
                   >LoketLokaalBestuur@vlaanderen.be</a>.
                 </p>
               </AuAlert>
-              <AuLink @route="subsidy.applications.edit" @skin="secondary">
-                <AuIcon @icon="arrow-left" @alignment="left" />
-                Terug naar vorige stap
-              </AuLink>
             </div>
           {{/if}}
         {{/if}}

--- a/app/templates/subsidy/applications/edit/step/edit.hbs
+++ b/app/templates/subsidy/applications/edit/step/edit.hbs
@@ -175,7 +175,7 @@
     <RdfForm
       @groupClass="au-o-grid__item"
       @form={{this.form}}
-      @show={{if (or this.submitted (not this.isActiveStep)) "true"}}
+      @show={{unless this.canSubmit "true"}}
       @graphs={{this.graphs}}
       @sourceNode={{this.sourceNode}}
       @formStore={{this.formStore}}

--- a/app/templates/subsidy/applications/edit/step/edit.hbs
+++ b/app/templates/subsidy/applications/edit/step/edit.hbs
@@ -1,23 +1,6 @@
 <div class="au-c-body-container au-c-body-container--scroll">
 
-  <div
-    class="au-o-box {{if (or this.saveConcept.isRunning this.submit.isRunning) 'au-c-form--disabled'}}"
-  >
-    <RdfForm
-      @groupClass="au-o-grid__item"
-      @form={{this.form}}
-      @show={{if (or this.submitted (not this.isActiveStep)) "true"}}
-      @graphs={{this.graphs}}
-      @sourceNode={{this.sourceNode}}
-      @formStore={{this.formStore}}
-      @forceShowErrors={{this.forceShowErrors}}
-      @useNewListingLayout={{true}}
-      @level={{2}}
-      class="au-u-max-width-medium"
-    />
-  </div>
-
-  <AuToolbar @size="large" as |Group|>
+  <AuToolbar @size="large" class="{{if this.canSubmit 'au-u-padding-none' 'au-u-padding-vertical'}}" as |Group|>
     {{#if (and this.forceShowErrors (not this.isValidForm))}}
       <Group class="au-c-toolbar__group--row">
         <AuAlert
@@ -33,54 +16,8 @@
         </AuAlert>
       </Group>
     {{/if}}
-    {{#if this.error}}
-      <Group class="au-c-toolbar__group--row">
-        <AuAlert
-          @icon="alert-triangle"
-          @title="Oeps! Dit is een beetje gênant ..."
-          @skin="error"
-          @size="small"
-          @closable="true"
-          class="au-u-margin-bottom-none"
-        >
-          <p>Het lijkt er op dat er iets onverwacht is fout gelopen bij het
-            {{this.error.action}}
-            van het formulier.</p>
-        </AuAlert>
-      </Group>
-    {{/if}}
-    <Group class="au-u-margin-top-small au-u-margin-bottom-small">
-      {{! DEFAULT CRUD CASE }}
-      {{#if this.canSubmit}}
-        <AuButton
-          @disabled={{if
-            (or
-              this.saveConcept.isRunning
-              this.submit.isRunning
-              this.delete.isRunning
-            )
-            "true"
-          }}
-          @loading={{if this.submit.isRunning "true"}}
-          {{on "click" (perform this.submit)}}
-        >Verstuur naar de Vlaamse overheid
-        </AuButton>
-        <AuButton
-          @disabled={{if
-            (or
-              this.saveConcept.isRunning
-              this.submit.isRunning
-              this.delete.isRunning
-            )
-            "true"
-          }}
-          @loading={{if this.saveConcept.isRunning "true"}}
-          @skin={{"secondary"}}
-          {{on "click" (perform this.saveConcept)}}
-        >
-          Bewaar als concept
-        </AuButton>
-      {{else}}
+    <Group class="au-u-margin-top-none au-u-margin-bottom-none">
+      {{#unless this.canSubmit}}
         {{! SENDING NOT POSSIBLE }}
         {{#if this.submitted}}
           <div>
@@ -89,6 +26,7 @@
               @title="De subsidiestap werd verstuurd."
               @skin="success"
               @size="small"
+              class="au-u-margin-bottom-none"
             >
               <p>We nemen contact op met de opgegeven contactpersoon over het
                 verdere verloop.
@@ -227,11 +165,96 @@
             </div>
           {{/if}}
         {{/if}}
-      {{/if}}
+      {{/unless}}
     </Group>
+  </AuToolbar>
+
+  <div
+    class="au-o-box {{if (or this.saveConcept.isRunning this.submit.isRunning) 'au-c-form--disabled'}}"
+  >
+    <RdfForm
+      @groupClass="au-o-grid__item"
+      @form={{this.form}}
+      @show={{if (or this.submitted (not this.isActiveStep)) "true"}}
+      @graphs={{this.graphs}}
+      @sourceNode={{this.sourceNode}}
+      @formStore={{this.formStore}}
+      @forceShowErrors={{this.forceShowErrors}}
+      @useNewListingLayout={{true}}
+      @level={{2}}
+      class="au-u-max-width-medium"
+    />
+  </div>
+
+  <AuToolbar @size="large" as |GroupBottom|>
+    {{#if this.error}}
+      <GroupBottom class="au-c-toolbar__group--row">
+        <AuAlert
+          @icon="alert-triangle"
+          @title="Oeps! Dit is een beetje gênant ..."
+          @skin="error"
+          @size="small"
+          @closable="true"
+          class="au-u-margin-bottom-none"
+        >
+          <p>Het lijkt er op dat er iets onverwacht is fout gelopen bij het
+            {{this.error.action}}
+            van het formulier.</p>
+        </AuAlert>
+      </GroupBottom>
+    {{/if}}
+    {{#if (and this.forceShowErrors (not this.isValidForm))}}
+      <GroupBottom class="au-c-toolbar__group--row">
+        <AuAlert
+          @icon="alert-triangle"
+          @title="Kan dossier niet versturen"
+          @skin="error"
+          @size="small"
+          @closable="true"
+          class="au-u-margin-bottom-none"
+        >
+          <p>Kan formulier niet versturen door ontbrekende of foutief ingevulde
+            velden.</p>
+        </AuAlert>
+      </GroupBottom>
+    {{/if}}
+    <GroupBottom class="au-u-margin-top-small au-u-margin-bottom-small">
+      {{! DEFAULT CRUD CASE }}
+      {{#if this.canSubmit}}
+        <AuButton
+          @disabled={{if
+            (or
+              this.saveConcept.isRunning
+              this.submit.isRunning
+              this.delete.isRunning
+            )
+            "true"
+          }}
+          @loading={{if this.submit.isRunning "true"}}
+          {{on "click" (perform this.submit)}}
+        >Verstuur naar de Vlaamse overheid
+        </AuButton>
+        <AuButton
+          @disabled={{if
+            (or
+              this.saveConcept.isRunning
+              this.submit.isRunning
+              this.delete.isRunning
+            )
+            "true"
+          }}
+          @loading={{if this.saveConcept.isRunning "true"}}
+          @skin={{"secondary"}}
+          {{on "click" (perform this.saveConcept)}}
+        >
+          Bewaar als concept
+        </AuButton>
+      {{/if}}
+    </GroupBottom>
+
 
     {{! USER NOTIFICATIONS }}
-    <Group>
+    <GroupBottom>
       <ul class="au-o-grid">
         {{! SAVING }}
         {{#if this.saveConcept.isRunning}}
@@ -295,6 +318,6 @@
           </li>
         {{/if}}
       </ul>
-    </Group>
+    </GroupBottom>
   </AuToolbar>
 </div>


### PR DESCRIPTION
## ID
DGS-112

## Description

To improve the UX of the edit view of subsidies this PR does the following:
- the subsidy warnings are now displayed on top of the page
- changed the 'terug naar vorige stap' to a primary button (as advised by Saska)
- disable the form when users cannot submit it

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How to test

Visit the subsidies module inside loket and try a few different subsidies. Verify they are still working and have the new, improved UX.