### PR TITLE
[DL-7261] Update user manual links

### DIFF
--- a/app/components/header-help.hbs
+++ b/app/components/header-help.hbs
@@ -42,7 +42,7 @@
               <AuLinkExternal
                 @skin="naked"
                 @icon="manual"
-                href="https://abb-vlaanderen.gitbook.io/handleiding-loket"
+                href={{(relevant-user-manual-link)}}
               >
                 Handleiding
               </AuLinkExternal>

--- a/app/components/header-help.hbs
+++ b/app/components/header-help.hbs
@@ -40,7 +40,6 @@
           <AuList @divider={{true}} as |ListItem|>
             <ListItem>
               <AuLinkExternal
-                @skin="naked"
                 @icon="manual"
                 href={{(relevant-user-manual-link)}}
               >
@@ -56,7 +55,6 @@
           <AuList @divider={{true}} as |ListItem|>
             <ListItem>
               <AuLinkExternal
-                @skin="naked"
                 @icon="mail"
                 href="mailto:LoketLokaalBestuur@vlaanderen.be"
               >

--- a/app/helpers/relevant-user-manual-link.js
+++ b/app/helpers/relevant-user-manual-link.js
@@ -1,0 +1,33 @@
+import Helper from '@ember/component/helper';
+import { service } from '@ember/service';
+
+const defaultManualLink =
+  'https://abb-vlaanderen.gitbook.io/hoofdloket-handleiding-loket-lokale-besturen';
+
+/**
+ * A helper that looks the meta data of all active routes and retrieves the userManualLink value and falls back to the generic loket manual if none is found.
+ */
+export default class RelevantUserManualLink extends Helper {
+  @service router;
+
+  compute() {
+    let manualLink = defaultManualLink;
+    let route = this.router.currentRoute;
+
+    do {
+      if (route.metadata?.userManualLink) {
+        manualLink = route.metadata.userManualLink;
+        break;
+      } else {
+        route = route.parent;
+      }
+    } while (route);
+
+    return manualLink;
+  }
+}
+
+// Simple util that sets up the route meta object as expected.
+export function buildLinkMetaObject(userManualLink) {
+  return { userManualLink };
+}

--- a/app/routes/bbcdr.js
+++ b/app/routes/bbcdr.js
@@ -1,10 +1,17 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { buildLinkMetaObject } from 'frontend-loket/helpers/relevant-user-manual-link';
 
 export default class BbcdrRoute extends Route {
   @service session;
   @service currentSession;
   @service router;
+
+  buildRouteInfoMetadata() {
+    return buildLinkMetaObject(
+      'https://abb-vlaanderen.gitbook.io/handleiding-bbc-dr',
+    );
+  }
 
   beforeModel(transition) {
     if (this.session.requireAuthentication(transition, 'login')) {

--- a/app/routes/berichtencentrum.js
+++ b/app/routes/berichtencentrum.js
@@ -1,10 +1,17 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { buildLinkMetaObject } from 'frontend-loket/helpers/relevant-user-manual-link';
 
 export default class BerichtencentrumRoute extends Route {
   @service session;
   @service currentSession;
   @service router;
+
+  buildRouteInfoMetadata() {
+    return buildLinkMetaObject(
+      'https://abb-vlaanderen.gitbook.io/hoofdloket-handleiding-loket-lokale-besturen/berichtencentrum',
+    );
+  }
 
   beforeModel(transition) {
     if (this.session.requireAuthentication(transition, 'login')) {

--- a/app/routes/eredienst-mandatenbeheer.js
+++ b/app/routes/eredienst-mandatenbeheer.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
 import moment from 'moment';
 import { sortByStartDate } from 'frontend-loket/utils/eredienst-mandatenbeheer';
+import { buildLinkMetaObject } from 'frontend-loket/helpers/relevant-user-manual-link';
 
 export default class EredienstMandatenbeheerRoute extends Route {
   @service currentSession;
@@ -14,6 +15,12 @@ export default class EredienstMandatenbeheerRoute extends Route {
     startDate: { refreshModel: true },
     endDate: { refreshModel: true },
   };
+
+  buildRouteInfoMetadata() {
+    return buildLinkMetaObject(
+      'https://abb-vlaanderen.gitbook.io/handleiding-mandatenbeheer-erediensten',
+    );
+  }
 
   beforeModel(transition) {
     if (this.session.requireAuthentication(transition, 'login')) {

--- a/app/routes/leidinggevendenbeheer.js
+++ b/app/routes/leidinggevendenbeheer.js
@@ -1,10 +1,17 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { buildLinkMetaObject } from 'frontend-loket/helpers/relevant-user-manual-link';
 
 export default class LeidinggevendenbeheerRoute extends Route {
   @service session;
   @service currentSession;
   @service router;
+
+  buildRouteInfoMetadata() {
+    return buildLinkMetaObject(
+      'https://abb-vlaanderen.gitbook.io/handleiding-leidinggevendenbeheer',
+    );
+  }
 
   beforeModel(transition) {
     if (this.session.requireAuthentication(transition, 'login')) {

--- a/app/routes/personeelsbeheer.js
+++ b/app/routes/personeelsbeheer.js
@@ -1,10 +1,17 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { buildLinkMetaObject } from 'frontend-loket/helpers/relevant-user-manual-link';
 
 export default class PersoneelsbeheerRoute extends Route {
   @service currentSession;
   @service session;
   @service router;
+
+  buildRouteInfoMetadata() {
+    return buildLinkMetaObject(
+      'https://abb-vlaanderen.gitbook.io/handleiding-personeelsbeheer',
+    );
+  }
 
   beforeModel(transition) {
     if (this.session.requireAuthentication(transition, 'login')) {

--- a/app/routes/supervision.js
+++ b/app/routes/supervision.js
@@ -1,10 +1,17 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { buildLinkMetaObject } from 'frontend-loket/helpers/relevant-user-manual-link';
 
 export default class SupervisionRoute extends Route {
   @service session;
   @service currentSession;
   @service router;
+
+  buildRouteInfoMetadata() {
+    return buildLinkMetaObject(
+      'https://abb-vlaanderen.gitbook.io/handleiding-toezicht',
+    );
+  }
 
   beforeModel(transition) {
     if (this.session.requireAuthentication(transition, 'login')) {

--- a/app/routes/worship-ministers-management.js
+++ b/app/routes/worship-ministers-management.js
@@ -1,11 +1,18 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { buildLinkMetaObject } from 'frontend-loket/helpers/relevant-user-manual-link';
 
 export default class WorshipMinistersManagementRoute extends Route {
   @service currentSession;
   @service session;
   @service router;
   @service store;
+
+  buildRouteInfoMetadata() {
+    return buildLinkMetaObject(
+      'https://abb-vlaanderen.gitbook.io/handleiding-bedienarenbeheer',
+    );
+  }
 
   beforeModel(transition) {
     if (this.session.requireAuthentication(transition, 'login')) {

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -33,7 +33,7 @@
         <AuLinkExternal
           @skin="secondary"
           @icon="question-circle"
-          href="https://abb-vlaanderen.gitbook.io/handleiding-loket/veelgestelde-vragen"
+          href="https://abb-vlaanderen.gitbook.io/hoofdloket-handleiding-loket-lokale-besturen"
         >
           Help
         </AuLinkExternal>
@@ -77,7 +77,7 @@
                 <AuLinkExternal
                   @skin="secondary"
                   @icon="documents"
-                  href="https://abb-vlaanderen.gitbook.io/handleiding-loket/"
+                  href="https://abb-vlaanderen.gitbook.io/hoofdloket-handleiding-loket-lokale-besturen"
                 >
                   Bekijk handleiding
                 </AuLinkExternal>

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -33,7 +33,7 @@
         <AuLinkExternal
           @skin="secondary"
           @icon="question-circle"
-          href="https://abb-vlaanderen.gitbook.io/hoofdloket-handleiding-loket-lokale-besturen"
+          href={{(relevant-user-manual-link)}}
         >
           Help
         </AuLinkExternal>

--- a/app/templates/eredienst-mandatenbeheer/mandataris/edit.hbs
+++ b/app/templates/eredienst-mandatenbeheer/mandataris/edit.hbs
@@ -96,7 +96,7 @@
               <AuLinkExternal
                 @icon="link-external"
                 @iconAlignment="right"
-                href="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/mandatenbeheer#verplichte-gegevens-1"
+                href="https://abb-vlaanderen.gitbook.io/handleiding-mandatenbeheer-erediensten/handleiding-mandatenbeheer/hoe-gebruik-ik-de-applicatie#verplichte-gegevens-1"
               >Meer info vind je hier.</AuLinkExternal>
             </AuHelpText>
           {{/if}}
@@ -138,7 +138,7 @@
                 <AuLinkExternal
                   @icon="link-external"
                   @iconAlignment="right"
-                  href="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/mandatenbeheer#verplichte-gegevens-1"
+                  href="https://abb-vlaanderen.gitbook.io/handleiding-mandatenbeheer-erediensten/handleiding-mandatenbeheer/hoe-gebruik-ik-de-applicatie#verplichte-gegevens-1"
                 >Meer info vind je hier.</AuLinkExternal>
               {{else}}
                 {{#if this.warningMessages.einde}}

--- a/app/templates/eredienst-mandatenbeheer/mandatarissen.hbs
+++ b/app/templates/eredienst-mandatenbeheer/mandatarissen.hbs
@@ -46,7 +46,7 @@
     afzonderlijk als bestuurslid toe te voegen. Meer informatie over waarom deze
     als twee aparte posities gezien worden vindt u in de
     <AuLinkExternal
-      href="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/mandatenbeheer#de-bestuursmandaten"
+      href="https://abb-vlaanderen.gitbook.io/handleiding-mandatenbeheer-erediensten/handleiding-mandatenbeheer/hoe-gebruik-ik-de-applicatie#wat-zijn-de-verschillende-bestuursmandaten"
     >handleiding</AuLinkExternal>.</AuAlert>
 
   <AuDataTable

--- a/app/templates/eredienst-mandatenbeheer/new.hbs
+++ b/app/templates/eredienst-mandatenbeheer/new.hbs
@@ -122,7 +122,7 @@
                 <AuLinkExternal
                   @icon="link-external"
                   @iconAlignment="right"
-                  href="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/mandatenbeheer#verplichte-gegevens-1"
+                  href="https://abb-vlaanderen.gitbook.io/handleiding-mandatenbeheer-erediensten/handleiding-mandatenbeheer/hoe-gebruik-ik-de-applicatie#verplichte-gegevens-1"
                 >Meer info vind je hier.</AuLinkExternal>
               </AuHelpText>
             {{/if}}
@@ -165,7 +165,7 @@
                   <AuLinkExternal
                     @icon="link-external"
                     @iconAlignment="right"
-                    href="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/mandatenbeheer#verplichte-gegevens-1"
+                    href="https://abb-vlaanderen.gitbook.io/handleiding-mandatenbeheer-erediensten/handleiding-mandatenbeheer/hoe-gebruik-ik-de-applicatie#verplichte-gegevens-1"
                   >Meer info vind je hier.</AuLinkExternal>
                 {{else}}
                   {{#if this.warningMessages.einde}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -155,7 +155,7 @@
             <LoketModuleCard
               @icon="search-folder"
               @extraInformationLink="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/toezicht"
-              @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/toezicht"
+              @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-toezicht"
             >
               <:title>Toezicht</:title>
               <:description>Bezorg besluiten en overzichtslijsten aan de
@@ -172,7 +172,7 @@
             <LoketModuleCard
               @icon="message"
               @extraInformationLink="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/berichtencentrum"
-              @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/berichtencentrum"
+              @userManualLink="https://abb-vlaanderen.gitbook.io/hoofdloket-handleiding-loket-lokale-besturen/berichtencentrum"
             >
               <:title>Berichtencentrum</:title>
               <:description>Bekijk en reageer op de berichten van de
@@ -189,7 +189,7 @@
             <LoketModuleCard
               @icon="document"
               @extraInformationLink="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/beleids-en-beheerscyclus-digitale-rapportering-bbc-dr"
-              @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/bbc-dr"
+              @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-bbc-dr"
             >
               <:title>BBC-DR</:title>
               <:description>Bezorg de digitale rapporten aan de Vlaamse Regering
@@ -223,7 +223,7 @@
             <LoketModuleCard
               @icon="user"
               @extraInformationLink="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/bedienarenbeheer"
-              @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/bedienarenbeheer"
+              @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-bedienarenbeheer"
             >
               <:title>Bedienarenbeheer</:title>
               <:description>Hou de bedienaren binnen de erediensten bij.</:description>
@@ -239,7 +239,7 @@
             <LoketModuleCard
               @icon="users-four-of-four"
               @extraInformationLink="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/mandatenbeheer-erediensten"
-              @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/mandatenbeheer"
+              @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-mandatenbeheer-erediensten"
             >
               <:title>Mandatenbeheer</:title>
               <:description>Hou de mandaten binnen de erediensten bij.</:description>
@@ -257,7 +257,7 @@
             <LoketModuleCard
               @icon="user-popup"
               @extraInformationLink="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/leidinggevendenbeheer"
-              @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/leidinggevendenbeheer"
+              @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-leidinggevendenbeheer"
             >
               <:title>Leidinggevendenbeheer</:title>
               <:description>Hou hier de leidinggevende functies voor uw bestuur
@@ -275,7 +275,7 @@
           <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
             <LoketModuleCard
               @icon="users"
-              @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/personeelsbeheer"
+              @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-personeelsbeheer"
             >
               <:title>Personeelsbeheer</:title>
               <:description>Hou hier de personeelsaantallen voor uw bestuur bij:
@@ -292,7 +292,7 @@
             <LoketModuleCard
               @icon="documents"
               @extraInformationLink="https://www.vlaanderen.be/lokaal-bestuur/loket-voor-lokale-besturen/subsidiebeheer"
-              @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/subsidiebeheer"
+              @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-subsidiepunt"
             >
               <:title>
                 SubsidiePunt
@@ -366,7 +366,7 @@
           <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
             <LoketModuleCard
               @icon="link-external"
-              @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/databank-erediensten"
+              @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-databank-erediensten"
             >
               <:title>Databank Erediensten</:title>
               <:description>Consulteer hier inzendingen van (centrale) besturen
@@ -387,7 +387,7 @@
           <li class="au-o-grid__item au-u-1-2@medium au-u-1-3@large">
             <LoketModuleCard
               @icon="link-external"
-              @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/eredienst-organisaties"
+              @userManualLink="https://abb-vlaanderen.gitbook.io/handleiding-organisaties-erediensten"
             >
               <:title>Organisaties Erediensten</:title>
               <:description>Consulteer hier de mandaten en bedienaren van de

--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -179,7 +179,7 @@
                       <AuLinkExternal
                         @skin="button-secondary"
                         @icon="manual"
-                        href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/toezicht"
+                        href="https://abb-vlaanderen.gitbook.io/handleiding-toezicht"
                       >
                         Handleiding
                       </AuLinkExternal>
@@ -210,7 +210,7 @@
                       <AuLinkExternal
                         @skin="button-secondary"
                         @icon="manual"
-                        href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/berichtencentrum"
+                        href="https://abb-vlaanderen.gitbook.io/hoofdloket-handleiding-loket-lokale-besturen/berichtencentrum"
                       >
                         Handleiding
                       </AuLinkExternal>
@@ -242,7 +242,7 @@
                       <AuLinkExternal
                         @skin="button-secondary"
                         @icon="manual"
-                        href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/bbc-dr"
+                        href="https://abb-vlaanderen.gitbook.io/handleiding-bbc-dr"
                       >
                         Handleiding
                       </AuLinkExternal>
@@ -308,7 +308,7 @@
                       <AuLinkExternal
                         @skin="button-secondary"
                         @icon="manual"
-                        href="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/bedienarenbeheer"
+                        href="https://abb-vlaanderen.gitbook.io/handleiding-bedienarenbeheer"
                       >
                         Handleiding
                       </AuLinkExternal>
@@ -340,7 +340,7 @@
                       <AuLinkExternal
                         @skin="button-secondary"
                         @icon="manual"
-                        href="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/mandatenbeheer"
+                        href="https://abb-vlaanderen.gitbook.io/handleiding-mandatenbeheer-erediensten"
                       >
                         Handleiding
                       </AuLinkExternal>
@@ -371,7 +371,7 @@
                       <AuLinkExternal
                         @skin="button-secondary"
                         @icon="manual"
-                        href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/leidinggevendenbeheer"
+                        href="https://abb-vlaanderen.gitbook.io/handleiding-leidinggevendenbeheer"
                       >
                         Handleiding
                       </AuLinkExternal>
@@ -395,7 +395,7 @@
                       <AuLinkExternal
                         @skin="button-secondary"
                         @icon="manual"
-                        href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/personeelsbeheer"
+                        href="https://abb-vlaanderen.gitbook.io/handleiding-personeelsbeheer"
                       >
                         Handleiding
                       </AuLinkExternal>
@@ -427,7 +427,7 @@
                       <AuLinkExternal
                         @skin="button-secondary"
                         @icon="manual"
-                        href="https://abb-vlaanderen.gitbook.io/handleiding-loket/modules/subsidiebeheer"
+                        href="https://abb-vlaanderen.gitbook.io/handleiding-subsidiepunt"
                       >
                         Handleiding
                       </AuLinkExternal>
@@ -542,7 +542,7 @@
                       <AuLinkExternal
                         @skin="button-secondary"
                         @icon="manual"
-                        href="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/databank-erediensten"
+                        href="https://abb-vlaanderen.gitbook.io/handleiding-databank-erediensten"
                       >
                         Handleiding
                       </AuLinkExternal>
@@ -576,7 +576,7 @@
                       <AuLinkExternal
                         @skin="button-secondary"
                         @icon="manual"
-                        href="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/eredienst-organisaties"
+                        href="https://abb-vlaanderen.gitbook.io/handleiding-organisaties-erediensten"
                       >
                         Handleiding
                       </AuLinkExternal>

--- a/app/templates/supervision/submissions/index.hbs
+++ b/app/templates/supervision/submissions/index.hbs
@@ -28,6 +28,13 @@
   />
 </div>
 
+<AuAlert @skin="info" @icon="manual" @size="small">
+  Meer informatie vindt u in de
+  <AuLinkExternal
+    href="https://abb-vlaanderen.gitbook.io/handleiding-toezicht"
+  >handleiding</AuLinkExternal>.
+</AuAlert>
+
 <AuDataTable
   @content={{this.model}}
   @isLoading={{this.isLoadingModel}}

--- a/app/templates/worship-ministers-management/index.hbs
+++ b/app/templates/worship-ministers-management/index.hbs
@@ -11,9 +11,11 @@
   {{/unless}}
 </AuToolbar>
 
-<AuAlert @skin="warning" @icon="alert-triangle" @size="small">Behoort u tot een rooms-katholiek bestuur van de eredienst? Het (aarts)bisdom zal de gegevens van de bedienaren beheren. U dient dus géén bedienaren te registreren. Meer informatie hierover vindt u in de <AuLinkExternal
-      href="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/bedienarenbeheer#registratievrijstelling-voor-rooms-katholieke-besturen-van-de-eredienst"
-    >handleiding</AuLinkExternal>.</AuAlert>
+<AuAlert @skin="info" @icon="manual" @size="small">
+  Meer informatie vindt u in de
+  <AuLinkExternal
+    href="https://abb-vlaanderen.gitbook.io/handleiding-bedienarenbeheer"
+  >handleiding</AuLinkExternal>.</AuAlert>
 
 <AuDataTable
   @content={{this.model}}


### PR DESCRIPTION
This replaces all references to the old Gitbook with the new links. 

The "help" link now also points to the most specific one, based on where the user is located in the app.