### PR TITLE
Fix verenigingen session role

### DIFF
--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -17,7 +17,7 @@ const MODULE = {
   PUBLIC_SERVICES: 'LoketLB-LPDCGebruiker',
   WORSHIP_DECISIONS_DB: 'LoketLB-databankEredienstenGebruiker',
   WORSHIP_ORGANISATIONS_DB: 'LoketLB-eredienstOrganisatiesGebruiker',
-  VERENIGINGEN: 'LoketVerenigingen-Gebruiker',
+  VERENIGINGEN: 'LoketLB-verenigingenGebruiker',
   CONTACT: 'LoketLB-ContactOrganisatiegegevensGebruiker',
 };
 


### PR DESCRIPTION
Same change as [#360](https://github.com/lblod/frontend-loket/pull/360) and [#361](https://github.com/lblod/frontend-loket/pull/361) in order to fix the `verenigingen` session role.