### PR TITLE
Fix an issue when logging in with ACM/IDM

### DIFF
--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -63,8 +63,15 @@ export default class CurrentSessionService extends Service {
       // TODO: I don't think we need all of these as properties
       this._user = this._account.gebruiker;
       this._roles = this.session.data.authenticated.data.attributes.roles;
-      this._group = this._user.group;
-      this._groupClassification = this._group.belongsTo('classificatie').value();
+
+      // We need to do an extra API call here because ACM/IDM users don't seem to have a "bestuurseenheden" relationship in the DB.
+      // By fetching the record directly we bypass that issue
+      const groupId = this.session.data.authenticated.relationships.group.data.id;
+      this._group = await this.store.findRecord('bestuurseenheid', groupId, {
+        include: 'classificatie',
+        reload: true,
+      });
+      this._groupClassification = await this.group.classificatie;
 
       if (this.isAdmin) {
         await this.impersonation.load();


### PR DESCRIPTION
It seems that the ACM/IDM users don't have a relationship to their administrative units like the mock users do. This causes issues on QA and Prod environments. As a workaround we revert to the explicit API call that we did before. Ideally this would be resolved so the data is consistent between mock and real users, but this is a quick fix for the problem.