### PR TITLE
[DL-5888] Fix the prefill of the fractie-selector component

### DIFF
--- a/app/components/mandatenbeheer/mandataris-edit.js
+++ b/app/components/mandatenbeheer/mandataris-edit.js
@@ -38,7 +38,7 @@ export default Component.extend({
     this.set('saveError', false);
     this.set('requiredFieldError', false);
     const membership = await this.mandataris.heeftLidmaatschap;
-    const fractie = await membership?.fractie;
+    const fractie = await membership?.binnenFractie;
     this.set('fractie', fractie);
 
     const beleidsdomeinen = await this.mandataris.beleidsdomein;


### PR DESCRIPTION
We accidentally introduced a typo regression when resolving deprecations in the past. This should fix that.

Same change as #385 but against an older tag.