### PR TITLE
Add a status filter to the "Toezicht" overview page

### DIFF
--- a/app/components/supervision/submission-status-select.gjs
+++ b/app/components/supervision/submission-status-select.gjs
@@ -1,0 +1,76 @@
+import AuLoader from '@appuniversum/ember-appuniversum/components/au-loader';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
+import PowerSelect from 'ember-power-select/components/power-select';
+import {
+  CONCEPT_STATUS,
+  SENT_STATUS,
+} from 'frontend-loket/models/submission-document-status';
+
+export default class SubmissionStatusSelect extends Component {
+  @service store;
+  @tracked statuses = [];
+
+  constructor() {
+    super(...arguments);
+
+    this.loadStatuses();
+  }
+
+  get isLoading() {
+    return this.statuses.length === 0;
+  }
+
+  get selectedStatus() {
+    const { statusUri } = this.args;
+    if (statusUri && !this.isLoading) {
+      return this.statuses.find((status) => status.uri === statusUri);
+    }
+
+    return null;
+  }
+
+  async loadStatuses() {
+    // We only want the concept and sent statuses for now, since those are the only ones visible in the table
+    this.statuses = (
+      await Promise.all([
+        this.store.query('submission-document-status', {
+          'filter[:uri:]': CONCEPT_STATUS,
+          page: { size: 1 },
+        }),
+        this.store.query('submission-document-status', {
+          'filter[:uri:]': SENT_STATUS,
+          page: { size: 1 },
+        }),
+      ])
+    ).map((statusResponse) => statusResponse.at(0));
+  }
+
+  handleChange = (maybeStatus) => {
+    this.args.onChange?.(maybeStatus?.uri);
+  };
+
+  <template>
+    <div ...attributes>
+      {{#if this.isLoading}}
+        <AuLoader
+          @hideMessage={{true}}
+          class="au-u-flex au-u-flex--center au-u-flex--vertical-center h-full"
+        >Aan het laden</AuLoader>
+      {{else}}
+        <PowerSelect
+          @options={{this.statuses}}
+          @onChange={{this.handleChange}}
+          @placeholder="Status"
+          @ariaLabel="Filter op status"
+          @selected={{this.selectedStatus}}
+          @allowClear={{true}}
+          as |status|
+        >
+          {{status.label}}
+        </PowerSelect>
+      {{/if}}
+    </div>
+  </template>
+}

--- a/app/controllers/supervision/submissions/index.js
+++ b/app/controllers/supervision/submissions/index.js
@@ -1,15 +1,24 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 import { CONCEPT_STATUS } from 'frontend-loket/models/submission-document-status';
 
 export default class SupervisionSubmissionsIndexController extends Controller {
   @service router;
   @service store;
 
-  page = 0;
+  queryParams = ['page', 'size', 'sort', 'status'];
+
+  @tracked status;
+  @tracked page = 0;
   size = 20;
   sort = '-modified';
+
+  @action handleStatusFilterChange(statusUri) {
+    this.status = statusUri;
+    this.page = 0;
+  }
 
   @action
   async reopen(submission) {

--- a/app/routes/supervision/submissions/index.js
+++ b/app/routes/supervision/submissions/index.js
@@ -9,15 +9,30 @@ export default class SupervisionSubmissionsIndexRoute extends Route.extend(
   @service session;
   @service store;
 
+  queryParams = {
+    filter: { refreshModel: true },
+    page: { refreshModel: true },
+    size: { refreshModel: true },
+    sort: { refreshModel: true },
+    status: { refreshModel: true },
+  };
+
   modelName = 'submission';
 
-  mergeQueryOptions() {
-    return {
-      'filter[status][id]': [
-        '79a52da4-f491-4e2f-9374-89a13cde8ecd', // Concept status
-        '9bd8d86d-bb10-4456-a84e-91e9507c374c', // Sent status
-      ].join(','),
+  mergeQueryOptions({ status }) {
+    const query = {
       include: ['form-data'].join(','),
     };
+
+    if (status) {
+      query['filter[status][:uri:]'] = status;
+    } else {
+      query['filter[status][id]'] = [
+        '79a52da4-f491-4e2f-9374-89a13cde8ecd', // Concept status
+        '9bd8d86d-bb10-4456-a84e-91e9507c374c', // Sent status
+      ].join(',');
+    }
+
+    return query;
   }
 }

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -333,3 +333,9 @@
   height: auto; // override the fixed height of the button height
   border: .1rem #c6cdd3 solid;
 }
+
+// Based on the Tailwind class: https://tailwindcss.com/docs/height#full-height
+.h-full {
+  height: 100% !important;
+}
+

--- a/app/templates/supervision/submissions/index.hbs
+++ b/app/templates/supervision/submissions/index.hbs
@@ -4,12 +4,19 @@
     <AuHeading @skin="2" data-test-loket="inzendingen-page-title">Toezicht</AuHeading>
   </Group>
   <Group>
-    <AuLink
-      @route="supervision.submissions.new"
-      @skin="button"
-      @icon="add"
-      data-test-field-uri="new-form-button"
-    >Maak nieuwe melding</AuLink>
+    <div class="au-u-flex">
+      <Supervision::SubmissionStatusSelect
+        @statusUri={{this.status}}
+        @onChange={{this.handleStatusFilterChange}}
+        class="au-u-margin-right-small"
+      />
+      <AuLink
+        @route="supervision.submissions.new"
+        @skin="button"
+        @icon="add"
+        data-test-field-uri="new-form-button"
+      >Maak nieuwe melding</AuLink>
+    </div>
   </Group>
 </AuToolbar>
 


### PR DESCRIPTION
This makes it (a little) easier to find the submission we want.

![image](https://github.com/lblod/frontend-loket/assets/3533236/4506db6b-224c-4feb-8601-6ac21b71fc7d)

Builds on #398 
