### PR TITLE
[DL-6195] Add data monitoring tool card

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The [ember-proxy-service](https://github.com/mu-semtech/ember-proxy-service#conf
 | `EMBER_VERENIGINGEN_URL`                   | Link to the verenigingen app                                                                          |
 | `EMBER_CONTACT_URL`                        | Link to the contact app                                                                               |
 | `EMBER_SUBSIDIES_URL`                      | Link to the subsidiepunt app                                                                          |
+| `EMBER_DATA_MONITORING_TOOL_URL`           | Link to the data monitoring tool app                                                                  |
 | `EMBER_MANDATENBEHEER_EXTERNAL_URL`        | Link to the mandatenbeheer app                                                                        |
 | `EMBER_OPEN_PROCES_HUIS_URL`               | Link to the open proces huis app                                                                      |
 | `EMBER_OPEN_PROCES_HUIS_ROLE`              | ACM/IDM user role that is used to display the app link. defaults to `LoketLB-OpenProcesHuisGebruiker` |

--- a/app/components/shared/compact-menu.hbs
+++ b/app/components/shared/compact-menu.hbs
@@ -55,6 +55,16 @@
       SubsidiePunt
     </AuLinkExternal>
   {{/if}}
+  {{#if this.currentSession.canAccessDataMonitoringTool}}
+    <AuLinkExternal
+      @icon="link-external"
+      @iconAlignment="left"
+      href={{(data-monitoring-tool-url)}}
+      role="menuitem"
+    >
+      Data Monitoring Tool
+    </AuLinkExternal>
+  {{/if}}
   {{#if this.currentSession.canAccessEredienstMandatenbeheer}}
     <AuLink @route="eredienst-mandatenbeheer.mandatarissen" @icon="users-four-of-four" role="menuitem">
       Mandatenbeheer

--- a/app/components/shared/main-menu.hbs
+++ b/app/components/shared/main-menu.hbs
@@ -75,6 +75,16 @@
         </AuLinkExternal>
       </li>
     {{/if}}
+    {{#if this.currentSession.canAccessDataMonitoringTool}}
+      <AuLinkExternal
+        @icon="link-external"
+        @iconAlignment="left"
+        class="au-c-list-navigation__link"
+        href={{(data-monitoring-tool-url)}}
+      >
+        Data Monitoring Tool
+      </AuLinkExternal>
+    {{/if}}
     {{#if this.currentSession.canAccessEredienstMandatenbeheer}}
       <AuNavigationLink @route="eredienst-mandatenbeheer.mandatarissen">
         <AuIcon @icon="users-four-of-four" @alignment="left" />

--- a/app/helpers/data-monitoring-tool-url.js
+++ b/app/helpers/data-monitoring-tool-url.js
@@ -1,0 +1,5 @@
+import config from 'frontend-loket/config/environment';
+
+export default function dataMonitoringToolUrl() {
+  return config.dataMonitoringToolUrl;
+}

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -156,6 +156,10 @@ export default class CurrentSessionService extends Service {
     return !config.subsidiesUrl.startsWith('{{');
   }
 
+  get canAccessDataMonitoringTool() {
+    return !config.dataMonitoringToolUrl.startsWith('{{');
+  }
+
   get canAccessWorshipMinisterManagement() {
     return this.canAccess(MODULE_ROLE.WORSHIP_MINISTER_MANAGEMENT);
   }

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -177,6 +177,23 @@
             </LoketModuleCard>
           </li>
         {{/if}}
+        {{#if this.currentSession.canAccessDataMonitoringTool}}
+          <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
+            <LoketModuleCard
+              @icon="external-link"
+            >
+              <:title>
+                Data Monitoring Tool
+              </:title>
+              <:description>Krijg inzicht in de kwaliteit van uw data, laatste zittingen, de meest recente harvests, aantal beslissingen en agendapunten.</:description>
+              <:link>
+                <AuLinkExternal @skin="button" href={{(data-monitoring-tool-url)}}>
+                  Ga naar Data Monitoring Tool (externe link)
+                </AuLinkExternal>
+              </:link>
+            </LoketModuleCard>
+          </li>
+        {{/if}}
         {{#if this.currentSession.canAccessPublicServices}}
           <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
             <LoketModuleCard

--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -334,6 +334,19 @@
 
             <div class="au-o-grid__item au-u-1-2@small au-u-1-3@medium">
               <AuCard @textCenter="true" as |c|>
+                <c.header @badgeSkin="brand" @badgeIcon="external-link">
+                  <AuHeading @level="3" @skin="4">
+                    Data Monitoring Tool
+                  </AuHeading>
+                </c.header>
+                <c.content>
+                  <p class="au-u-margin-top-tiny">Krijg inzicht in de kwaliteit van uw data, laatste zittingen, de meest recente harvests, aantal beslissingen en agendapunten.</p>
+                </c.content>
+              </AuCard>
+            </div>
+
+            <div class="au-o-grid__item au-u-1-2@small au-u-1-3@medium">
+              <AuCard @textCenter="true" as |c|>
                 <c.header @badgeSkin="brand" @badgeIcon="unordered-list">
                   <AuHeading @level="3" @skin="4">
                     Producten- en dienstencatalogus

--- a/config/environment.js
+++ b/config/environment.js
@@ -36,6 +36,7 @@ module.exports = function (environment) {
     },
     lpdcUrl: '{{LPDC_URL}}',
     subsidiesUrl: '{{SUBSIDIES_URL}}',
+    dataMonitoringToolUrl: '{{EMBER_DATA_MONITORING_TOOL_URL}}',
     worshipDecisionsDatabaseUrl: '{{WORSHIP_DECISIONS_DATABASE_URL}}',
     worshipOrganisationsDatabaseUrl: '{{WORSHIP_ORGANISATIONS_DATABASE_URL}}',
     mandatenbeheerExternalUrl: '{{MANDATENBEHEER_EXTERNAL_URL}}',


### PR DESCRIPTION
## ID

DL-6195

## Description

Add the data monitoring tool card

Deploys will need the following env variables in docker-compose.override.yml:

**Production:**
`EMBER_DATA_MONITORING_TOOL_URL: "https://datamonitoringtool.lokaalbestuur.vlaanderen.be/"`

**QA:**
`EMBER_DATA_MONITORING_TOOL_URL: "https://datamonitoringtool.lblod.info/"`

**DEV: links to QA since data monitoring tool doesn't have a dev env**
`EMBER_DATA_MONITORING_TOOL_URL: "https://datamonitoringtool.lblod.info/"`