### PR TITLE
[DL-5849] Refactor the impersonation feature

### DIFF
--- a/app/components/impersonation-menu.gjs
+++ b/app/components/impersonation-menu.gjs
@@ -22,6 +22,7 @@ const PauseIcon = <template>
 </template>
 
 export default class ImpersonationMenu extends Component {
+  @service currentSession;
   @service impersonation;
 
   get isImpersonating() {
@@ -37,7 +38,7 @@ export default class ImpersonationMenu extends Component {
       return null;
     }
 
-    return this.impersonation.impersonatedAccount.gebruiker;
+    return this.currentSession.user;
   }
 
   get adminLabel() {

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -18,11 +18,10 @@ export default class ApplicationController extends Controller {
     let group;
     let classification;
 
-    if (this.currentSession.isAdmin) {
-      // TODO: should we create extra "public" properties, so we don't need to use the underscored ones?
-      user = this.currentSession._user;
-      group = this.currentSession._group;
-      classification = this.currentSession._groupClassification;
+    if (this.impersonation.isImpersonating) {
+      user = this.impersonation.originalAccount.gebruiker;
+      group = this.impersonation.originalGroup;
+      classification = group.belongsTo('classificatie').value();
     } else {
       user = this.currentSession.user;
       group = this.currentSession.group;

--- a/app/controllers/impersonate.js
+++ b/app/controllers/impersonate.js
@@ -42,13 +42,9 @@ export default class ImpersonateController extends Controller {
   });
 
   impersonateAccount = task(async (accountId) => {
-    const shouldClearData = this.impersonation.isImpersonating;
-
     await this.impersonation.impersonate(accountId);
     await this.router.transitionTo('index');
 
-    if (shouldClearData) {
-      window.location.reload();
-    }
+    window.location.reload();
   });
 }

--- a/app/services/impersonation.js
+++ b/app/services/impersonation.js
@@ -18,7 +18,7 @@ export default class ImpersonationService extends Service {
     if (response.ok) {
       const result = await response.json();
       const originalAccountId =
-        result.data.relationships['original-resource'].data.id;
+        result.data.relationships['original-account'].data.id;
 
       const originalGroupId = result.data.relationships['original-session-group'].data.id;
       const [originalAccount, originalGroup] = await Promise.all([
@@ -48,7 +48,7 @@ export default class ImpersonationService extends Service {
           relationships: {
             impersonates: {
               data: {
-                type: 'resource',
+                type: 'accounts',
                 id: accountId,
               },
             },

--- a/app/services/impersonation.js
+++ b/app/services/impersonation.js
@@ -4,10 +4,12 @@ import { loadAccountData } from 'frontend-loket/utils/account';
 
 export default class ImpersonationService extends Service {
   @service store;
-  @tracked impersonatedAccount;
+  @tracked originalAccount;
+  @tracked originalGroup;
+  @tracked originalRoles;
 
   get isImpersonating() {
-    return Boolean(this.impersonatedAccount);
+    return Boolean(this.originalAccount);
   }
 
   async load() {
@@ -15,11 +17,21 @@ export default class ImpersonationService extends Service {
 
     if (response.ok) {
       const result = await response.json();
-      const impersonatedAccountId =
-        result.data.relationships.impersonates.data.id;
-      if (impersonatedAccountId) {
-        await this.#loadImpersonatedAccount(impersonatedAccountId);
-      }
+      const originalAccountId =
+        result.data.relationships['original-resource'].data.id;
+
+      const originalGroupId = result.data.relationships['original-session-group'].data.id;
+      const [originalAccount, originalGroup] = await Promise.all([
+        loadAccountData(this.store, originalAccountId),
+        this.store.findRecord('bestuurseenheid', originalGroupId, {
+          include: 'classificatie',
+          reload: true,
+        })
+      ]);
+
+      this.originalAccount = originalAccount;
+      this.originalGroup = originalGroup;
+      this.originalRoles = result.data.attributes['original-session-roles'];
     }
   }
 
@@ -45,9 +57,7 @@ export default class ImpersonationService extends Service {
       }),
     });
 
-    if (response.ok) {
-      await this.#loadImpersonatedAccount(accountId);
-    } else {
+    if (!response.ok) {
       const result = await response.json();
       throw new Error(
         'An exception occurred while trying to impersonate someone: ' +
@@ -63,14 +73,10 @@ export default class ImpersonationService extends Service {
       });
 
       if (response.ok) {
-        this.impersonatedAccount = null;
+        this.originalAccount = null;
+        this.originalGroup = null;
+        this.originalRoles = [];
       }
     }
-  }
-
-  async #loadImpersonatedAccount(accountId) {
-    const account = await loadAccountData(this.store, accountId);
-
-    this.impersonatedAccount = account;
   }
 }


### PR DESCRIPTION
The backend service changed implementations to work around some issues which requires us to update the logic in the frontend as well.

The backend now impersonates "transparently" which means the `/current` endpoints of the login services now return the impersonated account instead of the admin one. We then need to fetch the original admin account if an impersonation is active.

Needs the following branches to work:
- https://github.com/lblod/app-digitaal-loket/pull/561
- https://github.com/lblod/impersonation-service/pull/6