### PR TITLE
[DL-5751] Allow multiple emails in the berichtencentrum preferences

### DIFF
--- a/app/components/berichtencentrum/bericht-notificatie-voorkeuren.hbs
+++ b/app/components/berichtencentrum/bericht-notificatie-voorkeuren.hbs
@@ -27,7 +27,6 @@
             @width="block"
             value={{this.emailAddress}}
             id="voorkeurenmailadres"
-            type="email"
             {{on "input" (with-value (fn (mut this.emailAddress)))}}
             {{auto-focus}}
           />


### PR DESCRIPTION
The `type="email"` attribute enables the browser email validations, which won't allow entering multiple emails separated by `,`. Some users depend on this, so we remove the type again.