### PR TITLE
[DGS-383] fix subsidies card not showing

### DIFF
--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -195,12 +195,6 @@ export default class CurrentSessionService extends Service {
     );
   }
 
-  get canAccessModules() {
-    return Object.values(MODULE_ROLE).some((module) => {
-      return this.canAccess(module);
-    });
-  }
-
   get isAdmin() {
     let roles = this._roles;
     if (this.impersonation.isImpersonating) {

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -52,9 +52,7 @@
         <main.sidebar>
           <div class="au-c-sidebar">
             <div class="au-c-sidebar__content">
-              {{#if this.currentSession.canAccessModules}}
                 <Shared::MainMenu />
-              {{/if}}
             </div>
             <div class="au-c-sidebar__footer">
               <AuLinkExternal
@@ -74,7 +72,6 @@
             <AuToolbar @size="medium" @skin="tint" @border="bottom" as |Group|>
               <Group>
                 <ul class="au-c-list-horizontal au-c-list-horizontal--small">
-                  {{#if this.currentSession.canAccessModules}}
                     <li class="au-c-list-horizontal__item">
                       <AuLink @icon="arrow-left" @route="index">
                         Overzicht modules
@@ -83,7 +80,6 @@
                     <li class="au-c-list-horizontal__item">
                       <Shared::CompactMenu />
                     </li>
-                  {{/if}}
                   <Shared::BreadCrumb />
                 </ul>
               </Group>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -16,7 +16,6 @@
         </AuContent>
       </div>
     </div>
-    {{#if this.currentSession.canAccessModules}}
       <AuHeading @level="2" @skin="3" class="au-u-margin-bottom">
         Beschikbare modules
       </AuHeading>
@@ -308,6 +307,5 @@
           </li>
         {{/if}}
       </ul>
-    {{/if}}
   </div>
 </div>


### PR DESCRIPTION
## ID
DGS-383

## Description

When a user doesn't have any of the context-rights to the following modules https://github.com/lblod/frontend-loket/blob/8d38e68caaaf618a43da14ff66e9027d825c606c/app/services/current-session.js#L8-L25
The user won't be able to see any of the modules, even the ones that should always be visible (like subsidies).

So I removed the `canAccessModules` check, because there will always be some modules visible. And the other modules will also appear if the user has the right context rights.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


## How to test

Kinda hard to test without acm/idm. But you can try to remove all MODULE_ROLE's from https://github.com/lblod/frontend-loket/blob/8d38e68caaaf618a43da14ff66e9027d825c606c/app/services/current-session.js#L8-L25 to verify that all the modules will disappear, also the ones that are always visible.

After the changes, the always visible module cards will stay, (if you have a valid environment variable for them filled in, see https://github.com/lblod/frontend-loket/blob/8d38e68caaaf618a43da14ff66e9027d825c606c/app/services/current-session.js#L160)

