### PR TITLE
[DL-7331] Ensure the "orgaan" column is displayed correctly

### DIFF
--- a/app/controllers/eredienst-mandatenbeheer/mandatarissen.js
+++ b/app/controllers/eredienst-mandatenbeheer/mandatarissen.js
@@ -11,6 +11,7 @@ export default class EredienstMandatenbeheerMandatarissenController extends Cont
   sort = 'is-bestuurlijke-alias-van.gebruikte-voornaam';
 
   @tracked mandatenbeheer;
+  @tracked mandatarisBestuursorganen;
   @tracked filter = '';
   @tracked page = 0;
   @tracked size = 10;


### PR DESCRIPTION
- added tracked to mandatarisBestuursorganen for eredienst-mandatenbeheer. This makes sure the rerender is correct when switching pages and leads to no empty orgaan column.

TO TEST:
- start from prod data
- create local frontend image from this branch + proxy
- login as worship service O.-L.-Vrouw van Temse
- check that orgaan column is not empty when going to page 2 in eredienst-mandatenbeheer