### PR TITLE
[DL-7515] Speed up initial page loading

### DIFF
--- a/app/components/favorites-overview.gjs
+++ b/app/components/favorites-overview.gjs
@@ -1,0 +1,142 @@
+import AuAlert from '@appuniversum/ember-appuniversum/components/au-alert';
+import AuHeading from '@appuniversum/ember-appuniversum/components/au-heading';
+import AuIcon from '@appuniversum/ember-appuniversum/components/au-icon';
+import AuLink from '@appuniversum/ember-appuniversum/components/au-link';
+import AuLinkExternal from '@appuniversum/ember-appuniversum/components/au-link-external';
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { service } from '@ember/service';
+import { compare } from '@ember/utils';
+import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+import { remapWebsiteUrl } from 'frontend-loket/utils/remap-website-url';
+import StarFilled from 'frontend-loket/components/icons/star-filled';
+import { getPublicServiceCta } from 'frontend-loket/utils/get-public-service-cta';
+import { Await } from '@warp-drive/ember';
+import AuLoader from '@appuniversum/ember-appuniversum/components/au-loader';
+
+export default class FavoritesOverview extends Component {
+  @service('bookmarks') bookmarksService;
+  @service toaster;
+
+  @cached
+  get favoritesPromise() {
+    return (async () => {
+      await this.bookmarksService.load();
+
+      let errorLoadingFavorite = false;
+      let favoritesData = [];
+
+      try {
+        const favorites = this.bookmarksService.bookmarks
+          .map((bookmark) => bookmark.object)
+          .sort((a, b) => compare(a.name.default, b.name.default));
+
+        favoritesData = await Promise.all(
+          favorites.map(async (product) => {
+            try {
+              const callToAction = await getPublicServiceCta(product);
+              return { product, website: callToAction };
+            } catch (err) {
+              console.error(err);
+              errorLoadingFavorite = true;
+              return {};
+            }
+          }),
+        );
+      } catch (err) {
+        console.error(err);
+        errorLoadingFavorite = true;
+      }
+
+      if (errorLoadingFavorite) {
+        const errorMsg = `
+      U kan het product of de dienst
+        proberen terug te vinden via de reguliere zoekfunctie.
+      Gelieve de helpdesk te contacteren
+        indien u blijvende hinder ondervindt.
+    `;
+        const errorTitle = `Probleem bij
+     het ophalen van minstens één favoriet.`;
+
+        this.toaster.error(errorMsg, errorTitle);
+      }
+
+      return favoritesData;
+    })();
+  }
+
+  <template>
+    <div class="favorites-container au-u-margin-top-large" ...attributes>
+      <AuHeading @level="2" @skin="3">Favoriete producten of diensten</AuHeading>
+      <Await @promise={{this.favoritesPromise}}>
+        <:pending>
+          <AuLoader class="au-o-box">Favorieten aan het laden</AuLoader>
+        </:pending>
+
+        <:success as |favorites|>
+          {{#if favorites.length}}
+            <ul
+              class="au-u-flex au-u-flex--wrap au-u-flex--spaced-tiny au-u-padding-top-tiny au-u-padding-bottom-large"
+            >
+              {{#each favorites as |favorite|}}
+                <li class="favorite-card">
+                  <AuIcon
+                    @icon={{StarFilled}}
+                    @alignment="left"
+                    @size="large"
+                  />
+                  {{#if favorite.website.url}}
+                    <AuLinkExternal
+                      @skin="naked"
+                      href={{remapWebsiteUrl favorite.website.url}}
+                      class="favorite-title au-u-medium"
+                      title={{favorite.product.name.default}}
+                    >
+                      {{favorite.product.name.default}}
+                    </AuLinkExternal>
+                    <AuLinkExternal
+                      href={{remapWebsiteUrl favorite.website.url}}
+                      class="c-link--icon-medium"
+                      @skin="button-naked"
+                      @icon="external-link"
+                      @iconAlignment="right"
+                    />
+                  {{else}}
+                    <AuLink
+                      @skin="naked-button"
+                      class="favorite-title au-u-medium"
+                      {{on "click" (fn @onSelect favorite.product)}}
+                    >
+                      {{favorite.product.name.default}}
+                    </AuLink>
+                  {{/if}}
+                </li>
+              {{/each}}
+            </ul>
+          {{else}}
+            <AuAlert
+              @title="U heeft momenteel geen favorieten"
+              @skin="info"
+              @icon="circle-info"
+              @size="small"
+              class="au-u-margin-top-small"
+            >
+              <p>
+                Bekijk al onze services en klik op de ster om uw eerste toe te
+                voegen.
+              </p>
+              <AuLink
+                @route="search"
+                @skin="button"
+                class="au-u-margin-top-small"
+              >
+                Alle diensten
+              </AuLink>
+            </AuAlert>
+          {{/if}}
+        </:success>
+      </Await>
+    </div>
+  </template>
+}

--- a/app/routes/eredienst-mandatenbeheer.js
+++ b/app/routes/eredienst-mandatenbeheer.js
@@ -26,6 +26,8 @@ export default class EredienstMandatenbeheerRoute extends Route {
     if (this.session.requireAuthentication(transition, 'login')) {
       if (!this.currentSession.canAccessEredienstMandatenbeheer)
         this.router.transitionTo('unauthorized');
+
+      return this.currentSession.loadVendors();
     }
   }
 

--- a/app/routes/favorites.js
+++ b/app/routes/favorites.js
@@ -11,7 +11,9 @@ export default class FavoritesRoute extends Route {
     this.session.requireAuthentication(transition, 'login');
   }
 
-  model() {
+  async model() {
+    await this.bookmarksService.load();
+
     return this.bookmarksService.bookmarks
       .map((bookmark) => bookmark.object)
       .sort((a, b) => compare(a.name.default, b.name.default));

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,60 +1,15 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import { compare } from '@ember/utils';
-import { getPublicServiceCta } from '../utils/get-public-service-cta';
 
 export default class IndexRoute extends Route {
   @service currentSession;
   @service session;
   @service router;
-  @service('bookmarks') bookmarksService;
   @service toaster;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-  }
-
-  async model() {
-    let errorLoadingFavorite = false;
-    let favoritesData = [];
-
-    try {
-      const favorites = this.bookmarksService.bookmarks
-        .map((bookmark) => bookmark.object)
-        .sort((a, b) => compare(a.name.default, b.name.default));
-
-      favoritesData = await Promise.all(
-        favorites.map(async (product) => {
-          try {
-            const callToAction = await getPublicServiceCta(product);
-            return { product, website: callToAction };
-          } catch (err) {
-            console.error(err);
-            errorLoadingFavorite = true;
-            return {};
-          }
-        }),
-      );
-    } catch (err) {
-      console.error(err);
-      errorLoadingFavorite = true;
-    }
-
-    if (errorLoadingFavorite) {
-      const errorMsg = `
-        U kan het product of de dienst
-          proberen terug te vinden via de reguliere zoekfunctie.
-        Gelieve de helpdesk te contacteren
-          indien u blijvende hinder ondervindt.
-      `;
-      const errorTitle = `Probleem bij
-       het ophalen van minstens één favoriet.`;
-
-      this.toaster.error(errorMsg, errorTitle);
-    }
-
-    return favoritesData;
   }
 
   setupController(controller) {

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -9,6 +9,7 @@ const { EXECUTING_AUTHORITY_LEVELS, TARGET_AUDIENCES, REPRESENTATIVE_ORGAN } =
   constants;
 
 export default class SearchRoute extends Route {
+  @service bookmarks;
   @service store;
   @service session;
 
@@ -50,6 +51,7 @@ export default class SearchRoute extends Route {
     const [executingAuthorityLevel, targetAudience] = await Promise.all([
       this.store.findRecordByUri('concept', EXECUTING_AUTHORITY_LEVELS.FLEMISH),
       this.store.findRecordByUri('concept', TARGET_AUDIENCES.LOCAL_GOVERNMENT),
+      this.bookmarks.load(),
     ]);
 
     const filter = {

--- a/app/routes/worship-ministers-management.js
+++ b/app/routes/worship-ministers-management.js
@@ -18,6 +18,8 @@ export default class WorshipMinistersManagementRoute extends Route {
     if (this.session.requireAuthentication(transition, 'login')) {
       if (!this.currentSession.canAccessWorshipMinisterManagement)
         this.router.transitionTo('unauthorized');
+
+      return this.currentSession.loadVendors();
     }
   }
 

--- a/app/services/bookmarks.js
+++ b/app/services/bookmarks.js
@@ -6,13 +6,20 @@ export default class BookmarksService extends Service {
   @service toaster;
   @service store;
 
+  #loadingPromise;
+
   @tracked bookmarks = [];
 
   async load() {
-    await this.fetchBookmarks();
+    if (!this.#loadingPromise) {
+      this.#loadingPromise = this.fetchBookmarks();
+    }
+
+    await this.#loadingPromise;
   }
 
   async reset() {
+    this.#loadingPromise = null;
     this.bookmarks = [];
   }
 
@@ -97,6 +104,7 @@ export default class BookmarksService extends Service {
   async jsonToBookmark(bookmark) {
     const products = await this.store.query('public-service', {
       'filter[:uri:]': bookmark.attributes.object,
+      include: 'procedures.websites',
       page: { size: 1 },
     });
     return {

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -59,14 +59,11 @@ export default class CurrentSessionService extends Service {
         reload: true,
       });
       this.groupClassification = await this.group.classificatie;
-
-      await this.bookmarks.load();
+      this.setupSentrySession();
 
       this.vendors = await this.store.query('vendor', {
         'filter[can-act-on-behalf-of][:id:]': this.groupId,
       });
-
-      this.setupSentrySession();
     }
   }
 

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -1,3 +1,4 @@
+import { assert } from '@ember/debug';
 import Service, { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { setContext, setUser } from '@sentry/ember';
@@ -37,7 +38,8 @@ export default class CurrentSessionService extends Service {
   @tracked group;
   @tracked groupClassification;
   @tracked _roles = [];
-  @tracked vendors = [];
+  @tracked _vendors = [];
+  #vendorsPromise;
 
   async load() {
     if (this.session.isAuthenticated) {
@@ -60,11 +62,17 @@ export default class CurrentSessionService extends Service {
       });
       this.groupClassification = await this.group.classificatie;
       this.setupSentrySession();
+    }
+  }
 
-      this.vendors = await this.store.query('vendor', {
+  async loadVendors() {
+    if (!this.#vendorsPromise) {
+      this.#vendorsPromise = this.store.query('vendor', {
         'filter[can-act-on-behalf-of][:id:]': this.groupId,
       });
     }
+
+    this._vendors = await this.#vendorsPromise;
   }
 
   setupSentrySession() {
@@ -210,5 +218,14 @@ export default class CurrentSessionService extends Service {
       roles = this.impersonation.originalRoles || [];
     }
     return roles.includes(ADMIN_ROLE);
+  }
+
+  get vendors() {
+    assert(
+      'currentSession.vendors was accessed before the data was loaded. Call currentSession.loadVendors first.',
+      this.#vendorsPromise,
+    );
+
+    return this._vendors;
   }
 }

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -64,64 +64,7 @@
         {{/each}}
       </div>
     </div>
-
-    <div class="favorites-container au-u-margin-top-large">
-      <AuHeading @level="2" @skin="3">Favoriete producten of diensten</AuHeading>
-      {{#if @model.length}}
-        <ul
-          class="au-u-flex au-u-flex--wrap au-u-flex--spaced-tiny au-u-padding-top-tiny au-u-padding-bottom-large"
-        >
-          {{#each @model as |favorite|}}
-            <li class="favorite-card">
-              <AuIcon
-                @icon={{component "icons/star-filled"}}
-                @alignment="left"
-                @size="large"
-              />
-              {{#if favorite.website.url}}
-                <AuLinkExternal
-                  @skin="naked"
-                  href={{remap-url favorite.website.url}}
-                  class="favorite-title au-u-medium"
-                  title={{favorite.product.name.default}}
-                >
-                  {{favorite.product.name.default}}
-                </AuLinkExternal>
-                <AuLinkExternal
-                  href={{remap-url favorite.website.url}}
-                  class="c-link--icon-medium"
-                  @skin="button-naked"
-                  @icon="external-link"
-                  @iconAlignment="right"
-                />
-              {{else}}
-                <AuLink
-                  @skin="naked-button"
-                  class="favorite-title au-u-medium"
-                  {{on "click" (fn this.openProductDetail favorite.product)}}
-                >
-                  {{favorite.product.name.default}}
-                </AuLink>
-              {{/if}}
-            </li>
-          {{/each}}
-        </ul>
-      {{else}}
-        <AuAlert
-          @title="U heeft momenteel geen favorieten"
-          @skin="info"
-          @icon="circle-info"
-          @size="small"
-          class="au-u-margin-top-small"
-        >
-          <p>Bekijk al onze services en klik op de ster om uw eerste toe te
-            voegen.</p>
-          <AuLink @route="search" @skin="button" class="au-u-margin-top-small">
-            Alle diensten
-          </AuLink>
-        </AuAlert>
-      {{/if}}
-    </div>
+    <FavoritesOverview @onSelect={{fn (mut this.selectedProduct)}} />
   </section>
 </AuBodyContainer>
 


### PR DESCRIPTION
The currentSession service data needs to be loaded before the page can be displayed properly. It includes things likes the user and which organization they belong to.

When we integrated the "new loket" frontend we also started loading the user's bookmarks. This made sense in that frontend, since it only included routes that require this data. However, Loket also includes other built-in modules which do not need this data, and since this call can get quite slow (especially on QA) it's better to only load it when necessary.

We have a similar issue with the "vendors" which is only used by the worship modules (at this moment). So we do a similar thing there.

Builds on #482 so draft until that's merged first.

It's a bit hard to compare the actual speed improvement since there is a difference between dev and production builds, and the mu stack also does some caching. But it does feel faster.