### PR TITLE
[DL-6042] Add cards to the login page for all external apps

### DIFF
--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -187,8 +187,9 @@
                   </AuHeading>
                 </c.header>
                 <c.content>
-                  <p class="au-u-margin-top-tiny">Hou de mandaten binnen de
-                    erediensten bij.</p>
+                  <p class="au-u-margin-top-tiny">
+                    Hou de bedienaren binnen de erediensten bij.
+                  </p>
                 </c.content>
                 <c.footer>
                   <p>
@@ -218,8 +219,9 @@
                   </AuHeading>
                 </c.header>
                 <c.content>
-                  <p class="au-u-margin-top-tiny">Hou de mandaten binnen de
-                    erediensten bij.</p>
+                  <p class="au-u-margin-top-tiny">
+                    Hou de mandaten binnen de erediensten bij.
+                  </p>
                 </c.content>
                 <c.footer>
                   <p>
@@ -360,6 +362,172 @@
                       href="https://abb-vlaanderen.gitbook.io/informatie-lpdc/"
                     >
                       Handleiding
+                    </AuLinkExternal>
+                  </p>
+                </c.footer>
+              </AuCard>
+            </div>
+
+            <div class="au-o-grid__item au-u-1-2@small au-u-1-3@medium">
+              <AuCard @textCenter="true" as |c|>
+                <c.header @badgeSkin="brand" @badgeIcon="unordered-list">
+                  <AuHeading @level="3" @skin="4">
+                    Databank Erediensten
+                  </AuHeading>
+                </c.header>
+                <c.content>
+                  <p class="au-u-margin-top-tiny">
+                    Consulteer hier inzendingen van (centrale) besturen van de
+                    eredienst, gemeente- en provincieoverheid en representatief
+                    orgaan.
+                  </p>
+                </c.content>
+                <c.footer>
+                  <p>
+                    <AuLinkExternal
+                      @skin="button"
+                      @icon="link"
+                      href="https://www.vlaanderen.be/lokaal-bestuur/data-en-tools/databank-erediensten"
+                    >
+                      Meer informatie
+                    </AuLinkExternal>
+                    <AuLinkExternal
+                      @skin="button-secondary"
+                      @icon="manual"
+                      href="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/databank-erediensten"
+                    >
+                      Handleiding
+                    </AuLinkExternal>
+                  </p>
+                </c.footer>
+              </AuCard>
+            </div>
+
+            <div class="au-o-grid__item au-u-1-2@small au-u-1-3@medium">
+              <AuCard @textCenter="true" as |c|>
+                <c.header @badgeSkin="brand" @badgeIcon="unordered-list">
+                  <AuHeading @level="3" @skin="4">
+                    Organisaties Erediensten
+                  </AuHeading>
+                </c.header>
+                <c.content>
+                  <p class="au-u-margin-top-tiny">
+                    Consulteer hier de mandaten en bedienaren van de besturen
+                    van de eredienst.
+                  </p>
+                </c.content>
+                <c.footer>
+                  <p>
+                    <AuLinkExternal
+                      @skin="button"
+                      @icon="link"
+                      href="https://www.vlaanderen.be/lokaal-bestuur/organisatie-en-werking/loket-voor-lokale-besturen/organisaties-erediensten"
+                    >
+                      Meer informatie
+                    </AuLinkExternal>
+                    <AuLinkExternal
+                      @skin="button-secondary"
+                      @icon="manual"
+                      href="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/eredienst-organisaties"
+                    >
+                      Handleiding
+                    </AuLinkExternal>
+                  </p>
+                </c.footer>
+              </AuCard>
+            </div>
+
+            <div class="au-o-grid__item au-u-1-2@small au-u-1-3@medium">
+              <AuCard @textCenter="true" as |c|>
+                <c.header @badgeSkin="brand" @badgeIcon="unordered-list">
+                  <AuHeading @level="3" @skin="4">
+                    Verenigingen
+                  </AuHeading>
+                </c.header>
+                <c.content>
+                  <p class="au-u-margin-top-tiny">
+                    Consulteer uw verenigingen, zoals gekend in het
+                    Verenigingsregister, en beheer uw erkenningen.
+                  </p>
+                </c.content>
+                <c.footer>
+                  <p>
+                    <AuLinkExternal
+                      @skin="button"
+                      @icon="link"
+                      href="https://www.vlaanderen.be/lokaal-bestuur/organisatie-en-werking/loket-voor-lokale-besturen"
+                    >
+                      Meer informatie
+                    </AuLinkExternal>
+                    <AuLinkExternal
+                      @skin="button-secondary"
+                      @icon="manual"
+                      href="https://abb-vlaanderen.gitbook.io/handleiding-verenigingen/"
+                    >
+                      Handleiding
+                    </AuLinkExternal>
+                  </p>
+                </c.footer>
+              </AuCard>
+            </div>
+
+            <div class="au-o-grid__item au-u-1-2@small au-u-1-3@medium">
+              <AuCard @textCenter="true" as |c|>
+                <c.header @badgeSkin="brand" @badgeIcon="unordered-list">
+                  <AuHeading @level="3" @skin="4">
+                    Contact- en Organisatiegegevens
+                  </AuHeading>
+                </c.header>
+                <c.content>
+                  <p class="au-u-margin-top-tiny">
+                    Beheer uw contactgegevens en consulteer uw
+                    organisatiegegevens, zoals gekend bij Agentschap Binnenlands
+                    Bestuur.
+                  </p>
+                </c.content>
+                <c.footer>
+                  <p>
+                    <AuLinkExternal
+                      @skin="button"
+                      @icon="link"
+                      href="https://www.vlaanderen.be/lokaal-bestuur/organisatie-en-werking/loket-voor-lokale-besturen"
+                    >
+                      Meer informatie
+                    </AuLinkExternal>
+                    <AuLinkExternal
+                      @skin="button-secondary"
+                      @icon="manual"
+                      href="https://abb-vlaanderen.gitbook.io/handleiding-contact-en-organisatiegegevens/"
+                    >
+                      Handleiding
+                    </AuLinkExternal>
+                  </p>
+                </c.footer>
+              </AuCard>
+            </div>
+
+            <div class="au-o-grid__item au-u-1-2@small au-u-1-3@medium">
+              <AuCard @textCenter="true" as |c|>
+                <c.header @badgeSkin="brand" @badgeIcon="unordered-list">
+                  <AuHeading @level="3" @skin="4">
+                    Open Proces Huis
+                  </AuHeading>
+                </c.header>
+                <c.content>
+                  <p class="au-u-margin-top-tiny">
+                    Raadpleeg, doorzoek en upload processen en originele
+                    BPMN-bestanden in het Open Proces Huis, jouw centrale bron
+                    voor het ontdekken en delen van processen.
+                  </p>
+                </c.content>
+                <c.footer>
+                  <p>
+                    <AuLinkExternal
+                      @skin="button"
+                      @icon="link"
+                      href="https://www.vlaanderen.be/lokaal-bestuur/digitale-transformatie/open-proces-huis"
+                    >
+                      Meer informatie
                     </AuLinkExternal>
                   </p>
                 </c.footer>


### PR DESCRIPTION
It seems users get confused when they don't see the cards listed on the login page so we add them all, even though it's technically not part of loket itself.

The following cards have been added:
- Databank Erediensten
- Organisaties Erediensten
- Verenigingen
- Contact- en Organisatiegegevens
- Open Proces Huis