### PR TITLE
[DL-5708] Fix an issue in the "create person" flow

### DIFF
--- a/app/components/shared/persoon/create-persoon.hbs
+++ b/app/components/shared/persoon/create-persoon.hbs
@@ -82,7 +82,7 @@
               mask="99.99.99-999.99"
               placeholder="_"
             )}}
-            {{on "input" this.setRijksregisternummer}}
+            {{on "input" this.handleRijksregisternummerChange}}
           />
           {{#if showError}}
             <AuHelpText @error="true">

--- a/app/components/shared/persoon/create-persoon.js
+++ b/app/components/shared/persoon/create-persoon.js
@@ -180,15 +180,20 @@ export default class SharedPersoonCreatePersoonComponent extends Component {
   }
 
   @action
-  setRijksregisternummer(event) {
-    this.rijksregisternummer = event.target.inputmask.unmaskedvalue();
+  handleRijksregisternummerChange(event) {
+    const rijksregisternummer = event.target.inputmask.unmaskedvalue();
+    this.setRijksregisternummer(rijksregisternummer);
+  }
 
-    if (isValidRijksregisternummer(this.rijksregisternummer)) {
-      this.birthDate = isBirthDateKnown(this.rijksregisternummer)
-        ? new Date(getBirthDate(this.rijksregisternummer))
+  setRijksregisternummer(rijksregisternummer) {
+    this.rijksregisternummer = rijksregisternummer;
+
+    if (isValidRijksregisternummer(rijksregisternummer)) {
+      this.birthDate = isBirthDateKnown(rijksregisternummer)
+        ? new Date(getBirthDate(rijksregisternummer))
         : this.birthDate;
-      if (isGenderKnown(this.rijksregisternummer)) {
-        isBiologicalFemale(this.rijksregisternummer)
+      if (isGenderKnown(rijksregisternummer)) {
+        isBiologicalFemale(rijksregisternummer)
           ? this.setGender(femaleId)
           : this.setGender(maleId);
       }


### PR DESCRIPTION
We accidentally introduced a regression when resolving some [Appuniversum deprecations](https://github.com/lblod/frontend-loket/commit/cb16ed4a39b2a3b3ac2f5858b6d092aa683cf4ae#diff-1ddb3e656e7b094dd9777f1206d1292365678e3cac0c141b9e92c3b59dcda79bR184). The `setRijksregister` method was also used by the flow that sets initial data based on the provided rijksregisternummer, but this flow wasn't made compatible with the new code.

We now properly cover both scenarios.