### PR TITLE
Add contact app card and its external links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The [ember-proxy-service](https://github.com/mu-semtech/ember-proxy-service#conf
 | `EMBER_WORSHIP_DECISIONS_DATABASE_URL`     | Link to the worship decisions database                                                  |
 | `EMBER_WORSHIP_ORGANISATIONS_DATABASE_URL` | Link to the worship organisations database                                              |
 | `EMBER_VERENIGINGEN_URL`                   | Link to the verenigingen app                                                            |
+| `EMBER_CONTACT_URL`                        | Link to the contact app                                                                 |
 | `EMBER_GLOBAL_SYSTEM_NOTIFICATION`         | This can be used to display a message at the top of the application. HTML is supported. |
 
 ### ACM/IDM

--- a/app/components/shared/compact-menu.hbs
+++ b/app/components/shared/compact-menu.hbs
@@ -99,4 +99,14 @@
       Verenigingen
     </AuLinkExternal>
   {{/if}}
+  {{#if this.currentSession.canAccessContact}}
+    <AuLinkExternal
+      @icon="link-external"
+      @iconAlignment="left"
+      href={{(contact-url)}}
+      role="menuitem"
+    >
+      Contact- en Organisatiegegevens
+    </AuLinkExternal>
+  {{/if}}
 </AuDropdown>

--- a/app/components/shared/main-menu.hbs
+++ b/app/components/shared/main-menu.hbs
@@ -121,5 +121,17 @@
         </AuLinkExternal>
       </li>
     {{/if}}
+    {{#if this.currentSession.canAccessContact}}
+      <li class="au-c-list-navigation__item">
+        <AuLinkExternal
+          @icon="link-external"
+          @iconAlignment="left"
+          class="au-c-list-navigation__link"
+          href={{(contact-url)}}
+        >
+          Contact- en Organisatiegegevens
+        </AuLinkExternal>
+      </li>
+    {{/if}}
   </ul>
 </nav>

--- a/app/helpers/contact-url.js
+++ b/app/helpers/contact-url.js
@@ -1,0 +1,5 @@
+import config from 'frontend-loket/config/environment';
+
+export default function contactUrl() {
+  return config.contactUrl;
+}

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -18,6 +18,7 @@ const MODULE = {
   WORSHIP_DECISIONS_DB: 'LoketLB-databankEredienstenGebruiker',
   WORSHIP_ORGANISATIONS_DB: 'LoketLB-eredienstOrganisatiesGebruiker',
   VERENIGINGEN: 'abb_loketverenigingenapp',
+  CONTACT: 'abb_organisatieportaal_rol_3d'
 };
 
 export default class CurrentSessionService extends Service {
@@ -137,5 +138,9 @@ export default class CurrentSessionService extends Service {
 
   get canAccessVerenigingen() {
     return this.canAccess(MODULE.VERENIGINGEN);
+  }
+
+  get canAccessContact() {
+    return this.canAccess(MODULE.CONTACT);
   }
 }

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -18,7 +18,7 @@ const MODULE = {
   WORSHIP_DECISIONS_DB: 'LoketLB-databankEredienstenGebruiker',
   WORSHIP_ORGANISATIONS_DB: 'LoketLB-eredienstOrganisatiesGebruiker',
   VERENIGINGEN: 'abb_loketverenigingenapp',
-  CONTACT: 'abb_organisatieportaal_rol_3d'
+  CONTACT: 'abb_organisatieportaal_rol_3d',
 };
 
 export default class CurrentSessionService extends Service {

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -133,14 +133,21 @@ export default class CurrentSessionService extends Service {
   }
 
   get canAccessPublicServices() {
-    return this.canAccess(MODULE.PUBLIC_SERVICES);
+    return (
+      this.canAccess(MODULE.PUBLIC_SERVICES) && !config.lpdcUrl.startsWith('{{')
+    );
   }
 
   get canAccessVerenigingen() {
-    return this.canAccess(MODULE.VERENIGINGEN);
+    return (
+      this.canAccess(MODULE.VERENIGINGEN) &&
+      !config.verenigingenUrl.startsWith('{{')
+    );
   }
 
   get canAccessContact() {
-    return this.canAccess(MODULE.CONTACT);
+    return (
+      this.canAccess(MODULE.CONTACT) && !config.contactUrl.startsWith('{{')
+    );
   }
 }

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -252,6 +252,26 @@
           </LoketModuleCard>
         </li>
       {{/if}}
+      {{#if this.currentSession.canAccessContact}}
+        <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
+          <LoketModuleCard
+            @icon="link-external"
+            @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-contact-en-organisatiegegevens/"
+          >
+            <:title>Contact- en Organisatiegegevens</:title>
+            <:description>Beheer uw contactgegevens en consulteer uw organisatiegegevens, zoals gekend bij Agentschap Binnenlands Bestuur.
+            </:description>
+            <:link>
+              <AuLinkExternal
+                @skin="button"
+                href={{(contact-url)}}
+              >
+                Ga naar contact- en organisatiegegevens (externe link)
+              </AuLinkExternal>
+            </:link>
+          </LoketModuleCard>
+        </li>
+      {{/if}}
     </ul>
   </div>
 </div>

--- a/config/environment.js
+++ b/config/environment.js
@@ -38,6 +38,7 @@ module.exports = function (environment) {
     worshipDecisionsDatabaseUrl: '{{WORSHIP_DECISIONS_DATABASE_URL}}',
     worshipOrganisationsDatabaseUrl: '{{WORSHIP_ORGANISATIONS_DATABASE_URL}}',
     verenigingenUrl: '{{VERENIGINGEN_URL}}',
+    contactUrl: '{{CONTACT_URL}}',
     'ember-plausible': {
       enabled: false,
     },


### PR DESCRIPTION
## Ticket Number

DL-5537

## Ticket Description

Similar to https://github.com/lblod/frontend-loket/pull/353; a new app (`Contact- en Organisatiegegevens`) needs to be added to the module card in Loket for those who can access it.

## How to Test

We need to add a `sessionRole` for an organization(s) in order to trigger the external module card in the Loket homepage. Run the following migration inside app-digitaal-loket to grant an org the contact role:
```sparql
PREFIX ext:   <http://mu.semte.ch/vocabularies/ext/>
PREFIX foaf:  <http://xmlns.com/foaf/0.1/>

INSERT {
  GRAPH <http://mu.semte.ch/graphs/public> {
    ?account ext:sessionRole "abb_organisatieportaal_rol_3d" .
  }
}
WHERE {
  BIND(<BESTUURSEENHEID_URI> AS ?bestuurseenheid)

  ?persoon foaf:member ?bestuurseenheid ;
    foaf:account ?account .
}
```
Replace `BESTUURSEENHEID_URI` with a URI of your choice. On my local setup, I used:
```
http://data.lblod.info/id/bestuurseenheden/974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4
```
which corresponds to `Gemeente Aalst`.

