### PR TITLE
Make the groupClassification optional for the GlitchTip context

### DIFF
--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -60,7 +60,7 @@ export default class CurrentSessionService extends Service {
         account: this.account.id,
         user: this.user.id,
         group: this.group.uri,
-        groupClassification: this.groupClassification.uri,
+        groupClassification: this.groupClassification?.uri,
         roles: this.roles,
       });
     }


### PR DESCRIPTION
Not all mock users have a "groupClassification", which causes issues when logging in on the QA environment (since GlitchTip is enabled there).