### PR TITLE
[DL-7363] fix download files containing special characters

### DIFF
--- a/app/components/supervision/fields/decision-remote-documents.gjs
+++ b/app/components/supervision/fields/decision-remote-documents.gjs
@@ -513,7 +513,7 @@ export default class DecisionRemoteDocumentsShowComponent extends Component {
         );
       }
 
-      return response;
+      return { input: response, name: rdo.file.filename };
     });
 
     try {

--- a/app/models/file.js
+++ b/app/models/file.js
@@ -22,6 +22,6 @@ export default class File extends Model {
   }
 
   get downloadLink() {
-    return `/files/${this.id}/download?name=${this.filename}`;
+    return `/files/${this.id}/download?name=${encodeURIComponent(this.filename)}`;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@lblod/ember-acmidm-login": "2.1.0",
         "@lblod/ember-address-search": "^1.0.0",
         "@lblod/ember-mock-login": "^0.10.0",
-        "@lblod/ember-submission-form-fields": "^3.4.0",
+        "@lblod/ember-submission-form-fields": "^3.6.1",
         "@lblod/submission-form-helpers": "^3.0.0",
         "@sentry/ember": "^7.54.0",
         "broccoli-asset-rev": "^3.0.0",
@@ -7958,19 +7958,21 @@
       }
     },
     "node_modules/@lblod/ember-submission-form-fields": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-3.4.0.tgz",
-      "integrity": "sha512-OBHVMRzvXDNJErFNo6MkOMsZxpXfCqdvIi2sNVWcVMGIaBjriMUW/toZhyXU/SwCjUqthfzAmeOfHUDBRyHkJA==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-3.6.1.tgz",
+      "integrity": "sha512-jXf339upMJVMyF1W1hvIbe3iOXWmC5NBJhPIQIp5Ay7kIj7/+2pc52bL3i55Q7fhXb361vAdalYbOQUk5KYDLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "7.26.0",
+        "@embroider/macros": "^1.20.2",
         "client-zip": "^2.4.4",
         "clipboardy": "^4.0.0",
         "ember-auto-import": "^2.8.1",
         "ember-cli-babel": "^8.2.0",
         "ember-cli-htmlbars": "^6.3.0",
         "ember-cli-version-checker": "^5.1.2",
-        "ember-concurrency": "^4.0.2",
+        "ember-concurrency": "^4.0.2 || ^5.0.0",
         "ember-modifier": "^4.1.0",
         "ember-truth-helpers": "^4.0.0 || ^5.0.0",
         "forking-store": "^2.0.0",
@@ -8016,6 +8018,95 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@lblod/ember-submission-form-fields/node_modules/@embroider/macros": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.20.5.tgz",
+      "integrity": "sha512-JjIynmob1HbOwVG5uvwrOWecf48Vf9dltKL5C9x5Q6gEoLZJln6iG8D9YBM9EO24Oi8Ftw+oS7IJjA7TFvMLCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@embroider/shared-internals": "3.1.1",
+        "assert-never": "^1.2.1",
+        "babel-import-util": "^3.0.1",
+        "ember-cli-babel": "^7.26.6 || ^8.3.1",
+        "find-up": "^5.0.0",
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0",
+        "semver": "^7.3.2"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      },
+      "peerDependencies": {
+        "@glint/template": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@glint/template": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lblod/ember-submission-form-fields/node_modules/@embroider/macros/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@lblod/ember-submission-form-fields/node_modules/@embroider/shared-internals": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-3.1.1.tgz",
+      "integrity": "sha512-IlxD8okTt9cRUFpJKD8gTuQUBuEflrhCUju1xZFdYvmGm5XVqHPfG4I6+bEdKb8NO92aqHxr9SYuYibDmpMM9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-import-util": "^3.0.1",
+        "debug": "^4.3.2",
+        "ember-rfc176-data": "^0.3.17",
+        "fs-extra": "^9.1.0",
+        "is-subdir": "^1.2.0",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.21",
+        "minimatch": "^3.0.4",
+        "pkg-entry-points": "^1.1.1",
+        "resolve-package-path": "^4.0.1",
+        "resolve.exports": "^2.0.2",
+        "semver": "^7.3.5",
+        "typescript-memoize": "^1.0.1"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/@lblod/ember-submission-form-fields/node_modules/@embroider/shared-internals/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@lblod/ember-submission-form-fields/node_modules/babel-import-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-3.0.1.tgz",
+      "integrity": "sha512-2copPaWQFUrzooJVIVZA/Oppx/S/KOoZ4Uhr+XWEQDMZ8Rvq/0SNQpbdIyMBJ8IELWt10dewuJw+tX4XjOo7Rg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.*"
       }
     },
     "node_modules/@lblod/submission-form-helpers": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@lblod/ember-acmidm-login": "2.1.0",
     "@lblod/ember-address-search": "^1.0.0",
     "@lblod/ember-mock-login": "^0.10.0",
-    "@lblod/ember-submission-form-fields": "^3.4.0",
+    "@lblod/ember-submission-form-fields": "^3.6.1",
     "@lblod/submission-form-helpers": "^3.0.0",
     "@sentry/ember": "^7.54.0",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
[DL-7363]

Fix to allow files containing special characters in their titels (E.g. ^) to be downloaded as a zip.

TO TEST:
see https://github.com/lblod/frontend-toezicht-abb/pull/82 and https://github.com/lblod/frontend-worship-decisions/pull/47