### PR TITLE
[DL-6629] Use the `semtech/static-file-service` as the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,8 @@ RUN npm ci
 COPY . .
 RUN npm run build
 
-FROM semtech/ember-proxy-service:1.5.1
-
-ENV STATIC_FOLDERS_REGEX "^/(assets|font|files|toezicht/bestanden|@appuniversum)/"
+FROM semtech/static-file-service:0.2.0
 
 COPY ./proxy/file-upload.conf /config/file-upload.conf
 
-COPY --from=builder /app/dist /app
+COPY --from=builder /app/dist /data

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Frontend of the loket application
 
 ## Environment variables
 
-The [ember-proxy-service](https://github.com/mu-semtech/ember-proxy-service#configure-environment-variables-in-the-frontends-container) docker image (which we use to host the frontend) supports configuring environment variables. The following options are available for the loket image.
+The [mu-semtech/static-file-service](https://github.com/mu-semtech/static-file-service?tab=readme-ov-file#set-environment-variables-on-the-static-file-service) docker image (which we use to host the frontend) supports configuring environment variables. The following options are available for the loket image.
 
 ### General
 


### PR DESCRIPTION
The `semtech/ember-proxy-service` image is deprecated.

Breaking since it requires changes in the way it is deployed (but that is largely covered by https://github.com/lblod/app-digitaal-loket/pull/662).

More information: https://github.com/mu-semtech/static-file-service