### PR TITLE
[DL-4540, DL-4069] Fix sorting in various places

### DIFF
--- a/app/components/berichtencentrum/conversatie-table.hbs
+++ b/app/components/berichtencentrum/conversatie-table.hbs
@@ -12,12 +12,12 @@
    as |t|>
   <t.content as |c|>
     <c.header>
-      <AuDataTableThSortable @label='Betreft' @field='betreft' @currentSorting={{@sort}} />
-      <AuDataTableThSortable @label='Type communicatie' @field='currentTypeCommunicatie' @currentSorting={{@sort}} />
-      <AuDataTableThSortable @label='Dossiernummer' @field='dossiernummer' @currentSorting={{@sort}} class="au-u-visible-small-up" />
+      <AuDataTableThSortable @label='Betreft' @field=':no-case:betreft' @currentSorting={{@sort}} />
+      <AuDataTableThSortable @label='Type communicatie' @field=':no-case:currentTypeCommunicatie' @currentSorting={{@sort}} />
+      <AuDataTableThSortable @label='Dossiernummer' @field=':no-case:dossiernummer' @currentSorting={{@sort}} class="au-u-visible-small-up" />
       {{#unless @renderSmallTable}}
          <AuDataTableThSortable @label='Laatste bericht' @field='laatste-bericht.verzonden' @currentSorting={{@sort}} class="au-u-visible-small-up" />
-         <AuDataTableThSortable @label='Laatste bericht van' @field='laatste-bericht.van.naam' @currentSorting={{@sort}} class="au-u-visible-small-up" />
+         <AuDataTableThSortable @label='Laatste bericht van' @field=':no-case:laatste-bericht.van.naam' @currentSorting={{@sort}} class="au-u-visible-small-up" />
       {{/unless}}
       <th>{{!-- Actions --}}</th>
     </c.header>

--- a/app/templates/eredienst-mandatenbeheer/mandatarissen.hbs
+++ b/app/templates/eredienst-mandatenbeheer/mandatarissen.hbs
@@ -62,18 +62,18 @@
       <c.header>
         <th class="au-u-visible-small-up">Orgaan</th>
         <AuDataTableThSortable
-          @field="isBestuurlijkeAliasVan.gebruikteVoornaam"
+          @field=":no-case:isBestuurlijkeAliasVan.gebruikteVoornaam"
           @currentSorting={{this.sort}}
           @label="Naam"
           class="au-u-visible-small-up"
         />
         <AuDataTableThSortable
-          @field="isBestuurlijkeAliasVan.achternaam"
+          @field=":no-case:isBestuurlijkeAliasVan.achternaam"
           @currentSorting={{this.sort}}
           @label="Familienaam"
         />
         <AuDataTableThSortable
-          @field="bekleedt.bestuursfunctie.label"
+          @field=":no-case:bekleedt.bestuursfunctie.label"
           @currentSorting={{this.sort}}
           @label="Mandaat"
         />

--- a/app/templates/supervision/submissions/index.hbs
+++ b/app/templates/supervision/submissions/index.hbs
@@ -25,7 +25,7 @@
     <c.header>
       <AuDataTableThSortable @field=":no-case:formData.passedBy.isTijdsspecialisatieVan.naam" @currentSorting={{this.sort}}
                              @label="Orgaan"/>
-      <AuDataTableThSortable @field="formData.decisionType.label" @currentSorting={{this.sort}} @label="Type dossier"/>
+      <AuDataTableThSortable @field=":no-case:formData.types.label" @currentSorting={{this.sort}} @label="Type dossier"/>
       <AuDataTableThSortable @class="au-u-visible-small-up" @field="formData.sessionStartedAtTime"
                              @currentSorting={{this.sort}} @label="Datum zitting/besluit"/>
       <AuDataTableThSortable @class="au-u-visible-large-up" @field="sentDate" @currentSorting={{this.sort}}

--- a/app/templates/supervision/submissions/index.hbs
+++ b/app/templates/supervision/submissions/index.hbs
@@ -23,7 +23,7 @@
   as |t|>
   <t.content as |c|>
     <c.header>
-      <AuDataTableThSortable @field="formData.passedBy.isTijdsspecialisatieVan.naam" @currentSorting={{this.sort}}
+      <AuDataTableThSortable @field=":no-case:formData.passedBy.isTijdsspecialisatieVan.naam" @currentSorting={{this.sort}}
                              @label="Orgaan"/>
       <AuDataTableThSortable @field="formData.decisionType.label" @currentSorting={{this.sort}} @label="Type dossier"/>
       <AuDataTableThSortable @class="au-u-visible-small-up" @field="formData.sessionStartedAtTime"
@@ -32,7 +32,7 @@
                              @label="Datum verstuurd"/>
       <th class="au-u-visible-medium-up">Aangemaakt door</th>
       <th class="au-u-visible-small-up">Laatst gewijzigd door</th>
-      <AuDataTableThSortable @field="status.label" @currentSorting={{this.sort}} @label="Status"/>
+      <AuDataTableThSortable @field=":no-case:status.label" @currentSorting={{this.sort}} @label="Status"/>
       <th>Acties</th>
     </c.header>
     <c.body as |row|>

--- a/app/templates/worship-ministers-management/index.hbs
+++ b/app/templates/worship-ministers-management/index.hbs
@@ -27,17 +27,17 @@
   <t.content as |c|>
     <c.header>
       <AuDataTableThSortable
-        @field="ministerPosition.function.label"
+        @field=":no-case:ministerPosition.function.label"
         @currentSorting={{this.sort}}
         @label="Functienaam"
       />
       <AuDataTableThSortable
-        @field="person.gebruikteVoornaam"
+        @field=":no-case:person.gebruikteVoornaam"
         @currentSorting={{this.sort}}
         @label="Voornaam"
       />
       <AuDataTableThSortable
-        @field="person.achternaam"
+        @field=":no-case:person.achternaam"
         @currentSorting={{this.sort}}
         @label="Achternaam"
       />


### PR DESCRIPTION
**[DL-4540]** and **[DL-4069]**

The tables in the "Mandatenbeheer", "Bedienarenbeheer", "Toezicht" and "Berichtencentrum" modules all showed similar problems while sorting (alphabetically). The sorting would look good at first glance, but sometimes a single entry would be in the wrong place. Sometimes the sorting would look completely random.  
The root cause of this issue is a bug in Virtuoso, but can be solved by sorting on lowercase conversions of the fields.

**Note:** some edge case observed while testing that is not fixed: in the "Berichtencentrum" module, the "Betreft" column might still look improperly sorted. This could be caused by whitespaces at the beginning of the field that are not shown in the table because HTML collapses/trims spaces automatically. These spaces are in the database where the sorting happens, putting them at the top of the alphabetical list.

This PR also fixes another issue: sorting on "Type Dossier" of Submission in the module "Toezicht" caused an error. The sorting property did not exist in mu-cl-resources, because it is computed in the component code from a has-many relation. This has been changed to the correct model property, which seems to output useful results from mu-cl-resources. It is not clear whether this is a sound solution, because the property points to a has-many-relation.