### PR TITLE
[DL-7449]: Handle representative organs in public services filter

### DIFF
--- a/app/config/constants.js
+++ b/app/config/constants.js
@@ -24,4 +24,8 @@ export default {
     PROVINCE:
       'https://productencatalogus.data.vlaanderen.be/id/concept/UitvoerendBestuursniveau/Provinciaal',
   },
+  REPRESENTATIVE_ORGAN: {
+    ADMINISTRATIVE_UNIT_CLASSIFICATION_CODE: '36372fad-0358-499c-a4e3-f412d2eae213',
+    REPRESENTATIVE_ORGAN_CLASSIFICATION_CODE: '89a00b5a-024f-4630-a722-65a5e68967e5',
+  }
 };

--- a/app/config/constants.js
+++ b/app/config/constants.js
@@ -25,7 +25,9 @@ export default {
       'https://productencatalogus.data.vlaanderen.be/id/concept/UitvoerendBestuursniveau/Provinciaal',
   },
   REPRESENTATIVE_ORGAN: {
-    ADMINISTRATIVE_UNIT_CLASSIFICATION_CODE: '36372fad-0358-499c-a4e3-f412d2eae213',
-    REPRESENTATIVE_ORGAN_CLASSIFICATION_CODE: '89a00b5a-024f-4630-a722-65a5e68967e5',
-  }
+    ADMINISTRATIVE_UNIT_CLASSIFICATION_CODE:
+      '36372fad-0358-499c-a4e3-f412d2eae213',
+    REPRESENTATIVE_ORGAN_CLASSIFICATION_CODE:
+      '89a00b5a-024f-4630-a722-65a5e68967e5',
+  },
 };

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -5,7 +5,8 @@ import { isPresent } from '@ember/utils';
 import constants from '../config/constants';
 import search, { langStringResourceFormat } from '../utils/mu-search';
 
-const { EXECUTING_AUTHORITY_LEVELS, TARGET_AUDIENCES, REPRESENTATIVE_ORGAN } = constants;
+const { EXECUTING_AUTHORITY_LEVELS, TARGET_AUDIENCES, REPRESENTATIVE_ORGAN } =
+  constants;
 
 export default class SearchRoute extends Route {
   @service store;
@@ -100,8 +101,12 @@ export default class SearchRoute extends Route {
     let classificationId = classification.id;
 
     // For representative organ:
-    if (classificationId === REPRESENTATIVE_ORGAN.REPRESENTATIVE_ORGAN_CLASSIFICATION_CODE) {
-      classificationId = REPRESENTATIVE_ORGAN.ADMINISTRATIVE_UNIT_CLASSIFICATION_CODE;
+    if (
+      classificationId ===
+      REPRESENTATIVE_ORGAN.REPRESENTATIVE_ORGAN_CLASSIFICATION_CODE
+    ) {
+      classificationId =
+        REPRESENTATIVE_ORGAN.ADMINISTRATIVE_UNIT_CLASSIFICATION_CODE;
     }
 
     if (params.useDefaultAdminUnitFilter !== false) {

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -5,7 +5,7 @@ import { isPresent } from '@ember/utils';
 import constants from '../config/constants';
 import search, { langStringResourceFormat } from '../utils/mu-search';
 
-const { EXECUTING_AUTHORITY_LEVELS, TARGET_AUDIENCES } = constants;
+const { EXECUTING_AUTHORITY_LEVELS, TARGET_AUDIENCES, REPRESENTATIVE_ORGAN } = constants;
 
 export default class SearchRoute extends Route {
   @service store;
@@ -97,8 +97,15 @@ export default class SearchRoute extends Route {
     }
 
     let classification = this.session.currentSession.group.classificatie;
+    let classificationId = classification.id;
+
+    // For representative organ:
+    if (classificationId === REPRESENTATIVE_ORGAN.REPRESENTATIVE_ORGAN_CLASSIFICATION_CODE) {
+      classificationId = REPRESENTATIVE_ORGAN.ADMINISTRATIVE_UNIT_CLASSIFICATION_CODE;
+    }
+
     if (params.useDefaultAdminUnitFilter !== false) {
-      params.administrativeUnits = [classification.id];
+      params.administrativeUnits = [classificationId];
     }
 
     this.administrativeUnitRecords = [];


### PR DESCRIPTION
`this.session.currentSession.group.classificatie.id` returns the other uuid for representative organs than is expected. This fix forces representative organs to use the expected uuid