### PR TITLE
Show bestuursperiodes label per mandataris

### DIFF
--- a/app/controllers/eredienst-mandatenbeheer/mandatarissen.js
+++ b/app/controllers/eredienst-mandatenbeheer/mandatarissen.js
@@ -3,7 +3,8 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { restartableTask, timeout } from 'ember-concurrency';
-import { NO_PROVENANCE_VENDOR_ID } from 'frontend-loket/routes/eredienst-mandatenbeheer/mandatarissen';
+
+const NO_PROVENANCE_VENDOR_ID = 'none';
 
 export default class EredienstMandatenbeheerMandatarissenController extends Controller {
   @service() router;

--- a/app/controllers/worship-ministers-management/index.js
+++ b/app/controllers/worship-ministers-management/index.js
@@ -2,7 +2,8 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
-import { NO_PROVENANCE_VENDOR_ID } from 'frontend-loket/routes/eredienst-mandatenbeheer/mandatarissen';
+
+const NO_PROVENANCE_VENDOR_ID = 'none';
 
 export default class WorshipMinistersManagementIndexController extends Controller {
   @service currentSession;

--- a/app/routes/eredienst-mandatenbeheer/mandatarissen.js
+++ b/app/routes/eredienst-mandatenbeheer/mandatarissen.js
@@ -4,8 +4,39 @@ import DataTableRouteMixin from 'frontend-loket/mixins/ember-data-table/route';
 import { inject as service } from '@ember/service';
 import { getUniqueBestuursorganen } from 'frontend-loket/models/mandataris';
 import { hash } from 'rsvp';
+import moment from 'moment';
 
-export const NO_PROVENANCE_VENDOR_ID = 'none';
+const LIFETIME_BOARD_POSITION_URI =
+  'http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5972fccd87f864c4ec06bfbd20b5008b';
+
+const NO_PROVENANCE_VENDOR_ID = 'none';
+
+async function getActivePeriodsLabel(mandataris) {
+  const mandate = await mandataris.bekleedt;
+  const bestuursfunctie = await mandate.bestuursfunctie;
+
+  if (bestuursfunctie.uri === LIFETIME_BOARD_POSITION_URI) {
+    return 'Dit mandaat is een permanent mandaat.';
+  }
+
+  const bestuursorganenInTijd = await mandate.bevatIn;
+
+  const ranges = bestuursorganenInTijd
+    .map((b) => ({
+      startDate: moment(b.bindingStart).format('YYYY-MM-DD'),
+      endDate: b.bindingEinde
+        ? moment(b.bindingEinde).format('YYYY-MM-DD')
+        : null,
+    }))
+    .sort((a, b) => a.startDate.localeCompare(b.startDate))
+    .map(
+      (p) =>
+        `${moment(p.startDate).format('YYYY')}-${p.endDate ? moment(p.endDate).format('YYYY') : 'heden'}`,
+    );
+
+  if (!ranges.length) return '';
+  return `Dit mandaat loopt over de volgende bestuursperiodes: ${ranges.join(', ')}.`;
+}
 
 export default class EredienstMandatenbeheerMandatarissenRoute extends Route.extend(
   DataTableRouteMixin,
@@ -33,7 +64,13 @@ export default class EredienstMandatenbeheerMandatarissenRoute extends Route.ext
       return data;
     }, {});
 
+    let mandatarisActivePeriods = mandatarissen.reduce((data, mandataris) => {
+      data[mandataris.id] = getActivePeriodsLabel(mandataris);
+      return data;
+    }, {});
+
     this.mandatarisBestuursorganen = await hash(mandatarisBestuursorganen);
+    this.mandatarisActivePeriods = await hash(mandatarisActivePeriods);
   }
 
   mergeQueryOptions(params) {
@@ -78,5 +115,6 @@ export default class EredienstMandatenbeheerMandatarissenRoute extends Route.ext
     )['filter'];
     controller.mandatenbeheer = this.mandatenbeheer;
     controller.mandatarisBestuursorganen = this.mandatarisBestuursorganen;
+    controller.mandatarisActivePeriods = this.mandatarisActivePeriods;
   }
 }

--- a/app/routes/worship-ministers-management/index.js
+++ b/app/routes/worship-ministers-management/index.js
@@ -2,7 +2,8 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import DataTableRouteMixin from 'frontend-loket/mixins/ember-data-table/route';
-import { NO_PROVENANCE_VENDOR_ID } from 'frontend-loket/routes/eredienst-mandatenbeheer/mandatarissen';
+
+const NO_PROVENANCE_VENDOR_ID = 'none';
 
 export default class WorshipMinistersManagementIndexRoute extends Route.extend(
   DataTableRouteMixin,

--- a/app/templates/eredienst-mandatenbeheer/mandatarissen.hbs
+++ b/app/templates/eredienst-mandatenbeheer/mandatarissen.hbs
@@ -50,8 +50,7 @@
 
   <AuAlert @skin="info" @icon="info-circle" @size="small">
     Foutje in de gegevens? Contacteer ons gerust, dan zetten we dit samen recht.
-    U vindt onze contactgegevens onder het icoontje
-    <AuIcon @icon="question-circle" />, bovenaan de pagina.
+    U vindt onze contactgegevens in de helpsectie, bovenaan de pagina.
   </AuAlert>
 
   <AuAlert @skin="warning" @icon="alert-triangle" @size="small">Gelieve
@@ -123,6 +122,16 @@
         </td>
         <td>
           {{row.bekleedt.bestuursfunctie.label}}
+          {{#let
+            (get this.mandatarisActivePeriods row.id) as |activePeriodsLabel|
+          }}
+            {{#if activePeriodsLabel}}
+              <div class="au-u-h6 au-u-muted">{{activePeriodsLabel}}</div>
+            {{/if}}
+          {{/let}}
+          <div class="au-u-h-functional au-u-muted">
+            Voor meer informatie hieromtrent, kan u de helpsectie te consulteren.
+          </div>
         </td>
         <td class="au-u-visible-medium-up">{{moment-format
             row.start

--- a/app/templates/worship-ministers-management/index.hbs
+++ b/app/templates/worship-ministers-management/index.hbs
@@ -24,8 +24,7 @@
 
 <AuAlert @skin="info" @icon="info-circle" @size="small">
   Foutje in de gegevens? Contacteer ons gerust, dan zetten we dit samen recht.
-  U vindt onze contactgegevens onder het icoontje
-  <AuIcon @icon="question-circle" />, bovenaan de pagina.
+  U vindt onze contactgegevens in de helpsectie, bovenaan de pagina.
 </AuAlert>
 
 <AuAlert @skin="info" @icon="manual" @size="small">


### PR DESCRIPTION
Adds 'Dit mandaat loopt over de volgende bestuursperiodes...' under each row, with a 'permanent mandaat' message for the lifetime board-position concept. Inlines the previously-shared NO_PROVENANCE_VENDOR_ID and LIFETIME_BOARD_POSITION_URI constants into their respective files.