### PR TITLE
Also add the `forDecisionType` param to the `/related-document-information` call

### DIFF
--- a/app/components/supervision/decision-articles-field.gjs
+++ b/app/components/supervision/decision-articles-field.gjs
@@ -330,6 +330,7 @@ class ArticleDetails extends Component {
           window.location.origin,
         );
 
+        url.searchParams.append('forDecisionType', this.args.decisionType.uri);
         url.searchParams.append('forRelatedDecision', decisionNode.uri);
         const response = await fetch(url);
 


### PR DESCRIPTION
This makes it easier for the backend to do its thing.