### PR TITLE
Add power select full width to shame file

### DIFF
--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -321,3 +321,7 @@
 .data-table.data-table--zebra tbody tr:nth-child(odd) {
   background-color: #f3f5f6;
 }
+
+.ember-power-select-multiple-options > li {
+  width: 100%;
+}


### PR DESCRIPTION
## Ticket Number

DL-5512

## Description

When a worship service selects a nationality inside the `Mandatenbeheer` module while adding a new person, the placeholder text (`Selecteer een nationaliteit`) was getting clipped on Chromium-based browsers.

![image](https://github.com/lblod/frontend-loket/assets/14963820/7981eae6-9c17-481c-801c-45eaea7a077b)

After deeper investigation from @Windvis, it turns out the issue is also reproducable in PowerSelect and can happen regardless of the browser, and as such, the best way to fix this for now is to update the shame file and force the browsers (specifically the `<li>` element) to use the complete width.