### PR TITLE
Add open proces huis external module card

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The [ember-proxy-service](https://github.com/mu-semtech/ember-proxy-service#conf
 | `EMBER_VERENIGINGEN_URL`                   | Link to the verenigingen app                                                            |
 | `EMBER_CONTACT_URL`                        | Link to the contact app                                                                 |
 | `EMBER_SUBSIDIES_URL`                      | Link to the subsidiepunt app                                                            |
+| `EMBER_OPEN_PROCES_HUIS_URL`               | Link to the open proces huis app                                                            |
 | `EMBER_GLOBAL_SYSTEM_NOTIFICATION`         | This can be used to display a message at the top of the application. HTML is supported. |
 
 ### ACM/IDM

--- a/README.md
+++ b/README.md
@@ -8,16 +8,17 @@ The [ember-proxy-service](https://github.com/mu-semtech/ember-proxy-service#conf
 
 ### General
 
-| Name                                       | Description                                                                             |
-| ------------------------------------------ | --------------------------------------------------------------------------------------- |
-| `EMBER_LPDC_URL`                           | Link to the LPDC application                                                            |
-| `EMBER_WORSHIP_DECISIONS_DATABASE_URL`     | Link to the worship decisions database                                                  |
-| `EMBER_WORSHIP_ORGANISATIONS_DATABASE_URL` | Link to the worship organisations database                                              |
-| `EMBER_VERENIGINGEN_URL`                   | Link to the verenigingen app                                                            |
-| `EMBER_CONTACT_URL`                        | Link to the contact app                                                                 |
-| `EMBER_SUBSIDIES_URL`                      | Link to the subsidiepunt app                                                            |
-| `EMBER_OPEN_PROCES_HUIS_URL`               | Link to the open proces huis app                                                            |
-| `EMBER_GLOBAL_SYSTEM_NOTIFICATION`         | This can be used to display a message at the top of the application. HTML is supported. |
+| Name                                       | Description                                                                                           |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `EMBER_LPDC_URL`                           | Link to the LPDC application                                                                          |
+| `EMBER_WORSHIP_DECISIONS_DATABASE_URL`     | Link to the worship decisions database                                                                |
+| `EMBER_WORSHIP_ORGANISATIONS_DATABASE_URL` | Link to the worship organisations database                                                            |
+| `EMBER_VERENIGINGEN_URL`                   | Link to the verenigingen app                                                                          |
+| `EMBER_CONTACT_URL`                        | Link to the contact app                                                                               |
+| `EMBER_SUBSIDIES_URL`                      | Link to the subsidiepunt app                                                                          |
+| `EMBER_OPEN_PROCES_HUIS_URL`               | Link to the open proces huis app                                                                      |
+| `EMBER_OPEN_PROCES_HUIS_ROLE`              | ACM/IDM user role that is used to display the app link. defaults to `LoketLB-OpenProcesHuisGebruiker` |
+| `EMBER_GLOBAL_SYSTEM_NOTIFICATION`         | This can be used to display a message at the top of the application. HTML is supported.               |
 
 ### ACM/IDM
 
@@ -55,18 +56,20 @@ Feature flags are new / experimental features that can be enabled by setting the
 
 ## Releasing a new version
 
-We use [`release-it`](https://github.com/release-it/release-it) to handle our release flow 
+We use [`release-it`](https://github.com/release-it/release-it) to handle our release flow
 
 ### Generating the changelog (optional)
-At the moment the changelog is updated manually. To make this a bit easier you can generate a basic changelog based on the merged PRs with [`lerna-changelog`](https://github.com/lerna/lerna-changelog) by  adding the correct labels and updating the PR titles.
+
+At the moment the changelog is updated manually. To make this a bit easier you can generate a basic changelog based on the merged PRs with [`lerna-changelog`](https://github.com/lerna/lerna-changelog) by adding the correct labels and updating the PR titles.
 
 > `lerna-changelog` requires a Github [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) to work properly.
 
-The following command can  be used to generate the changelog:
+The following command can be used to generate the changelog:
 
 `GITHUB_AUTH=your-access-token npx lerna-changelog`
 
 ### Creating a new release
+
 Simply run `npm run release` and follow the prompts.
 
 > If you generated the changelog using lerna-changelog you can add it to the changelog file and add it to the staged changes when release-it asks if you want to commit the changes. This will ensure that the changelog change is part of the release commit.

--- a/app/components/shared/compact-menu.hbs
+++ b/app/components/shared/compact-menu.hbs
@@ -118,4 +118,14 @@
       Contact- en Organisatiegegevens
     </AuLinkExternal>
   {{/if}}
+  {{#if this.currentSession.canAccessOpenProcesHuis}}
+    <AuLinkExternal
+      @icon="link-external"
+      @iconAlignment="left"
+      href={{(open-proces-huis-url)}}
+      role="menuitem"
+    >
+      Open Proces Huis
+    </AuLinkExternal>
+  {{/if}}
 </AuDropdown>

--- a/app/components/shared/main-menu.hbs
+++ b/app/components/shared/main-menu.hbs
@@ -144,5 +144,17 @@
         </AuLinkExternal>
       </li>
     {{/if}}
+    {{#if this.currentSession.canAccessOpenProcesHuis}}
+      <li class="au-c-list-navigation__item">
+        <AuLinkExternal
+          @icon="link-external"
+          @iconAlignment="left"
+          class="au-c-list-navigation__link"
+          href={{(open-proces-huis-url)}}
+        >
+          Open Proces Huis
+        </AuLinkExternal>
+      </li>
+    {{/if}}
   </ul>
 </nav>

--- a/app/helpers/open-proces-huis-url.js
+++ b/app/helpers/open-proces-huis-url.js
@@ -1,0 +1,5 @@
+import config from 'frontend-loket/config/environment';
+
+export default function openProcesHuisUrl() {
+  return config.openProcesHuisUrl;
+}

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -21,6 +21,7 @@ const MODULE_ROLE = {
   WORSHIP_ORGANISATIONS_DB: 'LoketLB-eredienstOrganisatiesGebruiker',
   VERENIGINGEN: 'LoketLB-verenigingenGebruiker',
   CONTACT: 'LoketLB-ContactOrganisatiegegevensGebruiker',
+  OPEN_PROCES_HUIS: 'LoketLB-OpenProcesHuisGebruiker'
 };
 
 const ADMIN_ROLE = 'LoketLB-admin';
@@ -184,6 +185,12 @@ export default class CurrentSessionService extends Service {
   get canAccessContact() {
     return (
       this.canAccess(MODULE_ROLE.CONTACT) && !config.contactUrl.startsWith('{{')
+    );
+  }
+
+  get canAccessOpenProcesHuis() {
+    return (
+      this.canAccess(MODULE_ROLE.OPEN_PROCES_HUIS) && !config.openProcesHuisUrl.startsWith('{{')
     );
   }
 

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -21,7 +21,7 @@ const MODULE_ROLE = {
   WORSHIP_ORGANISATIONS_DB: 'LoketLB-eredienstOrganisatiesGebruiker',
   VERENIGINGEN: 'LoketLB-verenigingenGebruiker',
   CONTACT: 'LoketLB-ContactOrganisatiegegevensGebruiker',
-  OPEN_PROCES_HUIS: 'LoketLB-OpenProcesHuisGebruiker'
+  OPEN_PROCES_HUIS: 'LoketLB-OpenProcesHuisGebruiker',
 };
 
 const ADMIN_ROLE = 'LoketLB-admin';
@@ -190,7 +190,8 @@ export default class CurrentSessionService extends Service {
 
   get canAccessOpenProcesHuis() {
     return (
-      this.canAccess(MODULE_ROLE.OPEN_PROCES_HUIS) && !config.openProcesHuisUrl.startsWith('{{')
+      this.canAccess(MODULE_ROLE.OPEN_PROCES_HUIS) &&
+      !config.openProcesHuisUrl.startsWith('{{')
     );
   }
 

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -21,7 +21,9 @@ const MODULE_ROLE = {
   WORSHIP_ORGANISATIONS_DB: 'LoketLB-eredienstOrganisatiesGebruiker',
   VERENIGINGEN: 'LoketLB-verenigingenGebruiker',
   CONTACT: 'LoketLB-ContactOrganisatiegegevensGebruiker',
-  OPEN_PROCES_HUIS: 'LoketLB-OpenProcesHuisGebruiker',
+  OPEN_PROCES_HUIS: config.openProcesHuisRole.startsWith('{{')
+    ? 'LoketLB-OpenProcesHuisGebruiker'
+    : config.openProcesHuisRole,
 };
 
 const ADMIN_ROLE = 'LoketLB-admin';

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -279,6 +279,23 @@
             </LoketModuleCard>
           </li>
         {{/if}}
+        {{#if this.currentSession.canAccessOpenProcesHuis}}
+          <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
+            <LoketModuleCard
+              @icon="link-external"
+              @userManualLink=""
+            >
+              <:title>Open Proces Huis</:title>
+              <:description>Raadpleeg, doorzoek en upload processen en originele BPMN-bestanden in het Open Proces Huis, jouw centrale bron voor het ontdekken en delen van processen.
+              </:description>
+              <:link>
+                <AuLinkExternal @skin="button" href={{(open-proces-huis-url)}}>
+                  Ga naar open proces huis (externe link)
+                </AuLinkExternal>
+              </:link>
+            </LoketModuleCard>
+          </li>
+        {{/if}}
       </ul>
     {{/if}}
   </div>

--- a/config/environment.js
+++ b/config/environment.js
@@ -42,6 +42,7 @@ module.exports = function (environment) {
     verenigingenUrl: '{{VERENIGINGEN_URL}}',
     contactUrl: '{{CONTACT_URL}}',
     openProcesHuisUrl: '{{OPEN_PROCES_HUIS_URL}}',
+    openProcesHuisRole: '{{OPEN_PROCES_HUIS_ROLE}}', // TODO: remove this once the actual role is known
     'ember-plausible': {
       enabled: false,
     },

--- a/config/environment.js
+++ b/config/environment.js
@@ -41,6 +41,7 @@ module.exports = function (environment) {
     worshipOrganisationsDatabaseUrl: '{{WORSHIP_ORGANISATIONS_DATABASE_URL}}',
     verenigingenUrl: '{{VERENIGINGEN_URL}}',
     contactUrl: '{{CONTACT_URL}}',
+    openProcesHuisUrl: '{{OPEN_PROCES_HUIS_URL}}',
     'ember-plausible': {
       enabled: false,
     },


### PR DESCRIPTION
## Ticket Number

DL-5816

## Ticket Description

This PR adds the necessary code for the `Open Proces Huis` external module card, similar to what was done before for other external apps.

## How to Test

First, run the corresponding [backend PR](https://github.com/lblod/app-digitaal-loket/pull/582).

Assign `openProcesHuisUrl` in `environment.js` to the QA link for open proces huis (which you can find in the ticket) and run the frontend. You should see the external module card regardless of the type of organization you used to log in.