### PR TITLE
[DL-6340] Enable route bundle splitting

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -1,7 +1,7 @@
-import EmberRouter from '@ember/routing/router';
+import EmbroiderRouter from '@embroider/router';
 import config from 'frontend-loket/config/environment';
 
-export default class Router extends EmberRouter {
+export default class Router extends EmbroiderRouter {
   location = config.locationType;
   rootURL = config.rootURL;
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -29,6 +29,20 @@ module.exports = function (defaults) {
     staticModifiers: true,
     staticComponents: true,
     staticEmberSource: true,
+    splitAtRoutes: [
+      'mock-login',
+      'impersonate',
+      'contact',
+      'legaal',
+      'bbcdr',
+      'supervision',
+      'toezicht',
+      'berichtencentrum',
+      'leidinggevendenbeheer',
+      'personeelsbeheer',
+      'eredienst-mandatenbeheer',
+      'worship-ministers-management',
+    ],
     skipBabel: [
       {
         package: 'qunit',

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@embroider/compat": "^3.7.0",
         "@embroider/core": "^3.4.19",
         "@embroider/macros": "^1.16.9",
+        "@embroider/router": "^2.1.8",
         "@embroider/webpack": "^4.0.8",
         "@eslint/js": "^9.12.0",
         "@glimmer/component": "^1.1.2",
@@ -5901,6 +5902,75 @@
         "@babel/core": "^7.3.4",
         "object-assign": "4.1.1",
         "rsvp": "^4.8.4"
+      }
+    },
+    "node_modules/@embroider/router": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@embroider/router/-/router-2.1.8.tgz",
+      "integrity": "sha512-Dvp8YdqAWT6T0yzBZfUe6SyaVNH7xoXBlrxF1LbqoF/Q2buNzDy9oAQ5tTnbX1x+5KOrM0ryOjfeF0GoqkfobA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ember/test-waiters": "^3.0.2",
+        "@embroider/addon-shim": "^1.8.9"
+      },
+      "peerDependencies": {
+        "@embroider/core": "^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@embroider/core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@embroider/router/node_modules/@embroider/addon-shim": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.9.0.tgz",
+      "integrity": "sha512-fMzayl/licUL8VRAy4qXROKcYvHwUbV8aTh4m97L5/MRuVpxbcAy92DGGTqx5OBKCSQN3gMg+sUKeE6AviefpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@embroider/shared-internals": "^2.8.1",
+        "broccoli-funnel": "^3.0.8",
+        "common-ancestor-path": "^1.0.1",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/@embroider/router/node_modules/@embroider/shared-internals": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.8.1.tgz",
+      "integrity": "sha512-zi0CENFD1e0DH7c9M/rNKJnFnt2c3+736J3lguBddZdmaIV6Cb8l3HQSkskSW5O4ady+SavemLKO3hCjQQJBIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-import-util": "^2.0.0",
+        "debug": "^4.3.2",
+        "ember-rfc176-data": "^0.3.17",
+        "fs-extra": "^9.1.0",
+        "is-subdir": "^1.2.0",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.21",
+        "minimatch": "^3.0.4",
+        "pkg-entry-points": "^1.1.0",
+        "resolve-package-path": "^4.0.1",
+        "semver": "^7.3.5",
+        "typescript-memoize": "^1.0.1"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/@embroider/router/node_modules/babel-import-util": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.1.1.tgz",
+      "integrity": "sha512-3qBQWRjzP9NreSH/YrOEU1Lj5F60+pWSLP0kIdCWxjFHH7pX2YPHIxQ67el4gnMNfYoDxSDGcT0zpVlZ+gVtQA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.*"
       }
     },
     "node_modules/@embroider/shared-internals": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@embroider/compat": "^3.7.0",
     "@embroider/core": "^3.4.19",
     "@embroider/macros": "^1.16.9",
+    "@embroider/router": "^2.1.8",
     "@embroider/webpack": "^4.0.8",
     "@eslint/js": "^9.12.0",
     "@glimmer/component": "^1.1.2",


### PR DESCRIPTION
We configure Embroider to split the js bundles for each of the major routes. Embroider will then bundle the shared code in the initial bundle and load the other bundles lazily, when the routes are first accessed. This speeds up the initial load of the app and users won't download code of modules they don't have access to (or simply don't access).