### PR TITLE
feat: update mandatenbeheer tegels

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The [ember-proxy-service](https://github.com/mu-semtech/ember-proxy-service#conf
 | `EMBER_VERENIGINGEN_URL`                   | Link to the verenigingen app                                                                          |
 | `EMBER_CONTACT_URL`                        | Link to the contact app                                                                               |
 | `EMBER_SUBSIDIES_URL`                      | Link to the subsidiepunt app                                                                          |
+| `EMBER_MANDATENBEHEER_EXTERNAL_URL`        | Link to the mandatenbeheer app                                                                        |
+| `EMBER_MANDATENBEHEER`                     | Toggle access to the internal mandatenbeheer app                                                                |
 | `EMBER_OPEN_PROCES_HUIS_URL`               | Link to the open proces huis app                                                                      |
 | `EMBER_OPEN_PROCES_HUIS_ROLE`              | ACM/IDM user role that is used to display the app link. defaults to `LoketLB-OpenProcesHuisGebruiker` |
 | `EMBER_GLOBAL_SYSTEM_NOTIFICATION`         | This can be used to display a message at the top of the application. HTML is supported.               |

--- a/app/helpers/mandatenbeheer-url.js
+++ b/app/helpers/mandatenbeheer-url.js
@@ -1,0 +1,5 @@
+import config from 'frontend-loket/config/environment';
+
+export default function mandatenbeheerUrl() {
+  return config.mandatenbeheerExternalUrl;
+}

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -134,7 +134,11 @@ export default class CurrentSessionService extends Service {
   }
 
   get canAccessMandaat() {
-    return this.canAccess(MODULE_ROLE.MANDATENBEHEER);
+    return this.canAccess(MODULE_ROLE.MANDATENBEHEER) && config.mandatenbeheer;
+  }
+
+  get canAccessMandaatExternal() {
+    return !config.mandatenbeheerExternalUrl.startsWith('{{');
   }
 
   get canAccessBerichten() {

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -134,7 +134,10 @@ export default class CurrentSessionService extends Service {
   }
 
   get canAccessMandaat() {
-    return this.canAccess(MODULE_ROLE.MANDATENBEHEER) && config.mandatenbeheer === 'true';
+    return (
+      this.canAccess(MODULE_ROLE.MANDATENBEHEER) &&
+      config.mandatenbeheer === 'true'
+    );
   }
 
   get canAccessMandaatExternal() {

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -134,7 +134,7 @@ export default class CurrentSessionService extends Service {
   }
 
   get canAccessMandaat() {
-    return this.canAccess(MODULE_ROLE.MANDATENBEHEER) && config.mandatenbeheer;
+    return this.canAccess(MODULE_ROLE.MANDATENBEHEER) && config.mandatenbeheer === 'true';
   }
 
   get canAccessMandaatExternal() {

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -89,6 +89,24 @@
             </LoketModuleCard>
           </li>
         {{/if}}
+        {{#if this.currentSession.canAccessMandaatExternal}}
+          <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
+            <LoketModuleCard
+              @icon="user-fill"
+              @extraInformationLink="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/mandatenbeheer-lokale-besturen"
+              @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-lokaal-mandatenbeheer"
+            >
+              <:title>Mandatenbeheer</:title>
+              <:description>Hou de mandaten binnen de gemeenten, OCMW's,
+                districten en provincies bij.</:description>
+              <:link>
+                <AuLinkExternal @skin="button" href={{(mandatenbeheer-url)}}>
+                  Ga naar mandatenbeheer (externe link)
+                </AuLinkExternal>
+              </:link>
+            </LoketModuleCard>
+          </li>
+        {{/if}}
         {{#if this.currentSession.canAccessWorshipMinisterManagement}}
           <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
             <LoketModuleCard

--- a/config/environment.js
+++ b/config/environment.js
@@ -38,6 +38,8 @@ module.exports = function (environment) {
     subsidiesUrl: '{{SUBSIDIES_URL}}',
     worshipDecisionsDatabaseUrl: '{{WORSHIP_DECISIONS_DATABASE_URL}}',
     worshipOrganisationsDatabaseUrl: '{{WORSHIP_ORGANISATIONS_DATABASE_URL}}',
+    mandatenbeheer: '{{MANDATENBEHEER}}',
+    mandatenbeheerExternalUrl: '{{MANDATENBEHEER_EXTERNAL_URL}}',
     verenigingenUrl: '{{VERENIGINGEN_URL}}',
     contactUrl: '{{CONTACT_URL}}',
     openProcesHuisUrl: '{{OPEN_PROCES_HUIS_URL}}',


### PR DESCRIPTION
## ID
DL-6046

## Description

Adds a feature flag to toggle the existing mandatenbeheer tile, as well as adding a new mandatenbeheer tile for the external mandatenbeheer application.

docker-compose.override.yml for PROD:
```
EMBER_MANDATENBEHEER_EXTERNAL_URL: "mandatenbeheer.lokaalbestuur.vlaanderen.be
```

docker-compose.override.yml for QA:
```
EMBER_MANDATENBEHEER_EXTERNAL_URL: "https://mandatenbeheer.lblod.info/"
```

docker-compose.override.yml for DEV:
```
EMBER_MANDATENBEHEER_EXTERNAL_URL: "https://dev.mandatenbeheer.lblod.info/"
```

---

Make sure to add the following environment variable for the existing mandatenbeheer tile:
```
EMBER_MANDATENBEHEER: "true"
```
To disable the tile, simply change the value to false.

Note: no redirect logic was implemented since the new mandatenbeheer application is too different, so wasn't worth the effort.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


