### PR TITLE
Replace ember-auto-focus with an inlined version

### DIFF
--- a/app/modifiers/auto-focus.js
+++ b/app/modifiers/auto-focus.js
@@ -1,0 +1,49 @@
+import Modifier from 'ember-modifier';
+import { next, scheduleOnce } from '@ember/runloop';
+
+// This modifier is a copy of the `@zestia/ember-auto-focus` addon (v5.2.1): https://github.com/zestia/ember-auto-focus/blob/973e00749e6c4e9ab443b3bee08fbf7937a5bb4b/addon/modifiers/auto-focus.js
+// We inline the implementation since they no longer publish to npm and the implementation is very small anyways.
+// TODO: We should re-evaluate the usage of this since it has accessibility implications and we might not need this modifier in the future.
+export default class AutoFocusModifier extends Modifier {
+  didSetup = false;
+
+  modify(element, positional, named) {
+    if (this.didSetup) {
+      return;
+    }
+
+    this.didSetup = true;
+
+    const { disabled } = named;
+
+    if (disabled) {
+      return;
+    }
+
+    const [selector] = positional;
+
+    if (selector) {
+      element = element.querySelector(selector);
+    }
+
+    if (!element) {
+      return;
+    }
+
+    scheduleOnce('afterRender', this, afterRender, element, named);
+  }
+}
+
+function afterRender(element, options) {
+  if (element.contains(document.activeElement)) {
+    return;
+  }
+
+  focus(element, options);
+}
+
+function focus(element, options) {
+  element.dataset.programmaticallyFocused = 'true';
+  element.focus(options);
+  next(() => delete element.dataset.programmaticallyFocused);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "@lblod/ember-submission-form-fields": "^2.21.0",
         "@lblod/submission-form-helpers": "^2.10.0",
         "@sentry/ember": "^7.54.0",
-        "@zestia/ember-auto-focus": "^5.1.0",
         "broccoli-asset-rev": "^3.0.0",
         "browser-update": "^3.3.38",
         "concurrently": "^8.0.1",
@@ -5389,25 +5388,6 @@
       "version": "4.2.2",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@zestia/ember-auto-focus": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@zestia/ember-auto-focus/-/ember-auto-focus-5.1.0.tgz",
-      "integrity": "sha512-uyqhngaUMEJPLF6uwBmgS4U49NfTCa/APvla0faJAuceSiqjtDGFq1NUJAGDq6QT/KuWPOm/YaGqoWKN7Vo/LA==",
-      "deprecated": "Moved to GitHub Packages",
-      "dev": true,
-      "dependencies": {
-        "ember-auto-import": "^2.6.3",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.2.0",
-        "ember-modifier": "^4.1.0"
-      },
-      "engines": {
-        "node": "16.* || >= 18"
-      },
-      "peerDependencies": {
-        "ember-source": ">= 4.0.0"
-      }
     },
     "node_modules/abab": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@lblod/ember-submission-form-fields": "^2.21.0",
     "@lblod/submission-form-helpers": "^2.10.0",
     "@sentry/ember": "^7.54.0",
-    "@zestia/ember-auto-focus": "^5.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "browser-update": "^3.3.38",
     "concurrently": "^8.0.1",


### PR DESCRIPTION
The package is no longer published to npm which makes consuming it hard. Since it's a single modifier we simply inline the latest code in the app itself.

Same change as: https://github.com/lblod/frontend-mandatendatabank/pull/20/commits/d4f36ba6ab8c3667874aab55c223c901459ad217