### PR TITLE
[DL-7286] Add an info banner for the new loket release

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The [mu-semtech/static-file-service](https://github.com/mu-semtech/static-file-s
 | `EMBER_OPEN_PROCES_HUIS_URL`               | Link to the open proces huis app                                                                      |
 | `EMBER_OPEN_PROCES_HUIS_ROLE`              | ACM/IDM user role that is used to display the app link. defaults to `LoketLB-OpenProcesHuisGebruiker` |
 | `EMBER_GLOBAL_SYSTEM_NOTIFICATION`         | This can be used to display a message at the top of the application. HTML is supported.               |
+| `EMBER_NEW_LOKET_ANNOUNCEMENT_TITLE`       | Adjust the title of the "new loket" announcement banner. This is optional                             |
+| `EMBER_NEW_LOKET_ANNOUNCEMENT_MESSAGE`     | Adjust the message of the "new loket" announcement banner. HTML is supported.                         |
 
 ### ACM/IDM
 
@@ -49,7 +51,6 @@ Feature flags are new / experimental features that can be enabled by setting the
 
 The "new loket" feature displays a list of public services that are available. We use the production data on all environments but still want to link to correct environment specific versions. To enable this we added the `EMBER_PUBLIC_SERVICE_URL_MAP` variable that should be provided a CSV string of the url and the mapped url in the following format:
 
-
 ```yml
 services:
   frontend:
@@ -57,7 +58,6 @@ services:
       EMBER_FEATURE_NEW_LOKET: "true"
       EMBER_PUBLIC_SERVICE_URL_MAP: "https://url-a,https://mapped-url-a,https://url-b,https://mapped-url-b"
 ```
-
 
 ### Plausible
 

--- a/app/components/new-loket-announcement.gjs
+++ b/app/components/new-loket-announcement.gjs
@@ -1,0 +1,33 @@
+import AuAlert from '@appuniversum/ember-appuniversum/components/au-alert';
+import Component from '@glimmer/component';
+import config from 'frontend-loket/config/environment';
+
+const { title, message } = config.newLoketAnnouncement;
+
+export default class NewLoketAnnouncement extends Component {
+  get title() {
+    return title.startsWith('{{') ? '' : title;
+  }
+
+  get message() {
+    return message.startsWith('{{') ? '' : message;
+  }
+
+  get show() {
+    return !title.startsWith('{{') || !message.startsWith('{{');
+  }
+
+  <template>
+    {{#if this.show}}
+      <AuAlert
+        @icon="message"
+        @skin="success"
+        @title={{this.title}}
+        @closable={{true}}
+      >
+        {{!template-lint-disable no-triple-curlies}}
+        {{{this.message}}}
+      </AuAlert>
+    {{/if}}
+  </template>
+}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -12,6 +12,8 @@
           Veelgebruikte producten of diensten kun je zelf aanduiden als
           favoriet, zodat je ze snel kunt terugvinden in de onderstaande lijst
           of op de pagina Mijn favorieten.</p>
+
+        <NewLoketAnnouncement />
       </div>
 
       <div class="c-main-search-container au-u-margin-top">

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -7,8 +7,8 @@
           {{this.currentSession.groupClassification.label}}
           {{this.currentSession.group.naam}}
         </AuHeading>
-        <p class="au-u-para landing-intro">In dit loket vind je alle producten
-          of diensten die de Vlaamse overheid aanbiedt aan lokale besturen.
+        <p class="au-u-para landing-intro">In dit loket vind je producten of
+          diensten die de Vlaamse overheid aanbiedt aan lokale besturen.
           Veelgebruikte producten of diensten kun je zelf aanduiden als
           favoriet, zodat je ze snel kunt terugvinden in de onderstaande lijst
           of op de pagina Mijn favorieten.</p>

--- a/config/environment.js
+++ b/config/environment.js
@@ -61,6 +61,10 @@ module.exports = function (environment) {
       disablePerformance: true,
     },
     globalSystemNotification: '{{GLOBAL_SYSTEM_NOTIFICATION}}',
+    newLoketAnnouncement: {
+      title: '{{NEW_LOKET_ANNOUNCEMENT_TITLE}}',
+      message: '{{NEW_LOKET_ANNOUNCEMENT_MESSAGE}}',
+    },
   };
 
   if (environment === 'development') {


### PR DESCRIPTION
<img width="1440" height="867" alt="image" src="https://github.com/user-attachments/assets/d6879b4b-e639-4fda-8e3d-d82b7916709a" />

**Test instructions**

Add the following config to your docker-compose.override.yml file and run `drc build loket` and run the stack afterwards.
```yml
loket:
    image: !reset null
    build: https://github.com/lblod/frontend-loket.git#new-loket-announcement-banner
    environment:
      EMBER_NEW_LOKET_ANNOUNCEMENT_TITLE: "Bekijk onze korte introductievideo"
      EMBER_NEW_LOKET_ANNOUNCEMENT_MESSAGE: "Het Loket zit in een nieuw jasje. Wil je snel op de hoogte zijn van de aanpassingen, bekijk dan <a class='au-c-link' target='_blank' href='https://abb-vlaanderen.gitbook.io/hoofdloket-handleiding-loket-lokale-besturen'>hier</a> onze korte introductievideo. Je vind er ook meer uitleg over onze toepassing."
```
