### PR TITLE
[DL-6338] Disable the prototype extensions

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -17,14 +17,6 @@ export default class App extends Application {
   Resolver = Resolver;
 }
 
-// By default `Array.prototype._super` is enumerable which causes conflicts with rdflib.
-// We can force it to be non-enumerable so everything works as expected.
-// This code can be removed once the bug is fixed and released, or if we disable the prototype extensions in the app.
-// More information: https://github.com/emberjs/ember.js/issues/19289
-Object.defineProperty(Array.prototype, '_super', {
-  enumerable: false,
-});
-
 browserUpdate({
   vs: { i: 11, f: -3, o: -3, s: -3, c: -3 },
   style: 'corner',

--- a/app/components/adressenregister-selector.js
+++ b/app/components/adressenregister-selector.js
@@ -33,7 +33,7 @@ export default class AdressenregisterSelectorComponent extends Component {
         const selectedAddress = addresses.find(
           (a) => a.busnumber == address.busnummer,
         );
-        this.addressesWithBusnumbers = addresses.sortBy('busnumber');
+        this.addressesWithBusnumbers = sortByBusnumber(addresses);
         this.addressWithBusnumber = selectedAddress;
       } else {
         this.addressesWithBusnumbers = null;
@@ -54,7 +54,7 @@ export default class AdressenregisterSelectorComponent extends Component {
         this.args.onChange(addresses[0].adresProperties);
       } else {
         // selection of busnumber required
-        const sortedBusNumbers = addresses.sortBy('busnumber');
+        const sortedBusNumbers = sortByBusnumber(addresses);
         this.addressesWithBusnumbers = sortedBusNumbers;
         this.addressWithBusnumber = sortedBusNumbers[0];
         this.args.onChange(this.addressWithBusnumber.adresProperties);
@@ -76,4 +76,18 @@ export default class AdressenregisterSelectorComponent extends Component {
     this.addressWithBusnumber = address;
     this.args.onChange(address.adresProperties);
   }
+}
+
+/**
+ * @param {{busnumber: string | null}[]} arrayToSort
+ * @returns {{busnumber: string | null}[]}
+ */
+function sortByBusnumber(arrayToSort) {
+  return arrayToSort.slice().sort((a, b) => {
+    if (!a.busnumber) {
+      return -1;
+    }
+
+    return a.busnumber.localeCompare(b.busnumber);
+  });
 }

--- a/app/components/eredienst-mandatenbeheer/bestuursperioden-selector.js
+++ b/app/components/eredienst-mandatenbeheer/bestuursperioden-selector.js
@@ -1,13 +1,16 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { sortByStartDate } from 'frontend-loket/utils/eredienst-mandatenbeheer';
 
 export default class MandatenbeheerBestuursperiodenSelectorComponent extends Component {
   @tracked _options;
 
   constructor() {
     super(...arguments);
-    this._options = this.args.options?.sortBy('startDate') || [];
+    this._options = Array.isArray(this.args.options)
+      ? sortByStartDate(this.args.options)
+      : [];
   }
 
   @action

--- a/app/routes/eredienst-mandatenbeheer.js
+++ b/app/routes/eredienst-mandatenbeheer.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
 import moment from 'moment';
+import { sortByStartDate } from 'frontend-loket/utils/eredienst-mandatenbeheer';
 
 export default class EredienstMandatenbeheerRoute extends Route {
   @service currentSession;
@@ -73,7 +74,8 @@ export default class EredienstMandatenbeheerRoute extends Route {
     // - start < end
     //So, basically it assumes e.g.
     //  - [2001-2003][2003-2023] and possibly [2024-2025|null]
-    const sortedPeriods = periods.sortBy('startDate');
+    const sortedPeriods = sortByStartDate(periods);
+
     if (!(startDate || endDate)) {
       const today = moment(new Date()).format('YYYY-MM-DD');
 

--- a/app/utils/eredienst-mandatenbeheer.js
+++ b/app/utils/eredienst-mandatenbeheer.js
@@ -165,3 +165,15 @@ export async function warnOnMandateExceededTimePeriode(
 
   return warningMessages;
 }
+
+/**
+ * Sorts objects by their .startDate property which is expected to be an ISO date string
+ * @param {{ startDate: string }[]} arrayToSort
+ * @returns {{ startDate: string }[]}
+ */
+
+export function sortByStartDate(arrayToSort) {
+  return arrayToSort.slice().sort((a, b) => {
+    return a.startDate.localeCompare(b.startDate);
+  });
+}

--- a/config/environment.js
+++ b/config/environment.js
@@ -7,7 +7,7 @@ module.exports = function (environment) {
     rootURL: '/',
     locationType: 'history',
     EmberENV: {
-      // EXTEND_PROTOTYPES: false, // TODO: disable the prototypes and fix all the cases where we depended on this
+      EXTEND_PROTOTYPES: false,
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. EMBER_NATIVE_DECORATOR_SUPPORT: true


### PR DESCRIPTION
Not disabling the prototype extensions is deprecated and will error in Ember v6. This unblocks the update.

More info: https://deprecations.emberjs.com/id/deprecate-array-prototype-extensions