### PR TITLE
Hide the status label in the overview table until the data is loaded

### DIFF
--- a/app/templates/supervision/submissions/index.hbs
+++ b/app/templates/supervision/submissions/index.hbs
@@ -52,7 +52,9 @@
         {{/if}}
       </td>
       <td>
-        <AuPill @skin={{if row.status.isSent "success" "warning"}}>{{row.status.label}}</AuPill>
+        {{#if row.status}}
+          <AuPill @skin={{if row.status.isSent "success" "warning"}}>{{row.status.label}}</AuPill>
+        {{/if}}
       </td>
       <td>
         <AuButtonGroup @inline={{true}}>


### PR DESCRIPTION
This prevents the case where the status column would display empty warning pills until the relationship was loaded. Now it simply "pops in" like the other columns.