### PR TITLE
Bump ember-submission-form-fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@glimmer/tracking": "^1.1.2",
         "@lblod/ember-acmidm-login": "2.1.0",
         "@lblod/ember-mock-login": "^0.10.0",
-        "@lblod/ember-submission-form-fields": "^2.22.2",
+        "@lblod/ember-submission-form-fields": "^2.24.0",
         "@lblod/submission-form-helpers": "^2.10.0",
         "@sentry/ember": "^7.54.0",
         "broccoli-asset-rev": "^3.0.0",
@@ -8160,14 +8160,14 @@
       }
     },
     "node_modules/@lblod/ember-submission-form-fields": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.22.2.tgz",
-      "integrity": "sha512-sXMw1cVfZZRUqqaAxJEFXAm2snoE4k6VWPJGBtjip6N0ALCwgpkqz4UpYRdt1ik8Eb7w8erHTJdwttO1y3TPMQ==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.24.0.tgz",
+      "integrity": "sha512-T1EVjmWEyYdfitaf7++NAApmqLmoS+NWxDox9YMqzcGTC6+VlvBonttsg/FVAEMmOWlkyNfZEJdRz9XVmcHHLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@embroider/macros": "^1.13.5",
-        "@lblod/submission-form-helpers": "^2.9.0",
+        "@lblod/submission-form-helpers": "^2.10.2",
         "client-zip": "^2.4.4",
         "clipboardy": "^3.0.0",
         "ember-auto-import": "^2.7.2",
@@ -8692,10 +8692,11 @@
       }
     },
     "node_modules/@lblod/submission-form-helpers": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@lblod/submission-form-helpers/-/submission-form-helpers-2.10.0.tgz",
-      "integrity": "sha512-+gyWbP+JLCIVNKTmAPD/EyrxgKNkdhLVYVO2IKbWId8zBonauO7uhSHdkHhQNPeovUzi4ggTuAg5+ZXhhbLZZg==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@lblod/submission-form-helpers/-/submission-form-helpers-2.10.2.tgz",
+      "integrity": "sha512-ftc5T/sLpXFvRIdPR0QlZybQJJAoTleo1l6lEZ35ezuXG3h915G+WeCuq+PZMyPGo9d3deGE4pDA5H0D4q8qVQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "iban": "0.0.14",
         "libphonenumber-js": "^1.9.6",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@glimmer/tracking": "^1.1.2",
     "@lblod/ember-acmidm-login": "2.1.0",
     "@lblod/ember-mock-login": "^0.10.0",
-    "@lblod/ember-submission-form-fields": "^2.22.2",
+    "@lblod/ember-submission-form-fields": "^2.24.0",
     "@lblod/submission-form-helpers": "^2.10.0",
     "@sentry/ember": "^7.54.0",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
**[DL-6276]**

Use newer version of the `ember-submission-form-fields` to allow for HTML content to be rendered in alerts of semantic forms.

**Related PR's:**

* https://github.com/lblod/ember-submission-form-fields/pull/196
* https://github.com/lblod/manage-submission-form-tooling/pull/59