### PR TITLE
Add active filter for mandatarissen

### DIFF
--- a/app/controllers/eredienst-mandatenbeheer/mandatarissen.js
+++ b/app/controllers/eredienst-mandatenbeheer/mandatarissen.js
@@ -10,7 +10,7 @@ export default class EredienstMandatenbeheerMandatarissenController extends Cont
   @service() router;
   @service() currentSession;
 
-  queryParams = ['vendorId'];
+  queryParams = ['vendorId', 'active'];
 
   sort = 'is-bestuurlijke-alias-van.gebruikte-voornaam';
 
@@ -19,6 +19,9 @@ export default class EredienstMandatenbeheerMandatarissenController extends Cont
   @tracked page = 0;
   @tracked size = 10;
   @tracked vendorId = null;
+  @tracked active = true;
+  @tracked mandatarisBestuursorganen;
+  @tracked mandatarisActivePeriods;
 
   // TODO: hardcoded for now, only one real vendor exists in production.
   // Once more vendors exist, fetch them from the API
@@ -64,6 +67,12 @@ export default class EredienstMandatenbeheerMandatarissenController extends Cont
   selectVendor(vendor) {
     this.page = 0;
     this.vendorId = vendor ? vendor.id : null;
+  }
+
+  @action
+  toggleActive(checked) {
+    this.page = 0;
+    this.active = checked;
   }
 
   @action

--- a/app/routes/eredienst-mandatenbeheer/mandatarissen.js
+++ b/app/routes/eredienst-mandatenbeheer/mandatarissen.js
@@ -18,7 +18,7 @@ async function getActivePeriodsLabel(mandataris) {
   if (bestuursfunctie.uri === LIFETIME_BOARD_POSITION_URI) {
     return 'Dit mandaat is een permanent mandaat.';
   }
-
+  
   const bestuursorganenInTijd = await mandate.bevatIn;
 
   const ranges = bestuursorganenInTijd
@@ -49,6 +49,7 @@ export default class EredienstMandatenbeheerMandatarissenRoute extends Route.ext
     size: { refreshModel: true },
     sort: { refreshModel: true },
     vendorId: { refreshModel: true },
+    active: { refreshModel: true },
   };
 
   modelName = 'worship-mandatee';
@@ -103,6 +104,13 @@ export default class EredienstMandatenbeheerMandatarissenRoute extends Route.ext
       queryParams['filter'][':has-no:provenance'] = true;
     } else if (params.vendorId) {
       queryParams['filter']['provenance'] = { id: params.vendorId };
+    }
+
+    if (params.active) {
+      queryParams['filter'][':or:'] = {
+        ':has-no:einde': true, //TODO: note, from the doc I thought it would only work with relations. But it seems to work.
+        ':gt:einde': moment().toISOString(),
+      };
     }
 
     return queryParams;

--- a/app/templates/eredienst-mandatenbeheer/mandatarissen.hbs
+++ b/app/templates/eredienst-mandatenbeheer/mandatarissen.hbs
@@ -46,6 +46,14 @@
         @onSelect={{this.selectVendor}}
       />
     </Group>
+    <Group>
+      <AuToggleSwitch
+        @checked={{this.active}}
+        @onChange={{this.toggleActive}}
+      >
+        Toon enkel actieve mandatarissen
+      </AuToggleSwitch>
+    </Group>
   </AuToolbar>
 
   <AuAlert @skin="info" @icon="info-circle" @size="small">


### PR DESCRIPTION
Adds an 'active' toggle (default on) using mu-cl-resources :or: cross-filter on einde (no end date OR end date in the future). Tracks mandatarisBestuursorganen and mandatarisActivePeriods on the controller so the table re-renders correctly when the filter changes.