### PR TITLE
[DL-6228] Add a check to the external mandatenbeheer card

### DIFF
--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -141,7 +141,10 @@ export default class CurrentSessionService extends Service {
   }
 
   get canAccessMandaatExternal() {
-    return !config.mandatenbeheerExternalUrl.startsWith('{{');
+    return (
+      this.canAccess(MODULE_ROLE.MANDATENBEHEER) &&
+      !config.mandatenbeheerExternalUrl.startsWith('{{')
+    );
   }
 
   get canAccessBerichten() {


### PR DESCRIPTION
It seems not all users should be able to see this, similar to the internal card. We now also check the user's role before displaying the card.